### PR TITLE
Remove redundant comment

### DIFF
--- a/Sources/NIOHTTP3/HTTP3StreamHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3StreamHandler.swift
@@ -304,20 +304,12 @@ package final class HTTP3StreamHandler: ChannelDuplexHandler {
             }
         case let error as QUICConnectionError:
             self.logger.trace("Caught CONNECTION_CLOSE")
-            let h3Code: HTTP3ErrorCode?
-            if error.isApplication {
-                // RFC 9114 § 8: "Receipt of an unknown error code MUST be treated as equivalent to
-                // H3_NO_ERROR."
-                h3Code = HTTP3ErrorCode(rawValue: error.code)
-            } else {
-                h3Code = nil
-            }
             context.fireErrorCaught(
                 HTTP3Error(
                     code: .remoteConnectionError,
                     message: error.reason,
                     cause: error,
-                    errorCode: h3Code,
+                    errorCode: error.isApplication ? HTTP3ErrorCode(rawValue: error.code) : nil,
                     location: .here()
                 )
             )


### PR DESCRIPTION
Motivation:

The last PR was auto-merged with a comment which was redundant after merging from main.

Modifications:

- Remove redundant comment
- Simplify code now that the comment no longer needs to be inlined

Result:

Simpler code