### PR TITLE
Remove maximumTokenLength argument in test helper

### DIFF
--- a/Tests/H3IntegrationTests/EndToEndTests.swift
+++ b/Tests/H3IntegrationTests/EndToEndTests.swift
@@ -1548,7 +1548,6 @@ struct EndToEndTests {
                         configuration: config,
                         settings: settings,
                         quicConfiguration: quicConfiguration,
-                        maximumTokenLength: 100,
                         logger: logger,
                         internalInboundStreamInitializer: internalInboundStreamInitializer
                     )

--- a/Tests/H3IntegrationTests/HTTP3+NIOQUIC.swift
+++ b/Tests/H3IntegrationTests/HTTP3+NIOQUIC.swift
@@ -36,7 +36,6 @@ extension ChannelPipeline.SynchronousOperations {
     ///   - configuration: The ``HTTP3ServerConfiguration``.
     ///   - settings: The `HTTP3Settings` to use for all incoming connections.
     ///   - quicConfiguration: The `QUICConfiguration` to be used.
-    ///   - maximumTokenLength: The maximum length of tokens.
     ///   - metrics: The metrics.
     ///   - logger: The logger.
     ///   - inboundRequestStreamInitializer: Closure to run for each incoming stream. Must be synchronous.
@@ -47,7 +46,6 @@ extension ChannelPipeline.SynchronousOperations {
         configuration: HTTP3ServerConfiguration = .defaults,
         settings: HTTP3Settings = .init(),
         quicConfiguration: QUICConfiguration,
-        maximumTokenLength: Int = 0,
         metrics: QUICMetrics? = nil,
         logger: Logger,
         inboundRequestStreamInitializer:
@@ -67,7 +65,6 @@ extension ChannelPipeline.SynchronousOperations {
         let quicHandler = QUICHandler(
             channel: channel,
             quicConfiguration: quicConfiguration,
-            maximumTokenLength: maximumTokenLength,
             asyncVerifier: nil,
             authenticator: authenticator,
             logger: logger,
@@ -116,7 +113,6 @@ extension ChannelPipeline.SynchronousOperations {
     ///   - configuration: The ``HTTP3ClientConfiguration``.
     ///   - settings: The `HTTP3Settings` to use for all outgoing connections.
     ///   - quicConfiguration: The `QUICConfiguration` to be used.
-    ///   - maximumTokenLength: The maximum length of tokens.
     ///   - metrics: The metrics.
     ///   - logger: The logger.
     ///   - internalInboundStreamInitializer: A closure which will be called for every incoming non-push stream.
@@ -127,7 +123,6 @@ extension ChannelPipeline.SynchronousOperations {
         configuration: HTTP3ClientConfiguration = .defaults,
         settings: HTTP3Settings = .init(),
         quicConfiguration: QUICConfiguration,
-        maximumTokenLength: Int = 0,
         metrics: QUICMetrics? = nil,
         logger: Logger,
         internalInboundStreamInitializer: (
@@ -149,7 +144,6 @@ extension ChannelPipeline.SynchronousOperations {
         let quicHandler = QUICHandler(
             channel: channel,
             quicConfiguration: quicConfiguration,
-            maximumTokenLength: maximumTokenLength,
             asyncVerifier: asyncVerifier,
             authenticator: nil,
             logger: logger,
@@ -215,7 +209,6 @@ extension ChannelPipeline.SynchronousOperations {
     ///   - configuration: The ``HTTP3ServerConfiguration``.
     ///   - settings: The `HTTP3Settings` to use for all incoming connections.
     ///   - quicConfiguration: The `QUICConfiguration` to be used.
-    ///   - maximumTokenLength: The maximum length of tokens.
     ///   - metrics: The metrics.
     ///   - logger: The logger.
     ///   - inboundConnectionInitializer: Closure to run for each incoming connection.
@@ -227,7 +220,6 @@ extension ChannelPipeline.SynchronousOperations {
         configuration: HTTP3ServerConfiguration = .defaults,
         settings: HTTP3Settings = .init(),
         quicConfiguration: QUICConfiguration,
-        maximumTokenLength: Int = 0,
         metrics: QUICMetrics? = nil,
         logger: Logger,
         inboundConnectionInitializer: @Sendable @escaping (any Channel) -> EventLoopFuture<Void>,
@@ -251,7 +243,6 @@ extension ChannelPipeline.SynchronousOperations {
         let quicHandler = QUICHandler(
             channel: channel,
             quicConfiguration: quicConfiguration,
-            maximumTokenLength: maximumTokenLength,
             asyncVerifier: nil,
             authenticator: authenticator,
             logger: logger,


### PR DESCRIPTION
### Motivation

In https://github.com/apple/swift-nio-quic/pull/8, the `maximumTokenLength` argument was removed from `QUICHandler`'s initializer. This initializer is used in the `H3IntegrationTests` test target, which means it no longer compiles. We should fix this.  

### Modifications

Removed references to `maximumTokenLength` in `H3IntegrationTests`.

### Result

`H3IntegrationTests` now compiles.