### PR TITLE
Fuse the two passes in StaticQPACKEncoder.encode

### DIFF
--- a/Sources/QPACK/QPACKEncoder.swift
+++ b/Sources/QPACK/QPACKEncoder.swift
@@ -510,22 +510,25 @@ package struct StaticQPACKEncoder {
     package init() {}
     package func encode(headers: [HTTPField]) -> FieldSection {
         let base = 0  // base 0 is the cheapest way when no dynamic entries
-        let encodeResults = headers.map { header in
+        var lines = [FieldLine]()
+        lines.reserveCapacity(headers.count)
+        for header in headers {
             let requireLiteralRepresentation =
                 switch header.indexingStrategy {
                 case .prefer, .automatic, .avoid: false
                 case .disallow: true
                 default: false
                 }
-            return self.encodeSingleHeader(
-                header,
-                requireLiteralRepresentation: requireLiteralRepresentation
+            lines.append(
+                self.encodeSingleHeader(
+                    header,
+                    requireLiteralRepresentation: requireLiteralRepresentation
+                ).asFieldLine(base: base)
             )
         }
         let prefix = FieldSectionPrefix(requiredInsertCount: 0, base: base)
         let encodedPrefix = prefix.encode(maxCapacity: 0)
 
-        let lines = encodeResults.map { $0.asFieldLine(base: base) }
         return .init(prefix: encodedPrefix, lines: lines)
     }
 


### PR DESCRIPTION
### Motivation

`StaticQPACKEncoder.encode` built an intermediate `[HeaderRepresentation]` array with `headers.map`, then immediately mapped it again into `[FieldLine]`. The intermediate is written once, walked once and thrown away, so every statically encoded field section paid an extra heap allocation plus a retain/release for every `String` payload carried in `HeaderRepresentation`.

### Modification

Replaced the two `map` calls with a single loop that appends directly into a `[FieldLine]` reserved to `headers.count`. This is safe because the static encoder's `base` is a constant `0` and does not depend on the encoded lines, so no second pass is required.

### Result

`QPACKStaticEncode_BrowserGET` (p50):

| Metric            | before | after |
| ----------------- | -----: | ----: |
| Malloc (total)    |      2 |     1 |
| Instructions (K)  |     20 |    17 |
| Time (wall, ns)   |    784 |   672 |
