### PR TITLE
Do not create an encoder stream if dynamic table is not used

### DIFF
--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -88,7 +88,7 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
             var qpackState: QPACKStateMachine
             /// The type of the connection (client or server).
             let type: HTTP3ConnectionType
-            let localDynamicTableSize: Int
+            let encoderMaxTableSize: Int
             var streamIDTracker = StreamIDTracker()
             var quiescingState: HTTP3ConnectionQuiescingStateMachine
 
@@ -98,7 +98,7 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
                 self.inboundQPACKEncoderStream = .init()
                 self.qpackState = notStarted.qpackState
                 self.type = notStarted.type
-                self.localDynamicTableSize = Int(clamping: notStarted.localSettings.qpackMaximumTableCapacity)
+                self.encoderMaxTableSize = Int(clamping: notStarted.localSettings.qpackMaximumTableCapacity)
                 self.quiescingState = .init(type: notStarted.type)
             }
         }
@@ -526,8 +526,10 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
             case .initialized(var initializedState):
                 let action = initializedState.qpackState.receivedRemoteSettings(
                     maxQueueSize: Int(clamping: settings.qpackBlockedStreams),
-                    effectiveDynamicTableSize: initializedState.localDynamicTableSize == 0
-                        ? 0 : Int(clamping: settings.qpackMaximumTableCapacity)
+                    effectiveDynamicTableSize: min(
+                        initializedState.encoderMaxTableSize,
+                        Int(clamping: settings.qpackMaximumTableCapacity)
+                    )
                 )
                 self = .init(state: .initialized(initializedState))
                 switch action {

--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -88,6 +88,7 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
             var qpackState: QPACKStateMachine
             /// The type of the connection (client or server).
             let type: HTTP3ConnectionType
+            let localDynamicTableSize: Int
             var streamIDTracker = StreamIDTracker()
             var quiescingState: HTTP3ConnectionQuiescingStateMachine
 
@@ -97,6 +98,7 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
                 self.inboundQPACKEncoderStream = .init()
                 self.qpackState = notStarted.qpackState
                 self.type = notStarted.type
+                self.localDynamicTableSize = Int(clamping: notStarted.localSettings.qpackMaximumTableCapacity)
                 self.quiescingState = .init(type: notStarted.type)
             }
         }
@@ -524,7 +526,8 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
             case .initialized(var initializedState):
                 let action = initializedState.qpackState.receivedRemoteSettings(
                     maxQueueSize: Int(clamping: settings.qpackBlockedStreams),
-                    dynamicTableSize: Int(clamping: settings.qpackMaximumTableCapacity)
+                    effectiveDynamicTableSize: initializedState.localDynamicTableSize == 0
+                        ? 0 : Int(clamping: settings.qpackMaximumTableCapacity)
                 )
                 self = .init(state: .initialized(initializedState))
                 switch action {

--- a/Sources/HTTP3/QPACK/QPACKStateMachine.swift
+++ b/Sources/HTTP3/QPACK/QPACKStateMachine.swift
@@ -68,12 +68,12 @@ package struct QPACKStateMachine: ~Copyable {
 
         mutating func receivedRemoteSettings(
             maxQueueSize: Int,
-            dynamicTableSize: Int
+            effectiveDynamicTableSize: Int
         ) -> GotRemoteSettingsAction? {
             switch consume self.state {
             case .initial(let initial):
                 // RFC 9204 § 4.2: An endpoint MAY avoid creating an encoder stream if it will not be used
-                if dynamicTableSize == 0 {
+                if effectiveDynamicTableSize == 0 {
                     self = .init(
                         state: .withoutDynamic(
                             .init(encoder: initial.encoder)
@@ -86,7 +86,7 @@ package struct QPACKStateMachine: ~Copyable {
                             .init(
                                 encoder: initial.encoder,
                                 maxQueueSize: maxQueueSize,
-                                dynamicTableSize: dynamicTableSize
+                                dynamicTableSize: effectiveDynamicTableSize
                             )
                         )
                     )
@@ -298,9 +298,12 @@ package struct QPACKStateMachine: ~Copyable {
     /// Call this when the settings have been received from the remote. This must never be called more than once.
     package mutating func receivedRemoteSettings(
         maxQueueSize: Int,
-        dynamicTableSize: Int
+        effectiveDynamicTableSize: Int
     ) -> GotRemoteSettingsAction? {
-        self.encoderState.receivedRemoteSettings(maxQueueSize: maxQueueSize, dynamicTableSize: dynamicTableSize)
+        self.encoderState.receivedRemoteSettings(
+            maxQueueSize: maxQueueSize,
+            effectiveDynamicTableSize: effectiveDynamicTableSize
+        )
     }
 
     package enum OutboundEncoderStreamReadyAction: Hashable, Sendable {

--- a/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
@@ -363,11 +363,12 @@ struct HTTP3ConnectionStateMachineTests {
 
     @Test
     func testGotSettingsWithQPACK() {
+        let localSettings = HTTP3Settings(qpackMaximumTableCapacity: 200)
         let remoteSettings = HTTP3Settings(qpackMaximumTableCapacity: 100)
-        var stateMachine = HTTP3ConnectionStateMachine(settings: .init(), type: .client)
+        var stateMachine = HTTP3ConnectionStateMachine(settings: localSettings, type: .client)
 
         let action1 = stateMachine.initialize()
-        #expect(action1 == .createControlStream)
+        #expect(action1 == .createControlAndDecoderStreams)
 
         let action2 = stateMachine.receivedControlFrame(.settings(remoteSettings))
         guard case .makeEncoderInstructionStream = action2 else {
@@ -733,11 +734,12 @@ struct HTTP3ConnectionStateMachineTests {
 
     @Test
     func testEncoderStreamReadyAfterShutdown() {
+        let localSettings = HTTP3Settings(qpackMaximumTableCapacity: 200)
         let remoteSettings = HTTP3Settings(qpackMaximumTableCapacity: 100)
-        var stateMachine = HTTP3ConnectionStateMachine(settings: .init(), type: .client)
+        var stateMachine = HTTP3ConnectionStateMachine(settings: localSettings, type: .client)
 
         let action1 = stateMachine.initialize()
-        #expect(action1 == .createControlStream)
+        #expect(action1 == .createControlAndDecoderStreams)
 
         let action2 = stateMachine.receivedControlFrame(.settings(remoteSettings))
         guard case .makeEncoderInstructionStream = action2 else {

--- a/Tests/HTTP3Tests/QPACKStateMachineTests.swift
+++ b/Tests/HTTP3Tests/QPACKStateMachineTests.swift
@@ -27,7 +27,7 @@ struct QPACKStateMachineTests {
     @Test
     func testSettingsWithoutDynamicTable() {
         var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
-        let action = stateMachine.receivedRemoteSettings(maxQueueSize: 0, dynamicTableSize: 0)
+        let action = stateMachine.receivedRemoteSettings(maxQueueSize: 0, effectiveDynamicTableSize: 0)
         switch action {
         case .makeEncoderInstructionStream:
             Issue.record("Expected no outbound encoder stream")
@@ -59,7 +59,7 @@ struct QPACKStateMachineTests {
     @Test
     func testEncodeHeadersInWaitingForStreamState() {
         var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
-        let action = stateMachine.receivedRemoteSettings(maxQueueSize: 100, dynamicTableSize: 100)
+        let action = stateMachine.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: 100)
         #expect(action == .makeEncoderInstructionStream)
         // We have received remote settings, and been asked to create outbound encoder stream
         // However, the outbound stream isn't ready yet, so the dynamic table should not be used
@@ -69,7 +69,7 @@ struct QPACKStateMachineTests {
     @Test
     func testEncodeHeadersInWithoutDynamicState() {
         var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
-        let action = stateMachine.receivedRemoteSettings(maxQueueSize: 100, dynamicTableSize: 0)
+        let action = stateMachine.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: 0)
         #expect(action == nil)  // No outbound stream because 0 size
         // We have received remote settings, but they specify 0 table size. Therefore we should not use dynamic table
         stateMachine.assertEncodesWithoutUsingDynamicTable()
@@ -78,7 +78,7 @@ struct QPACKStateMachineTests {
     @Test
     func testEncodeHeadersInWithDynamicState() {
         var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
-        let action1 = stateMachine.receivedRemoteSettings(maxQueueSize: 100, dynamicTableSize: 300)
+        let action1 = stateMachine.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: 300)
         #expect(action1 == .makeEncoderInstructionStream)
         let action2 = stateMachine.outboundEncoderStreamReady()
         // The stream is ready so we should immediately start using the table at max capacity
@@ -464,7 +464,7 @@ struct QPACKStateMachineTests {
     @Test
     func testGotDecoderInstructionWhenExplicitlyNoDynamicTable() {
         var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
-        _ = stateMachine.receivedRemoteSettings(maxQueueSize: 0, dynamicTableSize: 0)
+        _ = stateMachine.receivedRemoteSettings(maxQueueSize: 0, effectiveDynamicTableSize: 0)
         // This instruction is invalid because remote explicitly told us no dynamic table capacity
         let action = stateMachine.receivedIncomingDecoderInstruction(.sectionAcknowledgement(streamID: 1))
         guard case .emitConnectionError(let error) = action else {
@@ -481,7 +481,7 @@ struct QPACKStateMachineTests {
     @Test
     func testGotDecoderInstructionWhenAwaitingStream() {
         var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
-        _ = stateMachine.receivedRemoteSettings(maxQueueSize: 100, dynamicTableSize: 100)
+        _ = stateMachine.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: 100)
         // We can't receive instructions from the remote decoder until we ourselves have sent an instruction to indicate support of the dynamic table
         let action = stateMachine.receivedIncomingDecoderInstruction(.sectionAcknowledgement(streamID: 1))
         guard case .emitConnectionError(let error) = action else {
@@ -660,7 +660,7 @@ extension QPACKStateMachine {
     /// Simulate receiving settings from the remote which allows the local encoder to use the dynamic table.
     fileprivate mutating func setupRemoteDynamicTable(maxSize: Int) {
         // remote sends us settings saying we may use the dynamic table
-        let actions1 = self.receivedRemoteSettings(maxQueueSize: 100, dynamicTableSize: maxSize)
+        let actions1 = self.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: maxSize)
         switch actions1 {
         // We open an encoder stream
         case .makeEncoderInstructionStream:


### PR DESCRIPTION
### Motivation

When the connection is started a client is offering a Dynamic Table with the size of 4096:
```
Hypertext Transfer Protocol Version 3
    UNI STREAM: Control Stream off=0
        Uni Stream Type: Control Stream (0x0000000000000000)
        SETTINGS len=15
            [Stream ID: 2]
            Type: SETTINGS (0x0000000000000004)
            Length: 15
            Frame Payload: 06ffffffffffffffff015000074064
            Settings - Max Field Section Size: 4611686018427387903
            Settings - Max Table Capacity: 4096
            Settings - Blocked Streams: 100
Hypertext Transfer Protocol Version 3
    UNI STREAM: QPACK Decoder Stream off=0
        Uni Stream Type: QPACK Decoder Stream (0x0000000000000003)
Hypertext Transfer Protocol Version 3
    UNI STREAM: QPACK Encoder Stream off=0
        Uni Stream Type: QPACK Encoder Stream (0x0000000000000002)
```
And so the HTTP server opens encoder streams even though it doesnt look like the Dynamic table is supported:
```
if settings.qpackMaximumTableCapacity > 0 {
    // These settings would enable the peer to use the dynamic table
    // We must not allow that, see the DynamicTable doc for explanation.
    fatalError("Dynamic table is not supported yet")
}
```
So each packet from the peer contains a client QPACK decoder frame:

(Each packet has a QPACK Decoder frame in it)
19 0.983563 HTTP3 1486 QPACK DEC[1], STREAM(12), HEADERS: GET https://192.168.xxx.xxx:8080/responsiveness/download/1000, PADDING
23 0.984147 HTTP3 1486 QPACK DEC[1], STREAM(20), HEADERS: GET https://192.168.xxx.xxx:8080/responsiveness/download/1000, PADDING

And this causes QUIC and HTTP3 to use a lot of CPU processing the decoder frame.

### Modifications

Setup a effectiveDynamicTableSize to be based on the local and remote table size, if one is zero then the encoder stream will not be opened.

### Result

Nice reduction in CPU.
Top of tree without this change:
```
14.83 G  100.0% -  http3-swift-quic (16387)
```
With this change:
```
12.89 G  100.0% -  http3-swift-quic (43069)
```
