### PR TITLE
Make HTTP3ErrorCode a public extensible struct

### DIFF
--- a/Sources/HTTP3/HTTP3ConnectionQuiescingStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionQuiescingStateMachine.swift
@@ -162,7 +162,7 @@ package struct HTTP3ConnectionQuiescingStateMachine: ~Copyable {
                 code: .invalidGoawayStreamID,
                 message: "Invalid GOAWAY id",
                 cause: nil,
-                errorCode: .H3_ID_ERROR,
+                errorCode: .idError,
                 location: location
             )
         }
@@ -418,7 +418,7 @@ extension HTTP3Error {
             code: .invalidGoawayStreamID,
             message: "GOAWAY id was increased",
             cause: nil,
-            errorCode: .H3_ID_ERROR,
+            errorCode: .idError,
             location: location
         )
     }

--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -58,7 +58,7 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
                         code: .invalidStream,
                         message: "Received a duplicate incoming stream",
                         cause: nil,
-                        errorCode: .H3_STREAM_CREATION_ERROR,
+                        errorCode: .streamCreationError,
                         location: .here()
                     )
                 )
@@ -185,7 +185,7 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
                             code: .rejected,
                             message: "Stream rejected due to server shutting down",
                             cause: nil,
-                            errorCode: .H3_REQUEST_REJECTED,
+                            errorCode: .requestRejected,
                             location: .here()
                         )
                     )
@@ -200,7 +200,7 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
                         code: .streamCreationError,
                         message: "Incoming request stream on client",
                         cause: nil,
-                        errorCode: .H3_STREAM_CREATION_ERROR,
+                        errorCode: .streamCreationError,
                         location: .here()
                     )
                 )
@@ -263,7 +263,7 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
                         code: .streamCreationError,
                         message: "Cannot accept push stream on server",
                         cause: nil,
-                        errorCode: .H3_STREAM_CREATION_ERROR,
+                        errorCode: .streamCreationError,
                         location: .here()
                     )
                 )
@@ -278,7 +278,7 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
                         code: .streamCreationError,
                         message: "Rejecting inbound push stream with invalid ID",
                         cause: nil,
-                        errorCode: .H3_ID_ERROR,
+                        errorCode: .idError,
                         location: .here()
                     )
                 )
@@ -367,7 +367,7 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
                     code: .streamCreationError,
                     message: "Rejecting inbound stream of unknown type \(streamType.rawValue)",
                     cause: nil,
-                    errorCode: .H3_STREAM_CREATION_ERROR,
+                    errorCode: .streamCreationError,
                     location: .here()
                 )
             )
@@ -600,7 +600,7 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
                             code: .unexpectedFrame,
                             message: "Received MAX_PUSH_ID on client",
                             cause: nil,
-                            errorCode: .H3_FRAME_UNEXPECTED,
+                            errorCode: .frameUnexpected,
                             location: .here()
                         )
                     )
@@ -959,7 +959,7 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
                             code: .criticalStreamClosed,
                             message: "The \(typeName) \(unidirectionalStreamType) stream was closed",
                             cause: nil,
-                            errorCode: .H3_CLOSED_CRITICAL_STREAM,
+                            errorCode: .closedCriticalStream,
                             location: .here()
                         )
                     )
@@ -1052,7 +1052,7 @@ extension HTTP3Error {
             code: .streamCreationError,
             message: "Endpoint is shutting down",
             cause: nil,
-            errorCode: .H3_STREAM_CREATION_ERROR,
+            errorCode: .streamCreationError,
             location: location
         )
     }

--- a/Sources/HTTP3/HTTP3Error.swift
+++ b/Sources/HTTP3/HTTP3Error.swift
@@ -30,9 +30,13 @@ public struct HTTP3Error: Error, Sendable {
     /// about the root cause of the failure.
     public var cause: (any Error)?
 
-    /// The http3 error code to be sent to the peer when the connection or stream is closed.
-    /// See RFC 9114 § 8.1.
-    package var h3ErrorCode: HTTP3ErrorCode?
+    /// The HTTP/3 error code associated with this error (RFC 9114 § 8.1).
+    ///
+    /// For an error this endpoint raises, this is the code it will send to the
+    /// peer when it closes the stream or connection. For an error representing a
+    /// reset received from the peer (see ``HTTP3Error/Code-swift.struct/remoteStreamError``),
+    /// this is the code the peer sent, preserved verbatim.
+    public var h3ErrorCode: HTTP3ErrorCode?
 
     /// The location from which this error was thrown.
     public var location: SourceLocation

--- a/Sources/HTTP3/HTTP3ErrorCode.swift
+++ b/Sources/HTTP3/HTTP3ErrorCode.swift
@@ -12,49 +12,96 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// RFC 9114 § 8.1: The following error codes are defined for use when abruptly terminating streams, aborting reading of streams, or immediately closing HTTP/3 connections.
-package enum HTTP3ErrorCode: UInt64 {
+/// An HTTP/3 error code.
+///
+/// HTTP/3 uses error codes to communicate what went wrong when abruptly
+/// terminating streams, aborting reading of streams, or immediately closing
+/// connections. See RFC 9114 § 8.1.
+///
+/// This is modeled as a struct rather than an enum so that codes registered by
+/// future revisions or extensions can be added without a source-breaking
+/// change, and so that a code received from a peer is preserved verbatim even
+/// when this library does not recognize it (mirroring `HTTP2ErrorCode`).
+public struct HTTP3ErrorCode: Hashable, Sendable {
+    /// The underlying error code value (RFC 9114 § 8.1 / RFC 9000 § 20.2).
+    public var rawValue: UInt64
+
+    /// Create an ``HTTP3ErrorCode`` from its raw value.
+    public init(rawValue: UInt64) {
+        self.rawValue = rawValue
+    }
+
     /// No error. This is used when the connection or stream needs to be closed, but there is no error to signal.
-    case H3_NO_ERROR = 0x0100
+    public static let noError = HTTP3ErrorCode(rawValue: 0x0100)
     /// Peer violated protocol requirements in a way that does not match a more specific error code or endpoint declines to use the more specific error code.
-    case H3_GENERAL_PROTOCOL_ERROR = 0x0101
+    public static let generalProtocolError = HTTP3ErrorCode(rawValue: 0x0101)
     /// An internal error has occurred in the HTTP stack.
-    case H3_INTERNAL_ERROR = 0x0102
+    public static let internalError = HTTP3ErrorCode(rawValue: 0x0102)
     /// The endpoint detected that its peer created a stream that it will not accept.
-    case H3_STREAM_CREATION_ERROR = 0x0103
+    public static let streamCreationError = HTTP3ErrorCode(rawValue: 0x0103)
     /// A stream required by the HTTP/3 connection was closed or reset.
-    case H3_CLOSED_CRITICAL_STREAM = 0x0104
+    public static let closedCriticalStream = HTTP3ErrorCode(rawValue: 0x0104)
     /// A frame was received that was not permitted in the current state or on the current stream.
-    case H3_FRAME_UNEXPECTED = 0x0105
+    public static let frameUnexpected = HTTP3ErrorCode(rawValue: 0x0105)
     /// A frame that fails to satisfy layout requirements or with an invalid size was received.
-    case H3_FRAME_ERROR = 0x0106
+    public static let frameError = HTTP3ErrorCode(rawValue: 0x0106)
     /// The endpoint detected that its peer is exhibiting a behavior that might be generating excessive load.
-    case H3_EXCESSIVE_LOAD = 0x0107
+    public static let excessiveLoad = HTTP3ErrorCode(rawValue: 0x0107)
     /// A stream ID or push ID was used incorrectly, such as exceeding a limit, reducing a limit, or being reused.
-    case H3_ID_ERROR = 0x0108
+    public static let idError = HTTP3ErrorCode(rawValue: 0x0108)
     /// An endpoint detected an error in the payload of a SETTINGS frame.
-    case H3_SETTINGS_ERROR = 0x0109
+    public static let settingsError = HTTP3ErrorCode(rawValue: 0x0109)
     /// No SETTINGS frame was received at the beginning of the control stream.
-    case H3_MISSING_SETTINGS = 0x010a
+    public static let missingSettings = HTTP3ErrorCode(rawValue: 0x010a)
     /// A server rejected a request without performing any application processing.
-    case H3_REQUEST_REJECTED = 0x010b
+    public static let requestRejected = HTTP3ErrorCode(rawValue: 0x010b)
     /// The request or its response (including pushed response) is cancelled.
-    case H3_REQUEST_CANCELLED = 0x010c
+    public static let requestCancelled = HTTP3ErrorCode(rawValue: 0x010c)
     /// The client's stream terminated without containing a fully formed request.
-    case H3_REQUEST_INCOMPLETE = 0x010d
+    public static let requestIncomplete = HTTP3ErrorCode(rawValue: 0x010d)
     /// An HTTP message was malformed and cannot be processed.
-    case H3_MESSAGE_ERROR = 0x010e
+    public static let messageError = HTTP3ErrorCode(rawValue: 0x010e)
     /// The TCP connection established in response to a CONNECT request was reset or abnormally closed.
-    case H3_CONNECT_ERROR = 0x010f
+    public static let connectError = HTTP3ErrorCode(rawValue: 0x010f)
     /// The requested operation cannot be served over HTTP/3. The peer should retry over HTTP/1.1.
-    case H3_VERSION_FALLBACK = 0x0110
+    public static let versionFallback = HTTP3ErrorCode(rawValue: 0x0110)
 
     // MARK: QPACK (RFC 9204)
 
     /// The decoder failed to interpret an encoded field section and is not able to continue decoding that field section.
-    case QPACK_DECOMPRESSION_FAILED = 0x0200
+    public static let qpackDecompressionFailed = HTTP3ErrorCode(rawValue: 0x0200)
     /// The decoder failed to interpret an encoder instruction received on the encoder stream.
-    case QPACK_ENCODER_STREAM_ERROR = 0x0201
+    public static let qpackEncoderStreamError = HTTP3ErrorCode(rawValue: 0x0201)
     /// The encoder failed to interpret a decoder instruction received on the decoder stream.
-    case QPACK_DECODER_STREAM_ERROR = 0x0202
+    public static let qpackDecoderStreamError = HTTP3ErrorCode(rawValue: 0x0202)
+}
+
+extension HTTP3ErrorCode: CustomStringConvertible {
+    public var description: String {
+        let name: String
+        switch self {
+        case .noError: name = "H3_NO_ERROR"
+        case .generalProtocolError: name = "H3_GENERAL_PROTOCOL_ERROR"
+        case .internalError: name = "H3_INTERNAL_ERROR"
+        case .streamCreationError: name = "H3_STREAM_CREATION_ERROR"
+        case .closedCriticalStream: name = "H3_CLOSED_CRITICAL_STREAM"
+        case .frameUnexpected: name = "H3_FRAME_UNEXPECTED"
+        case .frameError: name = "H3_FRAME_ERROR"
+        case .excessiveLoad: name = "H3_EXCESSIVE_LOAD"
+        case .idError: name = "H3_ID_ERROR"
+        case .settingsError: name = "H3_SETTINGS_ERROR"
+        case .missingSettings: name = "H3_MISSING_SETTINGS"
+        case .requestRejected: name = "H3_REQUEST_REJECTED"
+        case .requestCancelled: name = "H3_REQUEST_CANCELLED"
+        case .requestIncomplete: name = "H3_REQUEST_INCOMPLETE"
+        case .messageError: name = "H3_MESSAGE_ERROR"
+        case .connectError: name = "H3_CONNECT_ERROR"
+        case .versionFallback: name = "H3_VERSION_FALLBACK"
+        case .qpackDecompressionFailed: name = "QPACK_DECOMPRESSION_FAILED"
+        case .qpackEncoderStreamError: name = "QPACK_ENCODER_STREAM_ERROR"
+        case .qpackDecoderStreamError: name = "QPACK_DECODER_STREAM_ERROR"
+        default: name = "UNKNOWN"
+        }
+        return "HTTP3ErrorCode<0x\(String(self.rawValue, radix: 16)) \(name)>"
+    }
 }

--- a/Sources/HTTP3/HTTP3ErrorCode.swift
+++ b/Sources/HTTP3/HTTP3ErrorCode.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 /// An HTTP/3 error code.
-///
 /// HTTP/3 uses error codes to communicate what went wrong when abruptly
 /// terminating streams, aborting reading of streams, or immediately closing
 /// connections. See RFC 9114 § 8.1.

--- a/Sources/HTTP3/HTTP3ErrorCode.swift
+++ b/Sources/HTTP3/HTTP3ErrorCode.swift
@@ -18,10 +18,9 @@
 /// terminating streams, aborting reading of streams, or immediately closing
 /// connections. See RFC 9114 § 8.1.
 ///
-/// This is modeled as a struct rather than an enum so that codes registered by
-/// future revisions or extensions can be added without a source-breaking
-/// change, and so that a code received from a peer is preserved verbatim even
-/// when this library does not recognize it (mirroring `HTTP2ErrorCode`).
+/// This is modeled as a struct rather than an enum so that a code received from
+/// a peer is preserved verbatim even when this library does not recognize it
+/// (mirroring `HTTP2ErrorCode`).
 public struct HTTP3ErrorCode: Hashable, Sendable {
     /// The underlying error code value (RFC 9114 § 8.1 / RFC 9000 § 20.2).
     public var rawValue: UInt64
@@ -76,31 +75,31 @@ public struct HTTP3ErrorCode: Hashable, Sendable {
     public static let qpackDecoderStreamError = HTTP3ErrorCode(rawValue: 0x0202)
 }
 
-extension HTTP3ErrorCode: CustomStringConvertible {
-    public var description: String {
+extension HTTP3ErrorCode: CustomDebugStringConvertible {
+    public var debugDescription: String {
         let name: String
         switch self {
-        case .noError: name = "H3_NO_ERROR"
-        case .generalProtocolError: name = "H3_GENERAL_PROTOCOL_ERROR"
-        case .internalError: name = "H3_INTERNAL_ERROR"
-        case .streamCreationError: name = "H3_STREAM_CREATION_ERROR"
-        case .closedCriticalStream: name = "H3_CLOSED_CRITICAL_STREAM"
-        case .frameUnexpected: name = "H3_FRAME_UNEXPECTED"
-        case .frameError: name = "H3_FRAME_ERROR"
-        case .excessiveLoad: name = "H3_EXCESSIVE_LOAD"
-        case .idError: name = "H3_ID_ERROR"
-        case .settingsError: name = "H3_SETTINGS_ERROR"
-        case .missingSettings: name = "H3_MISSING_SETTINGS"
-        case .requestRejected: name = "H3_REQUEST_REJECTED"
-        case .requestCancelled: name = "H3_REQUEST_CANCELLED"
-        case .requestIncomplete: name = "H3_REQUEST_INCOMPLETE"
-        case .messageError: name = "H3_MESSAGE_ERROR"
-        case .connectError: name = "H3_CONNECT_ERROR"
-        case .versionFallback: name = "H3_VERSION_FALLBACK"
-        case .qpackDecompressionFailed: name = "QPACK_DECOMPRESSION_FAILED"
-        case .qpackEncoderStreamError: name = "QPACK_ENCODER_STREAM_ERROR"
-        case .qpackDecoderStreamError: name = "QPACK_DECODER_STREAM_ERROR"
-        default: name = "UNKNOWN"
+        case .noError: name = "No Error"
+        case .generalProtocolError: name = "General Protocol Error"
+        case .internalError: name = "Internal Error"
+        case .streamCreationError: name = "Stream Creation Error"
+        case .closedCriticalStream: name = "Closed Critical Stream"
+        case .frameUnexpected: name = "Frame Unexpected"
+        case .frameError: name = "Frame Error"
+        case .excessiveLoad: name = "Excessive Load"
+        case .idError: name = "ID Error"
+        case .settingsError: name = "Settings Error"
+        case .missingSettings: name = "Missing Settings"
+        case .requestRejected: name = "Request Rejected"
+        case .requestCancelled: name = "Request Cancelled"
+        case .requestIncomplete: name = "Request Incomplete"
+        case .messageError: name = "Message Error"
+        case .connectError: name = "Connect Error"
+        case .versionFallback: name = "Version Fallback"
+        case .qpackDecompressionFailed: name = "QPACK Decompression Failed"
+        case .qpackEncoderStreamError: name = "QPACK Encoder Stream Error"
+        case .qpackDecoderStreamError: name = "QPACK Decoder Stream Error"
+        default: name = "Unknown Error"
         }
         return "HTTP3ErrorCode<0x\(String(self.rawValue, radix: 16)) \(name)>"
     }

--- a/Sources/HTTP3/HTTP3Frame.swift
+++ b/Sources/HTTP3/HTTP3Frame.swift
@@ -97,7 +97,7 @@ package enum HTTP3FrameType: Hashable {
                 code: .forbiddenFrameType,
                 message: "\(rawValue) is not allowed",
                 cause: nil,
-                errorCode: .H3_FRAME_UNEXPECTED,  // RFC 9114 § 7.2.8
+                errorCode: .frameUnexpected,  // RFC 9114 § 7.2.8
                 location: location
             )
         }

--- a/Sources/HTTP3/HTTP3FrameDecoder.swift
+++ b/Sources/HTTP3/HTTP3FrameDecoder.swift
@@ -109,7 +109,7 @@ package struct HTTP3FrameDecoder: ~Copyable {
                         code: .invalidFramePayload,
                         message: "Payload too large",
                         cause: nil,
-                        errorCode: .H3_EXCESSIVE_LOAD,
+                        errorCode: .excessiveLoad,
                         location: .here()
                     )
                 }
@@ -163,7 +163,7 @@ package struct HTTP3FrameDecoder: ~Copyable {
                     code: .invalidFramePayload,
                     message: "Payload too large",
                     cause: nil,
-                    errorCode: .H3_EXCESSIVE_LOAD,
+                    errorCode: .excessiveLoad,
                     location: .here()
                 )
             }
@@ -182,7 +182,7 @@ package struct HTTP3FrameDecoder: ~Copyable {
                     code: .invalidFramePayload,
                     message: "Invalid frame payload",
                     cause: nil,
-                    errorCode: .H3_FRAME_ERROR,
+                    errorCode: .frameError,
                     location: .here()
                 )
             }
@@ -202,7 +202,7 @@ package struct HTTP3FrameDecoder: ~Copyable {
                     code: .invalidFramePayload,
                     message: "Frame length longer than payload",
                     cause: nil,
-                    errorCode: .H3_FRAME_ERROR,
+                    errorCode: .frameError,
                     location: .here()
                 )
             }
@@ -270,7 +270,7 @@ extension ByteBuffer {
                     code: .integerTooLarge,
                     message: "Integer is too large",
                     cause: error,
-                    errorCode: .H3_GENERAL_PROTOCOL_ERROR,
+                    errorCode: .generalProtocolError,
                     location: .here()
                 )
             }

--- a/Sources/HTTP3/HTTP3FrameValidator.swift
+++ b/Sources/HTTP3/HTTP3FrameValidator.swift
@@ -52,7 +52,7 @@ package enum HTTP3FrameValidator: ~Copyable {
                         code: .firstControlFrameNotSettings,
                         message: "Expected settings, got unknown",
                         cause: nil,
-                        errorCode: .H3_MISSING_SETTINGS,
+                        errorCode: .missingSettings,
                         location: .here()
                     )
                 )
@@ -82,7 +82,7 @@ package enum HTTP3FrameValidator: ~Copyable {
                             code: .firstControlFrameNotSettings,
                             message: "Expected settings, got \(frame.type)",
                             cause: nil,
-                            errorCode: .H3_MISSING_SETTINGS,
+                            errorCode: .missingSettings,
                             location: .here()
                         )
                     )
@@ -96,7 +96,7 @@ package enum HTTP3FrameValidator: ~Copyable {
                             code: .unexpectedFrame,
                             message: "Expected cancelPush or goaway or maxPushID, got \(frame.type)",
                             cause: nil,
-                            errorCode: .H3_FRAME_UNEXPECTED,
+                            errorCode: .frameUnexpected,
                             location: .here()
                         )
                     )
@@ -108,7 +108,7 @@ package enum HTTP3FrameValidator: ~Copyable {
                             code: .unexpectedFrame,
                             message: "Received a second settings frame",
                             cause: nil,
-                            errorCode: .H3_FRAME_UNEXPECTED,
+                            errorCode: .frameUnexpected,
                             location: location
                         )
                     }
@@ -160,7 +160,7 @@ package enum HTTP3FrameValidator: ~Copyable {
                             code: .unexpectedFrame,
                             message: "Expected headers or data, got \(frame.type)",
                             cause: nil,
-                            errorCode: .H3_FRAME_UNEXPECTED,
+                            errorCode: .frameUnexpected,
                             location: .here()
                         )
                     )
@@ -214,7 +214,7 @@ package enum HTTP3FrameValidator: ~Copyable {
                         code: .malformedMessage,
                         message: "A HTTP response was sent before a request",
                         cause: nil,
-                        errorCode: .H3_MESSAGE_ERROR,
+                        errorCode: .messageError,
                         location: .here()
                     )
                 )
@@ -243,7 +243,7 @@ package enum HTTP3FrameValidator: ~Copyable {
                             code: .unexpectedFrame,
                             message: "Expected headers, got \(frame.type)",
                             cause: nil,
-                            errorCode: .H3_FRAME_UNEXPECTED,
+                            errorCode: .frameUnexpected,
                             location: .here()
                         )
                     )
@@ -265,7 +265,7 @@ package enum HTTP3FrameValidator: ~Copyable {
                             code: .unexpectedFrame,
                             message: "Expected headers or data, got \(frame.type)",
                             cause: nil,
-                            errorCode: .H3_FRAME_UNEXPECTED,
+                            errorCode: .frameUnexpected,
                             location: .here()
                         )
                     )
@@ -280,7 +280,7 @@ package enum HTTP3FrameValidator: ~Copyable {
                             code: .unexpectedFrame,
                             message: "Expected no further frames after response trailers, got \(frame.type)",
                             cause: nil,
-                            errorCode: .H3_FRAME_UNEXPECTED,
+                            errorCode: .frameUnexpected,
                             location: .here()
                         )
                     )
@@ -311,7 +311,7 @@ package enum HTTP3FrameValidator: ~Copyable {
                             code: .unexpectedFrame,
                             message: "Expected headers, got \(frame.type)",
                             cause: nil,
-                            errorCode: .H3_FRAME_UNEXPECTED,
+                            errorCode: .frameUnexpected,
                             location: .here()
                         )
                     )
@@ -335,7 +335,7 @@ package enum HTTP3FrameValidator: ~Copyable {
                             code: .unexpectedFrame,
                             message: "Expected headers or data, got \(frame.type)",
                             cause: nil,
-                            errorCode: .H3_FRAME_UNEXPECTED,
+                            errorCode: .frameUnexpected,
                             location: .here()
                         )
                     )
@@ -350,7 +350,7 @@ package enum HTTP3FrameValidator: ~Copyable {
                             code: .unexpectedFrame,
                             message: "Expected no further frames after request trailers, got \(frame.type)",
                             cause: nil,
-                            errorCode: .H3_FRAME_UNEXPECTED,
+                            errorCode: .frameUnexpected,
                             location: .here()
                         )
                     )

--- a/Sources/HTTP3/HTTP3Settings.swift
+++ b/Sources/HTTP3/HTTP3Settings.swift
@@ -106,7 +106,7 @@ public struct HTTP3Settings: Hashable, Sendable {
                 code: .invalidFramePayload,
                 message: "Settings contains duplicated identifier \(identifier)",
                 cause: nil,
-                errorCode: .H3_SETTINGS_ERROR,
+                errorCode: .settingsError,
                 location: location
             )
         }
@@ -174,7 +174,7 @@ extension ByteBuffer {
                     code: .invalidFramePayload,
                     message: "Setting identifier is not a valid QUIC variable-length integer",
                     cause: nil,
-                    errorCode: .H3_FRAME_ERROR,
+                    errorCode: .frameError,
                     location: .here()
                 )
             }
@@ -183,7 +183,7 @@ extension ByteBuffer {
                     code: .invalidFramePayload,
                     message: "Setting value is not a valid QUIC variable-length integer",
                     cause: nil,
-                    errorCode: .H3_FRAME_ERROR,
+                    errorCode: .frameError,
                     location: .here()
                 )
             }
@@ -193,7 +193,7 @@ extension ByteBuffer {
                     code: .invalidFramePayload,
                     message: "Setting identifier is forbidden",
                     cause: nil,
-                    errorCode: .H3_SETTINGS_ERROR,
+                    errorCode: .settingsError,
                     location: .here()
                 )
             }

--- a/Sources/HTTP3/HTTP3StreamStateMachine.swift
+++ b/Sources/HTTP3/HTTP3StreamStateMachine.swift
@@ -137,7 +137,7 @@ package struct HTTP3StreamStateMachine: ~Copyable {
                                     code: .leftoverBytes,
                                     message: "There were leftover bytes when the input was closed",
                                     cause: nil,
-                                    errorCode: .H3_FRAME_ERROR,
+                                    errorCode: .frameError,
                                     location: location
                                 )
                             }
@@ -169,7 +169,7 @@ package struct HTTP3StreamStateMachine: ~Copyable {
                             code: .unexpectedFrame,
                             message: "Unexpected push promise",
                             cause: nil,
-                            errorCode: .H3_ID_ERROR,
+                            errorCode: .idError,
                             location: .here()
                         )
                     )
@@ -706,8 +706,11 @@ package struct HTTP3StreamStateMachine: ~Copyable {
 
     /// Inform the state machine of a stream error which was caught on this stream.
     package mutating func streamErrorCaught(errorCode: QUICApplicationErrorCode) -> ErrorCaughtAction? {
-        // RFC 9114 § 8: Receipt of an unknown error code MUST be treated as equivalent to H3_NO_ERROR
-        let errorCodeValue = HTTP3ErrorCode(rawValue: errorCode.rawValue) ?? .H3_NO_ERROR
+        // Preserve the peer's error code verbatim for reporting, even if it is
+        // not one this library recognizes. The reaction is a generic stream
+        // error (`.remoteStreamError`), which already satisfies RFC 9114 § 8's
+        // requirement to treat an unknown code as equivalent to H3_NO_ERROR.
+        let errorCodeValue = HTTP3ErrorCode(rawValue: errorCode.rawValue)
         @inline(never)
         func remoteStreamError(
             errorCode: HTTP3ErrorCode,

--- a/Sources/HTTP3/QPACK/QPACKStateMachine.swift
+++ b/Sources/HTTP3/QPACK/QPACKStateMachine.swift
@@ -174,7 +174,7 @@ package struct QPACKStateMachine: ~Copyable {
                     code: .qpackDecoderStreamError,
                     message: "Decoder instruction received when dynamic table not being used",
                     cause: nil,
-                    errorCode: .QPACK_DECODER_STREAM_ERROR,
+                    errorCode: .qpackDecoderStreamError,
                     location: location
                 )
             }
@@ -203,7 +203,7 @@ package struct QPACKStateMachine: ~Copyable {
                             code: .qpackDecoderStreamError,
                             message: "Invalid decoder instruction",
                             cause: cause,
-                            errorCode: .QPACK_DECODER_STREAM_ERROR,
+                            errorCode: .qpackDecoderStreamError,
                             location: location
                         )
                     }
@@ -388,7 +388,7 @@ package struct QPACKStateMachine: ~Copyable {
                 code: .qpackDecoderError,
                 message: "Invalid field section prefix",
                 cause: nil,
-                errorCode: .QPACK_DECOMPRESSION_FAILED,
+                errorCode: .qpackDecompressionFailed,
                 location: location
             )
         }
@@ -435,7 +435,7 @@ package struct QPACKStateMachine: ~Copyable {
                             code: .qpackDecoderError,
                             message: "Too many streams blocked on QPACK",
                             cause: cause,
-                            errorCode: .QPACK_DECOMPRESSION_FAILED,
+                            errorCode: .qpackDecompressionFailed,
                             location: location
                         )
                     }
@@ -518,7 +518,7 @@ package struct QPACKStateMachine: ~Copyable {
                 code: .qpackDecoderError,
                 message: "Could not decode QPACK headers for stream \(streamID)",
                 cause: qpackError,
-                errorCode: .QPACK_DECOMPRESSION_FAILED,
+                errorCode: .qpackDecompressionFailed,
                 location: .here()
             )
             return .connection(h3Error)
@@ -529,7 +529,7 @@ package struct QPACKStateMachine: ~Copyable {
                 code: .qpackDecoderError,
                 message: "Could not decode QPACK headers",
                 cause: qpackError,
-                errorCode: .H3_MESSAGE_ERROR,
+                errorCode: .messageError,
                 location: .here()
             )
             return .stream(h3Error)
@@ -556,7 +556,7 @@ package struct QPACKStateMachine: ~Copyable {
                 code: .qpackEncoderStreamError,
                 message: "Invalid encoder instruction",
                 cause: cause,
-                errorCode: .QPACK_ENCODER_STREAM_ERROR,
+                errorCode: .qpackEncoderStreamError,
                 location: location
             )
         }

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -289,7 +289,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
                         streamType: .request
                     )
                     streamChannel.triggerUserOutboundEvent(
-                        QUICStopSendingEvent(code: QUICApplicationErrorCode(.H3_REQUEST_REJECTED)),
+                        QUICStopSendingEvent(code: QUICApplicationErrorCode(.requestRejected)),
                         promise: nil
                     )
                 }
@@ -395,7 +395,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
                                         code: .qpackEncoderStreamError,
                                         message: "Invalid QPACK instruction",
                                         cause: error,
-                                        errorCode: .QPACK_ENCODER_STREAM_ERROR,
+                                        errorCode: .qpackEncoderStreamError,
                                         location: .here()
                                     )
                                 )
@@ -442,7 +442,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
                                         code: .qpackEncoderStreamError,
                                         message: "Invalid QPACK instruction",
                                         cause: error,
-                                        errorCode: .QPACK_ENCODER_STREAM_ERROR,
+                                        errorCode: .qpackEncoderStreamError,
                                         location: .here()
                                     )
                                 )
@@ -637,7 +637,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
                     code: .none,
                     message: "",
                     cause: nil,
-                    errorCode: .H3_NO_ERROR,
+                    errorCode: .noError,
                     location: .here()
                 )
             )

--- a/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
@@ -99,12 +99,12 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
             self.logger.debug(
                 "Closing connection",
                 metadata: [
-                    LoggingKeys.error: "\(error.h3ErrorCode ?? .H3_NO_ERROR)", LoggingKeys.reason: "\(error.message)",
+                    LoggingKeys.error: "\(error.h3ErrorCode ?? .noError)", LoggingKeys.reason: "\(error.message)",
                 ]
             )
             self.context?.triggerUserOutboundEvent(
                 QUICCloseConnectionEvent(
-                    code: QUICApplicationErrorCode(error.h3ErrorCode ?? .H3_NO_ERROR),
+                    code: QUICApplicationErrorCode(error.h3ErrorCode ?? .noError),
                     reasonPhrase: error.message
                 ),
                 promise: nil
@@ -360,7 +360,7 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
             return
         }
         // RFC 9114 § 8: Receipt of an unknown error code MUST be treated as equivalent to H3_NO_ERROR.
-        let h3Code = HTTP3ErrorCode(rawValue: quicError.code) ?? .H3_NO_ERROR
+        let h3Code = HTTP3ErrorCode(rawValue: quicError.code) ?? .noError
         self.logger.debug(
             "HTTP3ConnectionHandler caught error",
             metadata: [LoggingKeys.error: "\(h3Code)", LoggingKeys.reason: "\(quicError.reason)"]
@@ -404,7 +404,7 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
                     code: .unableToFindStreamID,
                     message: "Unable to find stream ID for incoming stream",
                     cause: cause,
-                    errorCode: .H3_INTERNAL_ERROR,
+                    errorCode: .internalError,
                     location: .here()
                 )
             )

--- a/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
@@ -359,8 +359,7 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
             context.fireErrorCaught(error)
             return
         }
-        // RFC 9114 § 8: Receipt of an unknown error code MUST be treated as equivalent to H3_NO_ERROR.
-        let h3Code = HTTP3ErrorCode(rawValue: quicError.code) ?? .noError
+        let h3Code = HTTP3ErrorCode(rawValue: quicError.code)
         self.logger.debug(
             "HTTP3ConnectionHandler caught error",
             metadata: [LoggingKeys.error: "\(h3Code)", LoggingKeys.reason: "\(quicError.reason)"]

--- a/Sources/NIOHTTP3/HTTP3StreamHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3StreamHandler.swift
@@ -185,7 +185,7 @@ package final class HTTP3StreamHandler: ChannelDuplexHandler {
                 self.qpackDecoder(partialHeader, self.streamID)
             case .emitStreamError(let error):
                 context.triggerUserOutboundEvent(
-                    QUICStopSendingEvent(code: QUICApplicationErrorCode(error.h3ErrorCode ?? .H3_NO_ERROR)),
+                    QUICStopSendingEvent(code: QUICApplicationErrorCode(error.h3ErrorCode ?? .noError)),
                     promise: nil
                 )
                 context.fireErrorCaught(error)
@@ -359,7 +359,7 @@ package final class HTTP3StreamHandler: ChannelDuplexHandler {
                 code: .rejected,
                 message: "Stream cancelled due to GOAWAY",
                 cause: nil,
-                errorCode: .H3_REQUEST_REJECTED,
+                errorCode: .requestRejected,
                 location: location
             )
         }

--- a/Sources/NIOHTTP3/HTTP3ToHTTPCodecs.swift
+++ b/Sources/NIOHTTP3/HTTP3ToHTTPCodecs.swift
@@ -34,7 +34,7 @@ private func invalidHeadersError(message: String, location: HTTP3Error.SourceLoc
         code: .malformedMessage,
         message: "Invalid headers",
         cause: cause,
-        errorCode: .H3_MESSAGE_ERROR,
+        errorCode: .messageError,
         location: location
     )
 }
@@ -49,7 +49,7 @@ extension HTTPRequestPart: HTTPMessagePart {
                 code: .malformedMessage,
                 message: "Invalid headers",
                 cause: error,
-                errorCode: .H3_MESSAGE_ERROR,
+                errorCode: .messageError,
                 location: .here()
             )
         }
@@ -130,7 +130,7 @@ extension HTTPRequestPart: HTTPMessagePart {
                     code: .malformedMessage,
                     message: "Invalid trailers",
                     cause: error,
-                    errorCode: .H3_MESSAGE_ERROR,
+                    errorCode: .messageError,
                     location: .here()
                 )
             }
@@ -152,7 +152,7 @@ extension HTTPResponsePart: HTTPMessagePart {
                 code: .malformedMessage,
                 message: "Invalid headers",
                 cause: error,
-                errorCode: .H3_MESSAGE_ERROR,
+                errorCode: .messageError,
                 location: .here()
             )
         }
@@ -180,7 +180,7 @@ extension HTTPResponsePart: HTTPMessagePart {
                     code: .malformedMessage,
                     message: "Invalid trailers",
                     cause: error,
-                    errorCode: .H3_MESSAGE_ERROR,
+                    errorCode: .messageError,
                     location: .here()
                 )
             }

--- a/Sources/NIOHTTP3/HTTP3UnidirectionalStreamTypeDecoderHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3UnidirectionalStreamTypeDecoderHandler.swift
@@ -121,7 +121,7 @@ package final class HTTP3UnidirectionalStreamTypeDecoderHandler: ChannelInboundH
                     // The callback threw an error, we should close the stream
                     if let h3Error = error as? HTTP3Error {
                         context.fireErrorCaught(h3Error)
-                        self.sendStreamReset(errorCode: h3Error.h3ErrorCode ?? .H3_INTERNAL_ERROR)
+                        self.sendStreamReset(errorCode: h3Error.h3ErrorCode ?? .internalError)
                     } else {
                         @inline(never)
                         func streamCreationError(
@@ -132,13 +132,13 @@ package final class HTTP3UnidirectionalStreamTypeDecoderHandler: ChannelInboundH
                                 code: .streamCreationError,
                                 message: "Failed to initialize inbound stream",
                                 cause: cause,
-                                errorCode: .H3_INTERNAL_ERROR,
+                                errorCode: .internalError,
                                 location: location
                             )
                         }
                         let h3Error = streamCreationError(cause: error, location: .here())
                         context.fireErrorCaught(h3Error)
-                        self.sendStreamReset(errorCode: .H3_INTERNAL_ERROR)
+                        self.sendStreamReset(errorCode: .internalError)
                     }
                 }
             }

--- a/Tests/H3IntegrationTests/AsyncEndToEndTests.swift
+++ b/Tests/H3IntegrationTests/AsyncEndToEndTests.swift
@@ -341,7 +341,7 @@ struct AsyncEndToEndTests {
                 let h3Error = caughtError as? HTTP3Error
                 #expect(
                     (h3Error?.code == .rejected && h3Error?.h3ErrorCode == nil)
-                        || (h3Error?.code == .remoteStreamError && h3Error?.h3ErrorCode == .H3_REQUEST_REJECTED)
+                        || (h3Error?.code == .remoteStreamError && h3Error?.h3ErrorCode == .requestRejected)
                         || (h3Error?.code == .remoteConnectionError && h3Error?.h3ErrorCode == nil)
                 )
 

--- a/Tests/H3IntegrationTests/EndToEndTests.swift
+++ b/Tests/H3IntegrationTests/EndToEndTests.swift
@@ -678,7 +678,7 @@ struct EndToEndTests {
         let clientConnectionError = try await clientErrorPromise.futureResult.get()
         let clientH3ConnectionError = clientConnectionError as? HTTP3Error
         #expect(clientH3ConnectionError?.code == .remoteConnectionError)
-        #expect(clientH3ConnectionError?.h3ErrorCode == .H3_FRAME_UNEXPECTED)
+        #expect(clientH3ConnectionError?.h3ErrorCode == .frameUnexpected)
         #expect(clientH3ConnectionError?.message == "Expected headers, got settings")
 
         // Client connection should close itself
@@ -727,7 +727,7 @@ struct EndToEndTests {
         let clientConnectionError = try await clientErrorPromise.futureResult.get()
         let clientH3ConnectionError = clientConnectionError as? HTTP3Error
         #expect(clientH3ConnectionError?.code == .remoteConnectionError)
-        #expect(clientH3ConnectionError?.h3ErrorCode == .H3_NO_ERROR)
+        #expect(clientH3ConnectionError?.h3ErrorCode == .noError)
 
         // Client connection should close itself
         try await clientConnectionChannel.closeFuture.get()
@@ -920,7 +920,7 @@ struct EndToEndTests {
         let streamError = try await clientErrorPromise.futureResult.get()
         let clientH3ConnectionError = streamError as? HTTP3Error
         #expect(clientH3ConnectionError?.code == .remoteStreamError)
-        #expect(clientH3ConnectionError?.h3ErrorCode == .H3_MESSAGE_ERROR)
+        #expect(clientH3ConnectionError?.h3ErrorCode == .messageError)
 
         // Request stream should close because of the error
         try await requestStreamChannel.closeFuture.get()
@@ -977,7 +977,7 @@ struct EndToEndTests {
 
         let clientStreamError = try await clientErrorPromise.futureResult.get()
         let clientStreamQUICError = clientStreamError as? QUICStopSendingError
-        #expect(clientStreamQUICError?.code == QUICApplicationErrorCode(.H3_STREAM_CREATION_ERROR))
+        #expect(clientStreamQUICError?.code == QUICApplicationErrorCode(.streamCreationError))
 
         // Client stream should close
         try await streamChannel.closeFuture.get()
@@ -1035,7 +1035,7 @@ struct EndToEndTests {
         let clientConnectionError = try await clientErrorPromise.futureResult.get()
         let clientH3ConnectionError = clientConnectionError as? HTTP3Error
         #expect(clientH3ConnectionError?.code == .remoteConnectionError)
-        #expect(clientH3ConnectionError?.h3ErrorCode == .H3_STREAM_CREATION_ERROR)
+        #expect(clientH3ConnectionError?.h3ErrorCode == .streamCreationError)
         #expect(clientH3ConnectionError?.message == "Cannot accept push stream on server")
 
         // Client connection should close itself
@@ -1121,7 +1121,7 @@ struct EndToEndTests {
         let serverConnectionError = try await serverErrorPromise.futureResult.get()
         let serverH3ConnectionError = serverConnectionError as? HTTP3Error
         #expect(serverH3ConnectionError?.code == .remoteConnectionError)
-        #expect(serverH3ConnectionError?.h3ErrorCode == .H3_ID_ERROR)
+        #expect(serverH3ConnectionError?.h3ErrorCode == .idError)
         #expect(serverH3ConnectionError?.message == "Rejecting inbound push stream with invalid ID")
 
         // server and client connections should close themselves
@@ -1194,7 +1194,7 @@ struct EndToEndTests {
         let clientConnectionError = try await clientErrorPromise.futureResult.get()
         let clientH3ConnectionError = clientConnectionError as? HTTP3Error
         #expect(clientH3ConnectionError?.code == .remoteConnectionError)
-        #expect(clientH3ConnectionError?.h3ErrorCode == .QPACK_ENCODER_STREAM_ERROR)
+        #expect(clientH3ConnectionError?.h3ErrorCode == .qpackEncoderStreamError)
         #expect(clientH3ConnectionError?.message == "Invalid QPACK instruction")
 
         // Client connection should close itself
@@ -1467,7 +1467,7 @@ struct EndToEndTests {
         expectH3ErrorEqual(
             error: serverCaughtError,
             expectedCode: .remoteConnectionError,
-            expectedH3ErrorCode: .H3_CLOSED_CRITICAL_STREAM
+            expectedH3ErrorCode: .closedCriticalStream
         )
 
         // Tear down

--- a/Tests/HTTP3Tests/HTTP3ConnectionQuiescingStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3ConnectionQuiescingStateMachineTests.swift
@@ -47,7 +47,7 @@ struct HTTP3ConnectionQuiescingStateMachineTests {
         expectH3ErrorEqual(
             error: action?.connectionError,
             expectedCode: .invalidGoawayStreamID,
-            expectedH3ErrorCode: .H3_ID_ERROR
+            expectedH3ErrorCode: .idError
         )
     }
 
@@ -59,7 +59,7 @@ struct HTTP3ConnectionQuiescingStateMachineTests {
         expectH3ErrorEqual(
             error: action?.connectionError,
             expectedCode: .invalidGoawayStreamID,
-            expectedH3ErrorCode: .H3_ID_ERROR
+            expectedH3ErrorCode: .idError
         )
     }
 
@@ -72,7 +72,7 @@ struct HTTP3ConnectionQuiescingStateMachineTests {
         expectH3ErrorEqual(
             error: action?.connectionError,
             expectedCode: .invalidGoawayStreamID,
-            expectedH3ErrorCode: .H3_ID_ERROR
+            expectedH3ErrorCode: .idError
         )
     }
 
@@ -120,7 +120,7 @@ struct HTTP3ConnectionQuiescingStateMachineTests {
         expectH3ErrorEqual(
             error: action3.throwError,
             expectedCode: .invalidGoawayStreamID,
-            expectedH3ErrorCode: .H3_ID_ERROR
+            expectedH3ErrorCode: .idError
         )
     }
 
@@ -149,7 +149,7 @@ struct HTTP3ConnectionQuiescingStateMachineTests {
         expectH3ErrorEqual(
             error: action4.throwError,
             expectedCode: .invalidGoawayStreamID,
-            expectedH3ErrorCode: .H3_ID_ERROR
+            expectedH3ErrorCode: .idError
         )
     }
 
@@ -172,7 +172,7 @@ struct HTTP3ConnectionQuiescingStateMachineTests {
         expectH3ErrorEqual(
             error: action3.throwError,
             expectedCode: .invalidGoawayStreamID,
-            expectedH3ErrorCode: .H3_ID_ERROR
+            expectedH3ErrorCode: .idError
         )
     }
 

--- a/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
@@ -75,7 +75,7 @@ struct HTTP3ConnectionStateMachineTests {
             Issue.record("Unexpected action \(action2)")
             return
         }
-        error.expect(code: .streamCreationError, h3ErrorCode: .H3_STREAM_CREATION_ERROR)
+        error.expect(code: .streamCreationError, h3ErrorCode: .streamCreationError)
     }
 
     @Test
@@ -97,7 +97,7 @@ struct HTTP3ConnectionStateMachineTests {
             Issue.record("Unexpected action \(action3)")
             return
         }
-        error.expect(code: .invalidStream, h3ErrorCode: .H3_STREAM_CREATION_ERROR)
+        error.expect(code: .invalidStream, h3ErrorCode: .streamCreationError)
     }
 
     @Test
@@ -110,7 +110,7 @@ struct HTTP3ConnectionStateMachineTests {
             Issue.record("Unexpected action \(action)")
             return
         }
-        error.expect(code: .streamCreationError, h3ErrorCode: .H3_STREAM_CREATION_ERROR)
+        error.expect(code: .streamCreationError, h3ErrorCode: .streamCreationError)
     }
 
     @Test
@@ -123,7 +123,7 @@ struct HTTP3ConnectionStateMachineTests {
             Issue.record("Unexpected action \(action)")
             return
         }
-        error.expect(code: .streamCreationError, h3ErrorCode: .H3_ID_ERROR)
+        error.expect(code: .streamCreationError, h3ErrorCode: .idError)
     }
 
     @Test
@@ -138,7 +138,7 @@ struct HTTP3ConnectionStateMachineTests {
             Issue.record("Unexpected action \(action)")
             return
         }
-        error.expect(code: .streamCreationError, h3ErrorCode: .H3_STREAM_CREATION_ERROR)
+        error.expect(code: .streamCreationError, h3ErrorCode: .streamCreationError)
     }
 
     @Test
@@ -169,7 +169,7 @@ struct HTTP3ConnectionStateMachineTests {
             Issue.record("Unexpected action \(action2)")
             return
         }
-        error.expect(code: .invalidStream, h3ErrorCode: .H3_STREAM_CREATION_ERROR)
+        error.expect(code: .invalidStream, h3ErrorCode: .streamCreationError)
     }
 
     @Test
@@ -187,7 +187,7 @@ struct HTTP3ConnectionStateMachineTests {
         expectH3ErrorEqual(
             error: error,
             expectedCode: .streamCreationError,
-            expectedH3ErrorCode: .H3_STREAM_CREATION_ERROR
+            expectedH3ErrorCode: .streamCreationError
         )
     }
 
@@ -219,7 +219,7 @@ struct HTTP3ConnectionStateMachineTests {
             Issue.record("Unexpected action \(action2)")
             return
         }
-        error.expect(code: .invalidStream, h3ErrorCode: .H3_STREAM_CREATION_ERROR)
+        error.expect(code: .invalidStream, h3ErrorCode: .streamCreationError)
     }
 
     @Test
@@ -237,7 +237,7 @@ struct HTTP3ConnectionStateMachineTests {
         expectH3ErrorEqual(
             error: error,
             expectedCode: .streamCreationError,
-            expectedH3ErrorCode: .H3_STREAM_CREATION_ERROR
+            expectedH3ErrorCode: .streamCreationError
         )
     }
 
@@ -264,7 +264,7 @@ struct HTTP3ConnectionStateMachineTests {
             return
         }
 
-        error.expect(code: .streamCreationError, h3ErrorCode: .H3_STREAM_CREATION_ERROR)
+        error.expect(code: .streamCreationError, h3ErrorCode: .streamCreationError)
     }
 
     @Test
@@ -279,7 +279,7 @@ struct HTTP3ConnectionStateMachineTests {
             Issue.record("Unexpected action \(action2)")
             return
         }
-        error.expect(code: .streamCreationError, h3ErrorCode: .H3_STREAM_CREATION_ERROR)
+        error.expect(code: .streamCreationError, h3ErrorCode: .streamCreationError)
     }
 
     @Test
@@ -298,7 +298,7 @@ struct HTTP3ConnectionStateMachineTests {
             Issue.record("Unexpected action \(action3)")
             return
         }
-        expectH3ErrorEqual(error: error, expectedCode: .rejected, expectedH3ErrorCode: .H3_REQUEST_REJECTED)
+        expectH3ErrorEqual(error: error, expectedCode: .rejected, expectedH3ErrorCode: .requestRejected)
     }
 
     @Test
@@ -317,7 +317,7 @@ struct HTTP3ConnectionStateMachineTests {
         expectH3ErrorEqual(
             error: error,
             expectedCode: .streamCreationError,
-            expectedH3ErrorCode: .H3_STREAM_CREATION_ERROR,
+            expectedH3ErrorCode: .streamCreationError,
             expectedMessage: "Rejecting inbound stream of unknown type 100"
         )
     }
@@ -344,7 +344,7 @@ struct HTTP3ConnectionStateMachineTests {
         expectH3ErrorEqual(
             error: error,
             expectedCode: .streamCreationError,
-            expectedH3ErrorCode: .H3_STREAM_CREATION_ERROR,
+            expectedH3ErrorCode: .streamCreationError,
             expectedMessage: "Rejecting inbound stream of unknown type 100"
         )
     }
@@ -433,7 +433,7 @@ struct HTTP3ConnectionStateMachineTests {
         expectH3ErrorEqual(
             error: error,
             expectedCode: .invalidGoawayStreamID,
-            expectedH3ErrorCode: .H3_ID_ERROR
+            expectedH3ErrorCode: .idError
         )
     }
 
@@ -567,7 +567,7 @@ struct HTTP3ConnectionStateMachineTests {
         let action = stateMachine.receivedControlFrame(.maxPushID(1))
         switch action {
         case .emitConnectionError(let error):
-            expectH3ErrorEqual(error: error, expectedCode: .unexpectedFrame, expectedH3ErrorCode: .H3_FRAME_UNEXPECTED)
+            expectH3ErrorEqual(error: error, expectedCode: .unexpectedFrame, expectedH3ErrorCode: .frameUnexpected)
         default:
             Issue.record("Unexpected action: \(String(describing: action))")
         }
@@ -763,7 +763,7 @@ struct HTTP3ConnectionStateMachineTests {
             code: .invalidFramePayload,
             message: "test",
             cause: nil,
-            errorCode: .H3_FRAME_ERROR,
+            errorCode: .frameError,
             location: .here()
         )
         let action = stateMachine.emitConnectionErrorFromStream(error: testError)
@@ -772,7 +772,7 @@ struct HTTP3ConnectionStateMachineTests {
             expectH3ErrorEqual(
                 error: emittedError,
                 expectedCode: .invalidFramePayload,
-                expectedH3ErrorCode: .H3_FRAME_ERROR,
+                expectedH3ErrorCode: .frameError,
                 expectedMessage: "test"
             )
         case .none:
@@ -856,7 +856,7 @@ struct HTTP3ConnectionStateMachineTests {
         expectH3ErrorEqual(
             error: connectionError,
             expectedCode: .criticalStreamClosed,
-            expectedH3ErrorCode: .H3_CLOSED_CRITICAL_STREAM,
+            expectedH3ErrorCode: .closedCriticalStream,
             expectedMessage: "The server-initiated control stream was closed"
         )
     }

--- a/Tests/HTTP3Tests/HTTP3FrameCodingTests.swift
+++ b/Tests/HTTP3Tests/HTTP3FrameCodingTests.swift
@@ -25,7 +25,7 @@ struct HTTP3FrameCodingTests {
         var buffer = ByteBuffer()
         buffer.writeEncodedInteger(2, strategy: .quic)  // type 2 was used in http/2, and forbidden in http/3
 
-        expectH3Error(code: .forbiddenFrameType, h3ErrorCode: .H3_FRAME_UNEXPECTED) {
+        expectH3Error(code: .forbiddenFrameType, h3ErrorCode: .frameUnexpected) {
             _ = try decoder.decode(buffer: &buffer)
         }
     }
@@ -241,7 +241,7 @@ struct HTTP3FrameCodingTests {
         var decoder = HTTP3FrameDecoder()
         expectH3Error(
             code: .invalidFramePayload,
-            h3ErrorCode: .H3_FRAME_ERROR,
+            h3ErrorCode: .frameError,
             message: "Frame length longer than payload"
         ) {
             _ = try decoder.decode(buffer: &buffer)
@@ -255,7 +255,7 @@ struct HTTP3FrameCodingTests {
         // But that one byte is insufficient to make a valid frame. It is malformed.
         var buffer = ByteBuffer(bytes: [7, 1, 64])
         var decoder = HTTP3FrameDecoder()
-        expectH3Error(code: .invalidFramePayload, h3ErrorCode: .H3_FRAME_ERROR, message: "Invalid frame payload") {
+        expectH3Error(code: .invalidFramePayload, h3ErrorCode: .frameError, message: "Invalid frame payload") {
             _ = try decoder.decode(buffer: &buffer)
         }
     }
@@ -556,7 +556,7 @@ struct HTTP3FrameCodingTests {
         var decoder = HTTP3FrameDecoder()
         expectH3Error(
             code: .invalidFramePayload,
-            h3ErrorCode: .H3_FRAME_ERROR,
+            h3ErrorCode: .frameError,
             message: "Frame length longer than payload"
         ) {
             _ = try decoder.decode(buffer: &buffer)
@@ -568,7 +568,7 @@ struct HTTP3FrameCodingTests {
         // Type 1 (headers) but not enough bytes to actually make a full header field section
         var buffer = ByteBuffer(bytes: [1, 1, 0])
         var decoder = HTTP3FrameDecoder()
-        expectH3Error(code: .invalidFramePayload, h3ErrorCode: .H3_FRAME_ERROR, message: "Invalid frame payload") {
+        expectH3Error(code: .invalidFramePayload, h3ErrorCode: .frameError, message: "Invalid frame payload") {
             _ = try decoder.decode(buffer: &buffer)
         }
     }
@@ -637,7 +637,7 @@ struct HTTP3FrameCodingTests {
         buffer.writeEncodedInteger(size, strategy: .quic)
 
         var decoder = HTTP3FrameDecoder()
-        expectH3Error(code: .invalidFramePayload, h3ErrorCode: .H3_EXCESSIVE_LOAD) {
+        expectH3Error(code: .invalidFramePayload, h3ErrorCode: .excessiveLoad) {
             _ = try decoder.decode(buffer: &buffer)
         }
     }

--- a/Tests/HTTP3Tests/HTTP3FrameDecoderStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3FrameDecoderStateMachineTests.swift
@@ -120,7 +120,7 @@ struct HTTP3FrameDecoderStateMachineTests {
                 expectH3ErrorEqual(
                     error: error,
                     expectedCode: .forbiddenFrameType,
-                    expectedH3ErrorCode: .H3_FRAME_UNEXPECTED
+                    expectedH3ErrorCode: .frameUnexpected
                 )
             case .returnFrame, .needMoreBytes, .previousError, .returnUnknownFrame:
                 Issue.record("Unexpected action")

--- a/Tests/HTTP3Tests/HTTP3FrameValidatorTests.swift
+++ b/Tests/HTTP3Tests/HTTP3FrameValidatorTests.swift
@@ -90,7 +90,7 @@ struct HTTP3FrameValidatorTests {
         expectH3ErrorEqual(
             error: action.connectionError,
             expectedCode: .unexpectedFrame,
-            expectedH3ErrorCode: .H3_FRAME_UNEXPECTED,
+            expectedH3ErrorCode: .frameUnexpected,
             expectedMessage: "Expected headers, got \(testFrame.type)"
         )
         // now, even sending valid headers will give no action due to previous error
@@ -146,7 +146,7 @@ struct HTTP3FrameValidatorTests {
         expectH3ErrorEqual(
             error: action2.connectionError,
             expectedCode: .unexpectedFrame,
-            expectedH3ErrorCode: .H3_FRAME_UNEXPECTED,
+            expectedH3ErrorCode: .frameUnexpected,
             expectedMessage: "Expected headers or data, got \(testFrame.type)"
         )
 
@@ -173,7 +173,7 @@ struct HTTP3FrameValidatorTests {
         expectH3ErrorEqual(
             error: action1.connectionError,
             expectedCode: .unexpectedFrame,
-            expectedH3ErrorCode: .H3_FRAME_UNEXPECTED,
+            expectedH3ErrorCode: .frameUnexpected,
             expectedMessage: "Expected no further frames after request trailers, got \(testFrame.type)"
         )
     }
@@ -188,7 +188,7 @@ struct HTTP3FrameValidatorTests {
         expectH3ErrorEqual(
             error: action3.connectionError,
             expectedCode: .unexpectedFrame,
-            expectedH3ErrorCode: .H3_FRAME_UNEXPECTED,
+            expectedH3ErrorCode: .frameUnexpected,
             expectedMessage: "Expected no further frames after request trailers, got headers"
         )
     }
@@ -200,7 +200,7 @@ struct HTTP3FrameValidatorTests {
         expectH3ErrorEqual(
             error: action.streamError,
             expectedCode: .malformedMessage,
-            expectedH3ErrorCode: .H3_MESSAGE_ERROR,
+            expectedH3ErrorCode: .messageError,
             expectedMessage: "A HTTP response was sent before a request"
         )
     }
@@ -252,7 +252,7 @@ struct HTTP3FrameValidatorTests {
         expectH3ErrorEqual(
             error: action3.connectionError,
             expectedCode: .unexpectedFrame,
-            expectedH3ErrorCode: .H3_FRAME_UNEXPECTED,
+            expectedH3ErrorCode: .frameUnexpected,
             expectedMessage: "Expected no further frames after response trailers, got \(testFrame.type)"
         )
     }
@@ -274,7 +274,7 @@ struct HTTP3FrameValidatorTests {
         expectH3ErrorEqual(
             error: action2.connectionError,
             expectedCode: .unexpectedFrame,
-            expectedH3ErrorCode: .H3_FRAME_UNEXPECTED,
+            expectedH3ErrorCode: .frameUnexpected,
             expectedMessage: "Expected headers or data, got \(testFrame.type)"
         )
 
@@ -298,7 +298,7 @@ struct HTTP3FrameValidatorTests {
         expectH3ErrorEqual(
             error: action.connectionError,
             expectedCode: .unexpectedFrame,
-            expectedH3ErrorCode: .H3_FRAME_UNEXPECTED,
+            expectedH3ErrorCode: .frameUnexpected,
             expectedMessage: "Expected headers, got \(testFrame.type)"
         )
         // now, even sending valid headers will give no action due to previous error
@@ -375,7 +375,7 @@ struct HTTP3FrameValidatorTests {
         expectH3ErrorEqual(
             error: action.connectionError,
             expectedCode: .firstControlFrameNotSettings,
-            expectedH3ErrorCode: .H3_MISSING_SETTINGS,
+            expectedH3ErrorCode: .missingSettings,
             expectedMessage: "Expected settings, got \(testFrame.type)"
         )
 
@@ -391,7 +391,7 @@ struct HTTP3FrameValidatorTests {
         expectH3ErrorEqual(
             error: action.connectionError,
             expectedCode: .firstControlFrameNotSettings,
-            expectedH3ErrorCode: .H3_MISSING_SETTINGS,
+            expectedH3ErrorCode: .missingSettings,
             expectedMessage: "Expected settings, got unknown"
         )
 
@@ -437,7 +437,7 @@ struct HTTP3FrameValidatorTests {
         expectH3ErrorEqual(
             error: action2.connectionError,
             expectedCode: .unexpectedFrame,
-            expectedH3ErrorCode: .H3_FRAME_UNEXPECTED,
+            expectedH3ErrorCode: .frameUnexpected,
             expectedMessage: "Expected cancelPush or goaway or maxPushID, got \(testFrame.type)"
         )
 
@@ -457,7 +457,7 @@ struct HTTP3FrameValidatorTests {
         expectH3ErrorEqual(
             error: action2.connectionError,
             expectedCode: .unexpectedFrame,
-            expectedH3ErrorCode: .H3_FRAME_UNEXPECTED,
+            expectedH3ErrorCode: .frameUnexpected,
             expectedMessage: "Received a second settings frame"
         )
     }
@@ -514,7 +514,7 @@ struct HTTP3FrameValidatorTests {
         expectH3ErrorEqual(
             error: action.connectionError,
             expectedCode: .unexpectedFrame,
-            expectedH3ErrorCode: .H3_FRAME_UNEXPECTED,
+            expectedH3ErrorCode: .frameUnexpected,
             expectedMessage: "Expected headers or data, got \(testFrame.type)"
         )
     }

--- a/Tests/HTTP3Tests/HTTP3SettingsTests.swift
+++ b/Tests/HTTP3Tests/HTTP3SettingsTests.swift
@@ -59,7 +59,7 @@ struct HTTP3SettingsTests {
 
     @Test
     func duplicateKnownSetting() {
-        expectH3Error(code: .invalidFramePayload, h3ErrorCode: .H3_SETTINGS_ERROR) {
+        expectH3Error(code: .invalidFramePayload, h3ErrorCode: .settingsError) {
             _ = try HTTP3Settings(parsing: [
                 .init(identifier: .qpackBlockedStreams, value: 30),
                 .init(identifier: .qpackBlockedStreams, value: 40),
@@ -69,7 +69,7 @@ struct HTTP3SettingsTests {
 
     @Test
     func duplicateUnknownSetting() {
-        expectH3Error(code: .invalidFramePayload, h3ErrorCode: .H3_SETTINGS_ERROR) {
+        expectH3Error(code: .invalidFramePayload, h3ErrorCode: .settingsError) {
             _ = try HTTP3Settings(parsing: [
                 .init(identifier: .init(extensionSetting: 100)!, value: 30),
                 .init(identifier: .init(extensionSetting: 100)!, value: 40),
@@ -114,7 +114,7 @@ struct HTTP3SettingsTests {
             var buffer = ByteBuffer(bytes: encodedSettingsBytes)
             expectH3Error(
                 code: .invalidFramePayload,
-                h3ErrorCode: .H3_SETTINGS_ERROR,
+                h3ErrorCode: .settingsError,
                 message: "Setting identifier is forbidden"
             ) {
                 _ = try buffer.readHTTP3Settings()

--- a/Tests/HTTP3Tests/HTTP3StreamStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3StreamStateMachineTests.swift
@@ -230,7 +230,7 @@ struct HTTP3StreamStateMachineTests {
             code: .qpackDecoderError,
             message: "test",
             cause: nil,
-            errorCode: .H3_INTERNAL_ERROR,
+            errorCode: .internalError,
             location: .here()
         )
         machine.gotHeaderDecodeError(testError, from: partialHeader)
@@ -241,7 +241,7 @@ struct HTTP3StreamStateMachineTests {
             expectH3ErrorEqual(
                 error: e,
                 expectedCode: .qpackDecoderError,
-                expectedH3ErrorCode: .H3_INTERNAL_ERROR,
+                expectedH3ErrorCode: .internalError,
                 expectedMessage: "test"
             )
         }
@@ -273,7 +273,7 @@ struct HTTP3StreamStateMachineTests {
             code: .qpackDecoderError,
             message: "test",
             cause: nil,
-            errorCode: .H3_INTERNAL_ERROR,
+            errorCode: .internalError,
             location: .here()
         )
         machine.gotHeaderDecodeError(testError, from: partialHeader)
@@ -287,7 +287,7 @@ struct HTTP3StreamStateMachineTests {
             expectH3ErrorEqual(
                 error: $0,
                 expectedCode: .qpackDecoderError,
-                expectedH3ErrorCode: .H3_INTERNAL_ERROR,
+                expectedH3ErrorCode: .internalError,
                 expectedMessage: "test"
             )
         }
@@ -306,7 +306,7 @@ struct HTTP3StreamStateMachineTests {
             Issue.record("Unexpected action \(action1)")
             return
         }
-        expectH3ErrorEqual(error: error, expectedCode: .forbiddenFrameType, expectedH3ErrorCode: .H3_FRAME_UNEXPECTED)
+        expectH3ErrorEqual(error: error, expectedCode: .forbiddenFrameType, expectedH3ErrorCode: .frameUnexpected)
 
         // All further reads and writes should fail
         machine.assertNoNext()
@@ -328,7 +328,7 @@ struct HTTP3StreamStateMachineTests {
             Issue.record("Unexpected action \(action1)")
             return
         }
-        expectH3ErrorEqual(error: error, expectedCode: .unexpectedFrame, expectedH3ErrorCode: .H3_FRAME_UNEXPECTED)
+        expectH3ErrorEqual(error: error, expectedCode: .unexpectedFrame, expectedH3ErrorCode: .frameUnexpected)
 
         // All further reads and writes should fail
         machine.assertNoNext()
@@ -465,7 +465,7 @@ struct HTTP3StreamStateMachineTests {
         case .wouldBeConnectionError(let error):
             expectH3Error(
                 code: .unexpectedFrame,
-                h3ErrorCode: .H3_FRAME_UNEXPECTED,
+                h3ErrorCode: .frameUnexpected,
                 message: "Expected headers, got data"
             ) {
                 throw error
@@ -591,7 +591,7 @@ struct HTTP3StreamStateMachineTests {
             Issue.record("Unexpected action \(action2)")
             return
         }
-        expectH3ErrorEqual(error: error, expectedCode: .leftoverBytes, expectedH3ErrorCode: .H3_FRAME_ERROR)
+        expectH3ErrorEqual(error: error, expectedCode: .leftoverBytes, expectedH3ErrorCode: .frameError)
     }
 
     // MARK: Stream closed
@@ -608,7 +608,7 @@ struct HTTP3StreamStateMachineTests {
     func testStreamClosedAfterError() {
         var machine = HTTP3StreamStateMachine(streamType: .request, incoming: true, preferHuffmanEncoding: false)
 
-        let action1 = machine.streamErrorCaught(errorCode: QUICApplicationErrorCode(.H3_MESSAGE_ERROR))
+        let action1 = machine.streamErrorCaught(errorCode: QUICApplicationErrorCode(.messageError))
         #expect(action1 != nil)
 
         let action2 = machine.closed()
@@ -701,7 +701,7 @@ struct HTTP3StreamStateMachineTests {
             Issue.record("Unexpected action \(action)")
             return
         }
-        expectH3ErrorEqual(error: error, expectedCode: .unexpectedFrame, expectedH3ErrorCode: .H3_ID_ERROR)
+        expectH3ErrorEqual(error: error, expectedCode: .unexpectedFrame, expectedH3ErrorCode: .idError)
     }
 
     @Test
@@ -764,7 +764,7 @@ extension HTTP3StreamStateMachine {
                 code: .qpackDecoderError,
                 message: "Failed to qpack decode",
                 cause: qpackError,
-                errorCode: .QPACK_DECOMPRESSION_FAILED,
+                errorCode: .qpackDecompressionFailed,
                 location: .here()
             )
             self.gotHeaderDecodeError(error, from: partialHeader)

--- a/Tests/HTTP3Tests/QPACKStateMachineTests.swift
+++ b/Tests/HTTP3Tests/QPACKStateMachineTests.swift
@@ -189,7 +189,7 @@ struct QPACKStateMachineTests {
         expectH3ErrorEqual(
             error: error,
             expectedCode: .qpackDecoderError,
-            expectedH3ErrorCode: .QPACK_DECOMPRESSION_FAILED
+            expectedH3ErrorCode: .qpackDecompressionFailed
         )
     }
 
@@ -216,7 +216,7 @@ struct QPACKStateMachineTests {
         }
         #expect(error.headers == testHeader)
         #expect(error.streamID == streamID)
-        expectH3ErrorEqual(error: error.error, expectedCode: .qpackDecoderError, expectedH3ErrorCode: .H3_MESSAGE_ERROR)
+        expectH3ErrorEqual(error: error.error, expectedCode: .qpackDecoderError, expectedH3ErrorCode: .messageError)
     }
 
     @Test
@@ -301,7 +301,7 @@ struct QPACKStateMachineTests {
         expectH3ErrorEqual(
             error: decodeError.error,
             expectedCode: .qpackDecoderError,
-            expectedH3ErrorCode: .H3_MESSAGE_ERROR
+            expectedH3ErrorCode: .messageError
         )
     }
 
@@ -330,7 +330,7 @@ struct QPACKStateMachineTests {
             error:
                 error,
             expectedCode: .qpackDecoderError,
-            expectedH3ErrorCode: .QPACK_DECOMPRESSION_FAILED,
+            expectedH3ErrorCode: .qpackDecompressionFailed,
             expectedMessage: "Invalid field section prefix"
         )
     }
@@ -374,7 +374,7 @@ struct QPACKStateMachineTests {
         expectH3ErrorEqual(
             error: error,
             expectedCode: .qpackDecoderError,
-            expectedH3ErrorCode: .QPACK_DECOMPRESSION_FAILED,
+            expectedH3ErrorCode: .qpackDecompressionFailed,
             expectedMessage: "Too many streams blocked on QPACK"
         )
     }
@@ -457,7 +457,7 @@ struct QPACKStateMachineTests {
         expectH3ErrorEqual(
             error: error,
             expectedCode: .qpackDecoderStreamError,
-            expectedH3ErrorCode: .QPACK_DECODER_STREAM_ERROR
+            expectedH3ErrorCode: .qpackDecoderStreamError
         )
     }
 
@@ -474,7 +474,7 @@ struct QPACKStateMachineTests {
         expectH3ErrorEqual(
             error: error,
             expectedCode: .qpackDecoderStreamError,
-            expectedH3ErrorCode: .QPACK_DECODER_STREAM_ERROR
+            expectedH3ErrorCode: .qpackDecoderStreamError
         )
     }
 
@@ -491,7 +491,7 @@ struct QPACKStateMachineTests {
         expectH3ErrorEqual(
             error: error,
             expectedCode: .qpackDecoderStreamError,
-            expectedH3ErrorCode: .QPACK_DECODER_STREAM_ERROR
+            expectedH3ErrorCode: .qpackDecoderStreamError
         )
     }
 
@@ -508,7 +508,7 @@ struct QPACKStateMachineTests {
         expectH3ErrorEqual(
             error: error,
             expectedCode: .qpackDecoderStreamError,
-            expectedH3ErrorCode: .QPACK_DECODER_STREAM_ERROR
+            expectedH3ErrorCode: .qpackDecoderStreamError
         )
     }
 
@@ -527,7 +527,7 @@ struct QPACKStateMachineTests {
         expectH3ErrorEqual(
             error: error,
             expectedCode: .qpackEncoderStreamError,
-            expectedH3ErrorCode: .QPACK_ENCODER_STREAM_ERROR
+            expectedH3ErrorCode: .qpackEncoderStreamError
         )
     }
 
@@ -550,7 +550,7 @@ struct QPACKStateMachineTests {
         expectH3ErrorEqual(
             error: error,
             expectedCode: .qpackEncoderStreamError,
-            expectedH3ErrorCode: .QPACK_ENCODER_STREAM_ERROR
+            expectedH3ErrorCode: .qpackEncoderStreamError
         )
     }
 

--- a/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
@@ -80,7 +80,7 @@ struct NIOHTTP3StreamHandlerTests {
             code: .qpackDecoderError,
             message: "test",
             cause: nil,
-            errorCode: .H3_INTERNAL_ERROR,
+            errorCode: .internalError,
             location: .here()
         )
         guard let headerToDecode else {
@@ -89,7 +89,7 @@ struct NIOHTTP3StreamHandlerTests {
         }
         handler.onQPACKDecodeError(testError, forHeaders: headerToDecode)
 
-        expectH3Error(code: .qpackDecoderError, h3ErrorCode: .H3_INTERNAL_ERROR, message: "test") {
+        expectH3Error(code: .qpackDecoderError, h3ErrorCode: .internalError, message: "test") {
             _ = try recorderPromise.futureResult.wait()
         }
     }
@@ -234,10 +234,10 @@ struct NIOHTTP3StreamHandlerTests {
         let channel = EmbeddedChannel(handlers: [handler, errorRecorder], loop: eventLoop)
 
         // write out response (invalid because we didn't get a request)
-        expectH3Error(code: .malformedMessage, h3ErrorCode: .H3_MESSAGE_ERROR) {
+        expectH3Error(code: .malformedMessage, h3ErrorCode: .messageError) {
             try channel.writeOutbound(HTTP3Frame.headers([]))
         }
-        expectH3Error(code: .malformedMessage, h3ErrorCode: .H3_MESSAGE_ERROR) {
+        expectH3Error(code: .malformedMessage, h3ErrorCode: .messageError) {
             let thrownError = try errorPromise.futureResult.wait()
             throw thrownError
         }
@@ -263,10 +263,10 @@ struct NIOHTTP3StreamHandlerTests {
         let channel = EmbeddedChannel(handlers: [handler, errorRecorder], loop: eventLoop)
 
         // write out a settings frame. This is invalid, because this is a request stream
-        expectH3Error(code: .unexpectedFrame, h3ErrorCode: .H3_FRAME_UNEXPECTED) {
+        expectH3Error(code: .unexpectedFrame, h3ErrorCode: .frameUnexpected) {
             try channel.writeOutbound(HTTP3Frame.settings(.init()))
         }
-        expectH3Error(code: .unexpectedFrame, h3ErrorCode: .H3_FRAME_UNEXPECTED) {
+        expectH3Error(code: .unexpectedFrame, h3ErrorCode: .frameUnexpected) {
             let thrownError = try errorPromise.futureResult.wait()
             throw thrownError
         }
@@ -328,7 +328,7 @@ struct NIOHTTP3StreamHandlerTests {
         expectH3ErrorEqual(
             error: error,
             expectedCode: .invalidFramePayload,
-            expectedH3ErrorCode: .H3_FRAME_ERROR,
+            expectedH3ErrorCode: .frameError,
             expectedMessage: "Setting value is not a valid QUIC variable-length integer"
         )
     }

--- a/Tests/NIOHTTP3Tests/HTTP3UnidirectionalStreamTypeDecoderHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3UnidirectionalStreamTypeDecoderHandlerTests.swift
@@ -266,7 +266,7 @@ struct HTTP3UnidirectionalStreamTypeDecoderHandlerTests {
                 code: .streamCreationError,
                 message: "test",
                 cause: nil,
-                errorCode: .H3_STREAM_CREATION_ERROR,
+                errorCode: .streamCreationError,
                 location: .here()
             )
         )
@@ -276,7 +276,7 @@ struct HTTP3UnidirectionalStreamTypeDecoderHandlerTests {
         #expect(inboundEventsHandler.channelReadCalls == 0)
 
         // The channel sends an outbound QUICStopSendingEvent event and an inbound error caught
-        #expect(closeTriggerRecorder.errorCode == QUICApplicationErrorCode(.H3_STREAM_CREATION_ERROR))
+        #expect(closeTriggerRecorder.errorCode == QUICApplicationErrorCode(.streamCreationError))
         #expect(inboundEventsHandler.errorCaughtCalls == 1)
         #expect(outboundEventsHandler.triggerUserOutboundEventCalls == 1)
     }

--- a/Tests/NIOHTTP3Tests/HTTPMessageParsingTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTPMessageParsingTests.swift
@@ -87,7 +87,7 @@ struct HTTPMessageParsingTests {
             expectH3ErrorEqual(
                 error: error,
                 expectedCode: .malformedMessage,
-                expectedH3ErrorCode: .H3_MESSAGE_ERROR,
+                expectedH3ErrorCode: .messageError,
                 expectedMessage: "Invalid headers",
                 verifyCause: { #expect($0.map(String.init(describing:)) == "requestWithoutMethod") }
             )
@@ -113,7 +113,7 @@ struct HTTPMessageParsingTests {
             expectH3ErrorEqual(
                 error: $0,
                 expectedCode: .malformedMessage,
-                expectedH3ErrorCode: .H3_MESSAGE_ERROR,
+                expectedH3ErrorCode: .messageError,
                 expectedMessage: "Invalid trailers",
                 verifyCause: { #expect($0.map(String.init(describing:)) == "trailerFieldsWithPseudo") }
             )
@@ -207,7 +207,7 @@ struct HTTPMessageParsingTests {
             expectH3ErrorEqual(
                 error: error,
                 expectedCode: .malformedMessage,
-                expectedH3ErrorCode: .H3_MESSAGE_ERROR,
+                expectedH3ErrorCode: .messageError,
                 expectedMessage: "Invalid headers"
             )
         }
@@ -553,7 +553,7 @@ struct HTTPMessageParsingTests {
             expectH3ErrorEqual(
                 error: $0,
                 expectedCode: .malformedMessage,
-                expectedH3ErrorCode: .H3_MESSAGE_ERROR,
+                expectedH3ErrorCode: .messageError,
                 expectedMessage: "Invalid trailers",
                 verifyCause: { #expect($0.map(String.init(describing:)) == "trailerFieldsWithPseudo") }
             )
@@ -567,7 +567,7 @@ struct HTTPMessageParsingTests {
             expectH3ErrorEqual(
                 error: $0,
                 expectedCode: .malformedMessage,
-                expectedH3ErrorCode: .H3_MESSAGE_ERROR,
+                expectedH3ErrorCode: .messageError,
                 expectedMessage: "Invalid trailers",
                 verifyCause: { #expect($0.map(String.init(describing:)) == "trailerFieldsWithPseudo") }
             )
@@ -587,7 +587,7 @@ struct HTTPMessageParsingTests {
             expectH3ErrorEqual(
                 error: error,
                 expectedCode: .malformedMessage,
-                expectedH3ErrorCode: .H3_MESSAGE_ERROR,
+                expectedH3ErrorCode: .messageError,
                 expectedMessage: "Invalid headers",
                 verifyCause: { #expect($0.map(String.init(describing:)) == expectedError) },
                 sourceLocation: sourceLocation
@@ -606,7 +606,7 @@ struct HTTPMessageParsingTests {
             expectH3ErrorEqual(
                 error: error,
                 expectedCode: .malformedMessage,
-                expectedH3ErrorCode: .H3_MESSAGE_ERROR,
+                expectedH3ErrorCode: .messageError,
                 expectedMessage: "Invalid headers",
                 verifyCause: { #expect($0.map(String.init(describing:)) == expectedError) },
                 sourceLocation: sourceLocation


### PR DESCRIPTION
Allows consumers to read the error code carried by a received RESET_STREAM / STOP_SENDING, matching what NIOHTTP2's StreamClosed.errorCode already exposes.

### Motivation

Need to be able to inspect HTTP/3 stream error code

### Modifications

Visibility of error code field change from package to public. Error enum changed struct.

### Result

User can now inspect HTTP/3 stream error code