### PR TITLE
Do not open QPACK Encoder Stream if it will not be used

### DIFF
--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -107,7 +107,8 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
     package init(settings: HTTP3Settings, type: HTTP3ConnectionType) {
         let qpackState = QPACKStateMachine(
             decoderMaxTableSize: Int(clamping: settings.qpackMaximumTableCapacity),
-            decoderMaxBlockedStreams: Int(clamping: settings.qpackBlockedStreams)
+            decoderMaxBlockedStreams: Int(clamping: settings.qpackBlockedStreams),
+            localEncoderMaxTableCapacity: Int(clamping: settings.qpackMaximumTableCapacity)
         )
         self.init(state: .notStarted(.init(qpackState: qpackState, localSettings: settings, type: type)))
     }

--- a/Sources/HTTP3/QPACK/QPACKStateMachine.swift
+++ b/Sources/HTTP3/QPACK/QPACKStateMachine.swift
@@ -57,27 +57,32 @@ package struct QPACKStateMachine: ~Copyable {
         }
 
         private let state: State
+        private let localMaxTableCapacity: Int
 
-        private init(state: consuming State) {
+        private init(state: consuming State, localMaxTableCapacity: Int) {
             self.state = state
+            self.localMaxTableCapacity = localMaxTableCapacity
         }
 
-        init() {
-            self.init(state: .initial(.init(encoder: .init())))
+        init(localMaxTableCapacity: Int) {
+            self.init(state: .initial(.init(encoder: .init())), localMaxTableCapacity: localMaxTableCapacity)
         }
 
         mutating func receivedRemoteSettings(
             maxQueueSize: Int,
             dynamicTableSize: Int
         ) -> GotRemoteSettingsAction? {
+            let localMaxTableCapacity = self.localMaxTableCapacity
             switch consume self.state {
             case .initial(let initial):
                 // RFC 9204 § 4.2: An endpoint MAY avoid creating an encoder stream if it will not be used
-                if dynamicTableSize == 0 {
+                // This should include if the local table will not be used either
+                if dynamicTableSize == 0 || localMaxTableCapacity == 0 {
                     self = .init(
                         state: .withoutDynamic(
                             .init(encoder: initial.encoder)
-                        )
+                        ),
+                        localMaxTableCapacity: localMaxTableCapacity
                     )
                     return nil
                 } else {
@@ -88,7 +93,8 @@ package struct QPACKStateMachine: ~Copyable {
                                 maxQueueSize: maxQueueSize,
                                 dynamicTableSize: dynamicTableSize
                             )
-                        )
+                        ),
+                        localMaxTableCapacity: localMaxTableCapacity
                     )
                     return .makeEncoderInstructionStream
                 }
@@ -109,6 +115,7 @@ package struct QPACKStateMachine: ~Copyable {
         }
 
         mutating func outboundEncoderStreamReady() -> OutboundEncoderStreamReadyAction {
+            let localMaxTableCapacity = self.localMaxTableCapacity
             switch consume self.state {
             case .initial:
                 fatalError("Encoder stream created when not needed or already made")
@@ -128,35 +135,37 @@ package struct QPACKStateMachine: ~Copyable {
                         .init(
                             encoder: dynamicEncoder
                         )
-                    )
+                    ),
+                    localMaxTableCapacity: localMaxTableCapacity
                 )
                 return .sendEncoderInstruction(instruction)
             }
         }
 
         mutating func encodeHeaders(_ headers: [HTTPField], forStream streamID: QUICStreamID) -> QPACKEncodeResult {
+            let localMaxTableCapacity = self.localMaxTableCapacity
             switch consume self.state {
             case .initial(let initial):
                 let result = QPACKEncodeResult(fieldSection: initial.encoder.encode(headers: headers), instructions: [])
-                self = .init(state: .initial(initial))
+                self = .init(state: .initial(initial), localMaxTableCapacity: localMaxTableCapacity)
                 return result
             case .awaitingStream(let awaiting):
                 let result = QPACKEncodeResult(
                     fieldSection: awaiting.encoder.encode(headers: headers),
                     instructions: []
                 )
-                self = .init(state: .awaitingStream(awaiting))
+                self = .init(state: .awaitingStream(awaiting), localMaxTableCapacity: localMaxTableCapacity)
                 return result
             case .withoutDynamic(let woDynamic):
                 let result = QPACKEncodeResult(
                     fieldSection: woDynamic.encoder.encode(headers: headers),
                     instructions: []
                 )
-                self = .init(state: .withoutDynamic(woDynamic))
+                self = .init(state: .withoutDynamic(woDynamic), localMaxTableCapacity: localMaxTableCapacity)
                 return result
             case .withDynamic(var withDynamic):
                 let result = withDynamic.encoder.encode(headers: headers, forStream: streamID)
-                self = .init(state: .withDynamic(withDynamic))
+                self = .init(state: .withDynamic(withDynamic), localMaxTableCapacity: localMaxTableCapacity)
                 return result
             }
         }
@@ -178,20 +187,21 @@ package struct QPACKStateMachine: ~Copyable {
                     location: location
                 )
             }
+            let localMaxTableCapacity = self.localMaxTableCapacity
             switch consume self.state {
             case .initial(let initial):
-                self = .init(state: .initial(initial))
+                self = .init(state: .initial(initial), localMaxTableCapacity: localMaxTableCapacity)
                 return .emitConnectionError(noDynamicTableError(location: .here()))
             case .awaitingStream(let awaitingStream):
-                self = .init(state: .awaitingStream(awaitingStream))
+                self = .init(state: .awaitingStream(awaitingStream), localMaxTableCapacity: localMaxTableCapacity)
                 return .emitConnectionError(noDynamicTableError(location: .here()))
             case .withoutDynamic(let withoutDynamic):
-                self = .init(state: .withoutDynamic(withoutDynamic))
+                self = .init(state: .withoutDynamic(withoutDynamic), localMaxTableCapacity: localMaxTableCapacity)
                 return .emitConnectionError(noDynamicTableError(location: .here()))
             case .withDynamic(var withDynamic):
                 do {
                     try withDynamic.encoder.processInstruction(instruction)
-                    self = .init(state: .withDynamic(withDynamic))
+                    self = .init(state: .withDynamic(withDynamic), localMaxTableCapacity: localMaxTableCapacity)
                     return nil
                 } catch {
                     @inline(never)
@@ -208,7 +218,7 @@ package struct QPACKStateMachine: ~Copyable {
                         )
                     }
                     // TODO: move to error state?
-                    self = .init(state: .withDynamic(withDynamic))
+                    self = .init(state: .withDynamic(withDynamic), localMaxTableCapacity: localMaxTableCapacity)
                     return .emitConnectionError(invalidDecoderInstructionError(cause: error, location: .here()))
                 }
             }
@@ -284,8 +294,8 @@ package struct QPACKStateMachine: ~Copyable {
     private var decoderQueue: FieldSectionQueue
     private var outboundDecoderInstructionQueue: OutboundDecoderInstructionQueue
 
-    package init(decoderMaxTableSize: Int, decoderMaxBlockedStreams: Int) {
-        self.encoderState = .init()
+    package init(decoderMaxTableSize: Int, decoderMaxBlockedStreams: Int, localEncoderMaxTableCapacity: Int = 0) {
+        self.encoderState = .init(localMaxTableCapacity: localEncoderMaxTableCapacity)
         self.qpackDecoder = .init(dynamicTableMaxCapacity: decoderMaxTableSize)
         self.decoderQueue = .init(maxItems: decoderMaxBlockedStreams)
         self.outboundDecoderInstructionQueue = .init()

--- a/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
@@ -369,14 +369,11 @@ struct HTTP3ConnectionStateMachineTests {
         let action1 = stateMachine.initialize()
         #expect(action1 == .createControlStream)
 
+        // Local settings have qpackMaximumTableCapacity = 0, so we will not use the dynamic table
+        // as an encoder even if the remote offers capacity. Per RFC 9204 § 4.2, we may skip the
+        // encoder stream if it will not be used.
         let action2 = stateMachine.receivedControlFrame(.settings(remoteSettings))
-        guard case .makeEncoderInstructionStream = action2 else {
-            Issue.record("Unexpected action \(String(describing: action2))")
-            return
-        }
-
-        let action3 = stateMachine.outboundEncoderStreamReady(streamID: 3)
-        #expect(action3 == .sendEncoderInstruction(.setDynamicTableCapacity(100)))
+        #expect(action2 == nil)
     }
 
     @Test
@@ -733,13 +730,16 @@ struct HTTP3ConnectionStateMachineTests {
 
     @Test
     func testEncoderStreamReadyAfterShutdown() {
-        let remoteSettings = HTTP3Settings(qpackMaximumTableCapacity: 100)
-        var stateMachine = HTTP3ConnectionStateMachine(settings: .init(), type: .client)
+        let settings = HTTP3Settings(qpackMaximumTableCapacity: 100)
+        var stateMachine = HTTP3ConnectionStateMachine(settings: settings, type: .client)
+        var idGenerator = IDGenerator(type: .client)
 
         let action1 = stateMachine.initialize()
-        #expect(action1 == .createControlStream)
+        #expect(action1 == .createControlAndDecoderStreams)
+        stateMachine.outboundControlStreamReady(streamID: idGenerator.outboundUni())
+        _ = stateMachine.outboundDecoderStreamReady(streamID: idGenerator.outboundUni())
 
-        let action2 = stateMachine.receivedControlFrame(.settings(remoteSettings))
+        let action2 = stateMachine.receivedControlFrame(.settings(settings))
         guard case .makeEncoderInstructionStream = action2 else {
             Issue.record("Unexpected action \(String(describing: action2))")
             return
@@ -747,7 +747,7 @@ struct HTTP3ConnectionStateMachineTests {
 
         #expect(stateMachine.shutdownConnectionImmediately() == .shutdown)
 
-        let action3 = stateMachine.outboundEncoderStreamReady(streamID: 2)
+        let action3 = stateMachine.outboundEncoderStreamReady(streamID: idGenerator.outboundUni())
         #expect(action3 == nil)  // We don't send our settings because we shutdown
     }
 

--- a/Tests/HTTP3Tests/QPACKStateMachineTests.swift
+++ b/Tests/HTTP3Tests/QPACKStateMachineTests.swift
@@ -20,7 +20,11 @@ import Testing
 struct QPACKStateMachineTests {
     @Test
     func testBeginUsingDynamicTable() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 100,
+            localEncoderMaxTableCapacity: 1024
+        )
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
     }
 
@@ -58,7 +62,11 @@ struct QPACKStateMachineTests {
 
     @Test
     func testEncodeHeadersInWaitingForStreamState() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 100,
+            localEncoderMaxTableCapacity: 1024
+        )
         let action = stateMachine.receivedRemoteSettings(maxQueueSize: 100, dynamicTableSize: 100)
         #expect(action == .makeEncoderInstructionStream)
         // We have received remote settings, and been asked to create outbound encoder stream
@@ -77,7 +85,11 @@ struct QPACKStateMachineTests {
 
     @Test
     func testEncodeHeadersInWithDynamicState() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 100,
+            localEncoderMaxTableCapacity: 1024
+        )
         let action1 = stateMachine.receivedRemoteSettings(maxQueueSize: 100, dynamicTableSize: 300)
         #expect(action1 == .makeEncoderInstructionStream)
         let action2 = stateMachine.outboundEncoderStreamReady()
@@ -128,7 +140,11 @@ struct QPACKStateMachineTests {
 
     @Test
     func testDecodeHeadersWithDynamicTable() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 100,
+            localEncoderMaxTableCapacity: 1024
+        )
         let streamID = QUICStreamID(0)
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
@@ -166,7 +182,11 @@ struct QPACKStateMachineTests {
 
     @Test
     func testDecodeHeadersConnectionError() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 100,
+            localEncoderMaxTableCapacity: 1024
+        )
         let streamID = QUICStreamID(0)
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
@@ -195,7 +215,11 @@ struct QPACKStateMachineTests {
 
     @Test
     func testDecodeHeadersStreamError() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 100,
+            localEncoderMaxTableCapacity: 1024
+        )
         let streamID = QUICStreamID(0)
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
@@ -221,7 +245,11 @@ struct QPACKStateMachineTests {
 
     @Test
     func testDecodeHeadersWithDynamicTableDelayed() throws {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 100,
+            localEncoderMaxTableCapacity: 1024
+        )
         let streamID = QUICStreamID(0)
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
@@ -262,7 +290,11 @@ struct QPACKStateMachineTests {
 
     @Test
     func testDecodeHeadersStreamErrorDelayed() throws {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 100,
+            localEncoderMaxTableCapacity: 1024
+        )
         let streamID = QUICStreamID(0)
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
@@ -307,7 +339,11 @@ struct QPACKStateMachineTests {
 
     @Test
     func testInvalidFieldPrefix() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 100,
+            localEncoderMaxTableCapacity: 1024
+        )
         let streamID = QUICStreamID(0)
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
         stateMachine.setupLocalDynamicTable(maxSize: 1024)
@@ -337,7 +373,11 @@ struct QPACKStateMachineTests {
 
     @Test
     func testMaxBlockedStreams() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 3)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 3,
+            localEncoderMaxTableCapacity: 1024
+        )
 
         let streamID1 = QUICStreamID(1)
         let streamID2 = QUICStreamID(2)
@@ -381,7 +421,11 @@ struct QPACKStateMachineTests {
 
     @Test
     func testDecodeInstructionsBufferedWhenStreamNotReady() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 100,
+            localEncoderMaxTableCapacity: 1024
+        )
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
         stateMachine.setupLocalDynamicTable(maxSize: 1024)
@@ -435,7 +479,11 @@ struct QPACKStateMachineTests {
 
     @Test
     func testGotIncomingDecoderInstruction() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 100,
+            localEncoderMaxTableCapacity: 1024
+        )
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
         let streamID = QUICStreamID(4)
         _ = stateMachine.encodeHeaders([.init(name: .cookie, value: "test")], forStream: streamID)
@@ -480,7 +528,11 @@ struct QPACKStateMachineTests {
 
     @Test
     func testGotDecoderInstructionWhenAwaitingStream() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 100,
+            localEncoderMaxTableCapacity: 1024
+        )
         _ = stateMachine.receivedRemoteSettings(maxQueueSize: 100, dynamicTableSize: 100)
         // We can't receive instructions from the remote decoder until we ourselves have sent an instruction to indicate support of the dynamic table
         let action = stateMachine.receivedIncomingDecoderInstruction(.sectionAcknowledgement(streamID: 1))
@@ -497,7 +549,11 @@ struct QPACKStateMachineTests {
 
     @Test
     func testGotInvalidIncomingDecoderInstruction() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 100,
+            localEncoderMaxTableCapacity: 1024
+        )
         stateMachine.setupRemoteDynamicTable(maxSize: 1)
         // This instruction is invalid because we can't ack an insert which hasn't happened
         let action = stateMachine.receivedIncomingDecoderInstruction(.insertCountIncrement(increment: 1))
@@ -558,7 +614,11 @@ struct QPACKStateMachineTests {
 
     @Test
     func testClosedRequestStreamAfterEOF() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 100,
+            localEncoderMaxTableCapacity: 1024
+        )
         let streamID = QUICStreamID(1)
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
@@ -582,7 +642,11 @@ struct QPACKStateMachineTests {
 
     @Test
     func testClosedRequestStreamWhilstDecodingQPACK() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 100,
+            localEncoderMaxTableCapacity: 1024
+        )
         let streamID = QUICStreamID(1)
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
@@ -617,7 +681,11 @@ struct QPACKStateMachineTests {
     /// This test is for a potential bug where we accidentally treat it as an error to receive an ack for a 'nonexistent' stream.
     @Test
     func testClosedRequestStreamThenReceiveSectionAck() throws {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        var stateMachine = QPACKStateMachine(
+            decoderMaxTableSize: 1024,
+            decoderMaxBlockedStreams: 100,
+            localEncoderMaxTableCapacity: 1024
+        )
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
         stateMachine.setupLocalDynamicTable(maxSize: 1024)


### PR DESCRIPTION
### Motivation

When the connection is started a client is offering a Dynamic Table with the size of 4096:
```
Hypertext Transfer Protocol Version 3
    UNI STREAM: Control Stream off=0
        Uni Stream Type: Control Stream (0x0000000000000000)
        SETTINGS len=15
            [Stream ID: 2]
            Type: SETTINGS (0x0000000000000004)
            Length: 15
            Frame Payload: 06ffffffffffffffff015000074064
            Settings - Max Field Section Size: 4611686018427387903
            Settings - Max Table Capacity: 4096
            Settings - Blocked Streams: 100
Hypertext Transfer Protocol Version 3
    UNI STREAM: QPACK Decoder Stream off=0
        Uni Stream Type: QPACK Decoder Stream (0x0000000000000003)
Hypertext Transfer Protocol Version 3
    UNI STREAM: QPACK Encoder Stream off=0
        Uni Stream Type: QPACK Encoder Stream (0x0000000000000002)
```


And so the HTTP server opens encoder streams even though it doesnt look like the Dynamic table is supported:
```
if settings.qpackMaximumTableCapacity > 0 {
    // These settings would enable the peer to use the dynamic table
    // We must not allow that, see the DynamicTable doc for explanation.
    fatalError("Dynamic table is not supported yet")
}
```
So each packet from the peer contains a client QPACK decoder frame:

(Each packet has a QPACK Decoder frame in it)
19  0.983563  HTTP3 1486  QPACK DEC[1], STREAM(12), HEADERS: GET https://192.168.xxx.xxx:8080/responsiveness/download/1000, PADDING
23  0.984147  HTTP3 1486  QPACK DEC[1], STREAM(20), HEADERS: GET https://192.168.xxx.xxx:8080/responsiveness/download/1000, PADDING

And this causes QUIC and HTTP3 to use a lot of CPU processing the decoder frame.


### Modifications

Add `localMaxTableCapacity` that is initialized from `HTTP3Settings`'s `qpackMaximumTableCapacity` so that an encoder stream is only ever opened if there is a valid table size on both the server and the peer.

### Result
Nice reduction in CPU.
Top of tree without this change:
```
14.83 G  100.0% -  http3-swift-quic (16387)
```
With this change:
```
12.89 G  100.0% -  http3-swift-quic (43069)
```
