### PR TITLE
Bump to swift-nio-quic 0.2.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.19.3"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.22.0"),
         .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", .upToNextMinor(from: "0.1.0")),
-        .package(url: "https://github.com/apple/swift-nio-quic.git", branch: "main"),
+        .package(url: "https://github.com/apple/swift-nio-quic.git", .upToNextMinor(from: "0.2.1")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.19.3"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.22.0"),
         .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", .upToNextMinor(from: "0.1.0")),
-        .package(url: "https://github.com/apple/swift-nio-quic.git", .upToNextMinor(from: "0.1.0")),
+        .package(url: "https://github.com/apple/swift-nio-quic.git", .upToNextMinor(from: "0.2.0")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.19.3"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.22.0"),
         .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", .upToNextMinor(from: "0.1.0")),
-        .package(url: "https://github.com/apple/swift-nio-quic.git", .upToNextMinor(from: "0.2.0")),
+        .package(url: "https://github.com/apple/swift-nio-quic.git", branch: "main"),
     ],
     targets: [
         .target(

--- a/Sources/NIOHTTP3/HTTP3StreamHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3StreamHandler.swift
@@ -302,6 +302,20 @@ package final class HTTP3StreamHandler: ChannelDuplexHandler {
             case .none:
                 break
             }
+        case let error as QUICConnectionError:
+            self.logger.trace("Caught CONNECTION_CLOSE")
+            // RFC 9114 § 8: "Receipt of an unknown error code MUST be treated as equivalent to
+            // H3_NO_ERROR."
+            let h3Code = error.isApplication ? HTTP3ErrorCode(rawValue: error.code) ?? .H3_NO_ERROR : nil
+            context.fireErrorCaught(
+                HTTP3Error(
+                    code: .remoteConnectionError,
+                    message: error.reason,
+                    cause: error,
+                    errorCode: h3Code,
+                    location: .here()
+                )
+            )
         default:
             context.fireErrorCaught(error)
         }

--- a/Sources/NIOHTTP3/HTTP3StreamHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3StreamHandler.swift
@@ -304,9 +304,14 @@ package final class HTTP3StreamHandler: ChannelDuplexHandler {
             }
         case let error as QUICConnectionError:
             self.logger.trace("Caught CONNECTION_CLOSE")
-            // RFC 9114 § 8: "Receipt of an unknown error code MUST be treated as equivalent to
-            // H3_NO_ERROR."
-            let h3Code = error.isApplication ? HTTP3ErrorCode(rawValue: error.code) ?? .H3_NO_ERROR : nil
+            let h3Code: HTTP3ErrorCode?
+            if error.isApplication {
+                // RFC 9114 § 8: "Receipt of an unknown error code MUST be treated as equivalent to
+                // H3_NO_ERROR."
+                h3Code = HTTP3ErrorCode(rawValue: error.code) ?? .H3_NO_ERROR
+            } else {
+                h3Code = nil
+            }
             context.fireErrorCaught(
                 HTTP3Error(
                     code: .remoteConnectionError,

--- a/Sources/NIOHTTP3/HTTP3StreamHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3StreamHandler.swift
@@ -308,7 +308,7 @@ package final class HTTP3StreamHandler: ChannelDuplexHandler {
             if error.isApplication {
                 // RFC 9114 § 8: "Receipt of an unknown error code MUST be treated as equivalent to
                 // H3_NO_ERROR."
-                h3Code = HTTP3ErrorCode(rawValue: error.code) ?? .H3_NO_ERROR
+                h3Code = HTTP3ErrorCode(rawValue: error.code)
             } else {
                 h3Code = nil
             }

--- a/Sources/NIOHTTP3/HTTP3UnidirectionalStreamTypeDecoderHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3UnidirectionalStreamTypeDecoderHandler.swift
@@ -69,8 +69,10 @@ package final class HTTP3UnidirectionalStreamTypeDecoderHandler: ChannelInboundH
     /// You should not release the queue before the stream type is known.
     private func releaseQueue() {
         guard let context = self.context else {
-            fatalError("Tried to release queue but missing context")
+            // No context means the stream is closed: no-op.
+            return
         }
+
         // We must call unbufferElement in a loop until `done` is returned
         var didFireChannelRead = false
         loop: while true {

--- a/Tests/H3IntegrationTests/EndToEndTests.swift
+++ b/Tests/H3IntegrationTests/EndToEndTests.swift
@@ -1257,10 +1257,10 @@ struct EndToEndTests {
             try $0.channel.pipeline.syncOperations.addHandler(ShouldQuiesceRecorder(promise: gotQueisceOnStreamPromise))
         }.get()
 
-        clientConnectionChannel.pipeline.fireUserInboundEventTriggered(ChannelShouldQuiesceEvent())
+        clientConnectionChannel.parent!.pipeline.fireUserInboundEventTriggered(ChannelShouldQuiesceEvent())
         try await gotQueisceOnStreamPromise.futureResult.get()
 
-        try await clientConnectionChannel.close()
+        try await clientConnectionChannel.closeFuture.get()
         try await serverChannel.close()
     }
 

--- a/Tests/H3IntegrationTests/HTTP3+NIOQUIC.swift
+++ b/Tests/H3IntegrationTests/HTTP3+NIOQUIC.swift
@@ -22,7 +22,6 @@ import class NIOQUIC.AsyncVerifier
 import class NIOQUIC.Authenticator
 import struct NIOQUIC.QUICConfiguration
 import class NIOQUIC.QUICHandler
-import struct NIOQUIC.QUICMetrics
 import struct NIOQUIC.QUICStreamCreator
 
 typealias QUICHTTP3ConnectionHandler = HTTP3ConnectionHandler<QUICStreamCreator>
@@ -37,7 +36,6 @@ extension ChannelPipeline.SynchronousOperations {
     ///   - configuration: The ``HTTP3ServerConfiguration``.
     ///   - settings: The `HTTP3Settings` to use for all incoming connections.
     ///   - quicConfiguration: The `QUICConfiguration` to be used.
-    ///   - metrics: The metrics.
     ///   - logger: The logger.
     ///   - inboundRequestStreamInitializer: Closure to run for each incoming stream. Must be synchronous.
     /// - Returns: A ``HTTP3ServerConnectionMultiplexer``. Use this to iterate incoming connections.
@@ -47,7 +45,6 @@ extension ChannelPipeline.SynchronousOperations {
         configuration: HTTP3ServerConfiguration = .defaults,
         settings: HTTP3Settings = .init(),
         quicConfiguration: QUICConfiguration,
-        metrics: QUICMetrics? = nil,
         logger: Logger,
         inboundRequestStreamInitializer:
             @Sendable @escaping (HTTP3StreamInitializerParameters)
@@ -69,7 +66,6 @@ extension ChannelPipeline.SynchronousOperations {
             asyncVerifier: nil,
             authenticator: authenticator,
             logger: logger,
-            metrics: metrics,
             inboundConnectionInitializer: { connectionChannel, streamCreator in
                 connectionChannel.eventLoop.makeCompletedFuture {
                     let loopBoundHandler: NIOLoopBoundBox<HTTP3ConnectionHandler<QUICStreamCreator>?> = .init(
@@ -114,7 +110,6 @@ extension ChannelPipeline.SynchronousOperations {
     ///   - configuration: The ``HTTP3ClientConfiguration``.
     ///   - settings: The `HTTP3Settings` to use for all outgoing connections.
     ///   - quicConfiguration: The `QUICConfiguration` to be used.
-    ///   - metrics: The metrics.
     ///   - logger: The logger.
     ///   - internalInboundStreamInitializer: A closure which will be called for every incoming non-push stream.
     /// - Returns: A ``HTTP3ClientConnectionMultiplexer``. Use this to create outgoing connections.
@@ -124,7 +119,6 @@ extension ChannelPipeline.SynchronousOperations {
         configuration: HTTP3ClientConfiguration = .defaults,
         settings: HTTP3Settings = .init(),
         quicConfiguration: QUICConfiguration,
-        metrics: QUICMetrics? = nil,
         logger: Logger,
         internalInboundStreamInitializer: (
             @Sendable (any Channel, QUICStreamID, HTTP3StreamType.Unidirectional) -> EventLoopFuture<Void>
@@ -148,7 +142,6 @@ extension ChannelPipeline.SynchronousOperations {
             asyncVerifier: asyncVerifier,
             authenticator: nil,
             logger: logger,
-            metrics: metrics,
             inboundConnectionInitializer: { _, _ in
                 fatalError()
             },
@@ -211,7 +204,6 @@ extension ChannelPipeline.SynchronousOperations {
     ///   - configuration: The ``HTTP3ServerConfiguration``.
     ///   - settings: The `HTTP3Settings` to use for all incoming connections.
     ///   - quicConfiguration: The `QUICConfiguration` to be used.
-    ///   - metrics: The metrics.
     ///   - logger: The logger.
     ///   - inboundConnectionInitializer: Closure to run for each incoming connection.
     ///   - inboundRequestStreamInitializer: Closure to run for each incoming request stream.
@@ -222,7 +214,6 @@ extension ChannelPipeline.SynchronousOperations {
         configuration: HTTP3ServerConfiguration = .defaults,
         settings: HTTP3Settings = .init(),
         quicConfiguration: QUICConfiguration,
-        metrics: QUICMetrics? = nil,
         logger: Logger,
         inboundConnectionInitializer: @Sendable @escaping (any Channel) -> EventLoopFuture<Void>,
         inboundRequestStreamInitializer:
@@ -248,7 +239,6 @@ extension ChannelPipeline.SynchronousOperations {
             asyncVerifier: nil,
             authenticator: authenticator,
             logger: logger,
-            metrics: metrics,
             inboundConnectionInitializer: { connectionChannel, streamCreator in
                 connectionChannel.eventLoop.makeCompletedFuture {
                     let h3Handler = HTTP3ConnectionHandler.server(

--- a/Tests/H3IntegrationTests/QUICConnectionCreator.swift
+++ b/Tests/H3IntegrationTests/QUICConnectionCreator.swift
@@ -40,6 +40,8 @@ struct QUICConnectionCreator: HTTP3ConnectionCreator {
                 }
             },
             inboundStreamInitializer: self.inboundStreamInitializer
-        )
+        ).map { connectionChannel, _ in
+            connectionChannel
+        }
     }
 }


### PR DESCRIPTION
Motivation:

swift-nio-quic tagged a new release with some breaking changes

Modifications:

- Adopt new API
- Translate QUIC errors to HTTP3 errors in the stream channel
- Bail out when `self.context` is nil in release queue; this can be reached re-entrantly when a peer attempts to open an invalid stream. This was previously not reachable because of incorrect behavior in swift-nio-quic.

Result:

Builds and tests pass