### PR TITLE
Add various types to support datagrams

### DIFF
--- a/Sources/HTTP3/HTTP3Error.swift
+++ b/Sources/HTTP3/HTTP3Error.swift
@@ -144,6 +144,8 @@ extension HTTP3Error {
             case none
             case invalidGoawayStreamID
             case criticalStreamClosed
+            case datagramsNotNegotiated
+            case connectionClosed
         }
 
         public var description: String {
@@ -253,6 +255,17 @@ extension HTTP3Error {
         /// A critical stream was closed.
         public static var criticalStreamClosed: Self {
             Self(.criticalStreamClosed)
+        }
+
+        /// Attempted to send a datagram but the remote peer hasn't advertised that it's willing
+        /// to receive datagrams.
+        public static var datagramsNotNegotiated: Self {
+            Self(.datagramsNotNegotiated)
+        }
+
+        /// The operation requires a connection which is no longer open.
+        public static var connectionClosed: Self {
+            Self(.connectionClosed)
         }
     }
 

--- a/Sources/HTTP3/HTTP3Error.swift
+++ b/Sources/HTTP3/HTTP3Error.swift
@@ -257,7 +257,7 @@ extension HTTP3Error {
         public static var criticalStreamClosed: Self {
             Self(.criticalStreamClosed)
         }
-      
+
         /// The peer terminated the inbound stream before delivering a complete request or response.
         public static var peerTerminatedInboundStream: Self {
             Self(.peerTerminatedInboundStream)

--- a/Sources/HTTP3/HTTP3ErrorCode.swift
+++ b/Sources/HTTP3/HTTP3ErrorCode.swift
@@ -72,6 +72,11 @@ public struct HTTP3ErrorCode: Hashable, Sendable {
     public static let qpackEncoderStreamError = HTTP3ErrorCode(rawValue: 0x0201)
     /// The encoder failed to interpret a decoder instruction received on the decoder stream.
     public static let qpackDecoderStreamError = HTTP3ErrorCode(rawValue: 0x0202)
+
+    // MARK: Datagrams and Capsule (RFC 9297)
+
+    /// Datagram or Capsule protocol parse error.
+    public static let datagramError = HTTP3ErrorCode(rawValue: 0x33)
 }
 
 extension HTTP3ErrorCode: CustomDebugStringConvertible {
@@ -98,6 +103,7 @@ extension HTTP3ErrorCode: CustomDebugStringConvertible {
         case .qpackDecompressionFailed: name = "QPACK Decompression Failed"
         case .qpackEncoderStreamError: name = "QPACK Encoder Stream Error"
         case .qpackDecoderStreamError: name = "QPACK Decoder Stream Error"
+        case .datagramError: name = "Datagram Error"
         default: name = "Unknown Error"
         }
         return "HTTP3ErrorCode<0x\(String(self.rawValue, radix: 16)) \(name)>"

--- a/Sources/HTTP3/HTTP3Setting.swift
+++ b/Sources/HTTP3/HTTP3Setting.swift
@@ -85,5 +85,13 @@ extension HTTP3Setting {
         ///
         /// See [RFC 9204 § 5](https://datatracker.ietf.org/doc/html/rfc9204#name-configuration)
         public static let qpackBlockedStreams = Self(extensionSetting: 0x07)!
+
+        /// Corresponds to `SETTINGS_H3_DATAGRAM`.
+        ///
+        /// The value must be either zero or one; the default is zero. A value of one indicates
+        /// that the sender is willing to receive HTTP datagrams.
+        ///
+        /// See [RFC 9297 § 2.1.1](https://www.rfc-editor.org/rfc/rfc9297.html#section-2.1.1)
+        public static let h3Datagram = Self(extensionSetting: 0x33)!
     }
 }

--- a/Sources/HTTP3/HTTP3Settings.swift
+++ b/Sources/HTTP3/HTTP3Settings.swift
@@ -63,12 +63,13 @@ public struct HTTP3Settings: Hashable, Sendable {
     ///   - qpackBlockedStreams: The maximum number of streams which may be blocked on QPACK at any one time. Corresponds to `SETTINGS_QPACK_BLOCKED_STREAMS`.
     ///   - maximumFieldSectionSize: The maximum size of a field section. Corresponds to `SETTINGS_MAX_FIELD_SECTION_SIZE`.
     ///   - h3Datagram: Whether this endpoint is willing to receive HTTP datagrams. Corresponds to `SETTINGS_H3_DATAGRAM`.
+    ///     Defaults to 'true' per RFC 9297 § 2.1.1.
     /// - Precondition: The values must be QUIC-encodable integers, that means they must be between 1 and 2^62-1.
     public init(
         qpackMaximumTableCapacity: UInt64? = nil,
         qpackBlockedStreams: UInt64? = nil,
         maximumFieldSectionSize: UInt64? = nil,
-        h3Datagram: Bool = false
+        h3Datagram: Bool = true
     ) {
         self.init()
 

--- a/Sources/HTTP3/HTTP3Settings.swift
+++ b/Sources/HTTP3/HTTP3Settings.swift
@@ -20,6 +20,7 @@ public struct HTTP3Settings: Hashable, Sendable {
     private var _qpackMaximumTableCapacity: UInt64?
     private var _qpackBlockedStreams: UInt64?
     private var _maximumFieldSectionSize: UInt64?
+    private var _h3Datagram: Bool?
     private var _other: [HTTP3Setting] = []
 
     /// The maximum capacity of the qpack dynamic table. Corresponds to `SETTINGS_QPACK_MAX_TABLE_CAPACITY`.
@@ -40,6 +41,12 @@ public struct HTTP3Settings: Hashable, Sendable {
         self._maximumFieldSectionSize
     }
 
+    /// Whether the sender is willing to receive HTTP datagrams. Corresponds to `SETTINGS_H3_DATAGRAM`.
+    /// Returns false if this setting was not explicitly set.
+    public var h3Datagram: Bool {
+        self._h3Datagram ?? false
+    }
+
     /// All settings which are not understood by this implementation.
     /// There are guaranteed to be no duplicated identifiers in this array.
     public var other: [HTTP3Setting] {
@@ -55,11 +62,13 @@ public struct HTTP3Settings: Hashable, Sendable {
     ///   - qpackMaximumTableCapacity: The maximum capacity of the qpack dynamic table. Corresponds to `SETTINGS_QPACK_MAX_TABLE_CAPACITY`.
     ///   - qpackBlockedStreams: The maximum number of streams which may be blocked on QPACK at any one time. Corresponds to `SETTINGS_QPACK_BLOCKED_STREAMS`.
     ///   - maximumFieldSectionSize: The maximum size of a field section. Corresponds to `SETTINGS_MAX_FIELD_SECTION_SIZE`.
+    ///   - h3Datagram: Whether this endpoint is willing to receive HTTP datagrams. Corresponds to `SETTINGS_H3_DATAGRAM`.
     /// - Precondition: The values must be QUIC-encodable integers, that means they must be between 1 and 2^62-1.
     public init(
         qpackMaximumTableCapacity: UInt64? = nil,
         qpackBlockedStreams: UInt64? = nil,
-        maximumFieldSectionSize: UInt64? = nil
+        maximumFieldSectionSize: UInt64? = nil,
+        h3Datagram: Bool = false
     ) {
         self.init()
 
@@ -79,6 +88,7 @@ public struct HTTP3Settings: Hashable, Sendable {
         self._qpackMaximumTableCapacity = qpackMaximumTableCapacity
         self._qpackBlockedStreams = qpackBlockedStreams
         self._maximumFieldSectionSize = maximumFieldSectionSize
+        self._h3Datagram = h3Datagram
     }
 
     /// Parse the provided settings into a ``HTTP3Settings``.
@@ -111,6 +121,23 @@ public struct HTTP3Settings: Hashable, Sendable {
             )
         }
 
+        // RFC 9297 § 2.1.1: An endpoint that receives the SETTINGS_H3_DATAGRAM parameter with a value
+        // that is neither 0 nor 1 MUST terminate the connection with error H3_SETTINGS_ERROR.
+        @inline(never)
+        func invalidSettingValueError(
+            identifier: HTTP3Setting.Identifier,
+            value: UInt64,
+            location: HTTP3Error.SourceLocation
+        ) -> HTTP3Error {
+            HTTP3Error(
+                code: .invalidFramePayload,
+                message: "Settings contains invalid value \(value) for identifier \(identifier)",
+                cause: nil,
+                errorCode: .settingsError,
+                location: location
+            )
+        }
+
         switch setting.identifier {
         case .qpackMaximumTableCapacity:
             if self._qpackMaximumTableCapacity != nil {
@@ -127,6 +154,22 @@ public struct HTTP3Settings: Hashable, Sendable {
                 throw duplicateSettingError(identifier: setting.identifier, location: .here())
             }
             self._maximumFieldSectionSize = setting.value
+        case .h3Datagram:
+            if self._h3Datagram != nil {
+                throw duplicateSettingError(identifier: setting.identifier, location: .here())
+            }
+            switch setting.value {
+            case 0:
+                self._h3Datagram = false
+            case 1:
+                self._h3Datagram = true
+            default:
+                throw invalidSettingValueError(
+                    identifier: setting.identifier,
+                    value: setting.value,
+                    location: .here()
+                )
+            }
         default:
             // A linear search is likely cheaper than using a Set or other technique to detect duplicates
             // That is because we do not expect many unknown settings
@@ -145,6 +188,7 @@ public struct HTTP3Settings: Hashable, Sendable {
         hasher.combine(self.qpackMaximumTableCapacity)
         hasher.combine(self.qpackBlockedStreams)
         hasher.combine(self.maximumFieldSectionSize)
+        hasher.combine(self.h3Datagram)
         hasher.combine(self.other)
     }
 
@@ -155,7 +199,8 @@ public struct HTTP3Settings: Hashable, Sendable {
         // same as one with it not set
         lhs.qpackMaximumTableCapacity == rhs.qpackMaximumTableCapacity
             && lhs.qpackBlockedStreams == rhs.qpackBlockedStreams
-            && lhs.maximumFieldSectionSize == rhs.maximumFieldSectionSize && lhs.other == rhs.other
+            && lhs.maximumFieldSectionSize == rhs.maximumFieldSectionSize && lhs.h3Datagram == rhs.h3Datagram
+            && lhs.other == rhs.other
     }
 }
 
@@ -223,6 +268,9 @@ extension ByteBuffer {
             bytesWritten += self.writeHTTP3Setting(
                 .init(identifier: .maximumFieldSectionSize, value: maximumFieldSectionSize)
             )
+        }
+        if settings.h3Datagram {
+            bytesWritten += self.writeHTTP3Setting(.init(identifier: .h3Datagram, value: 1))
         }
         for setting in settings.other {
             bytesWritten += self.writeHTTP3Setting(setting)

--- a/Sources/NIOHTTP3/HTTP3Datagram.swift
+++ b/Sources/NIOHTTP3/HTTP3Datagram.swift
@@ -27,15 +27,15 @@ public struct HTTP3Datagram: @unchecked Sendable {
     // using a backing class we still pay that cost but only once, on construction.
     private final class Storage {
         var streamID: QUICStreamID
-        var data: ByteBuffer
+        var payload: ByteBuffer
 
         init(streamID: QUICStreamID, data: ByteBuffer) {
             self.streamID = streamID
-            self.data = data
+            self.payload = data
         }
 
         func copy() -> Storage {
-            Storage(streamID: self.streamID, data: self.data)
+            Storage(streamID: self.streamID, data: self.payload)
         }
     }
 
@@ -60,11 +60,11 @@ public struct HTTP3Datagram: @unchecked Sendable {
     }
 
     /// The payload of the datagram.
-    public var data: ByteBuffer {
-        get { self.storage.data }
+    public var payload: ByteBuffer {
+        get { self.storage.payload }
         set {
             self.copyIfNotUniquelyReferenced()
-            self.storage.data = newValue
+            self.storage.payload = newValue
         }
     }
 
@@ -133,7 +133,7 @@ extension ByteBuffer {
     mutating func writeDatagram(_ datagram: HTTP3Datagram) -> Int {
         // Assume largest sized integer for stream ID. Capacity is rounded up to the nearest power
         // of two so using the largest size won't make any difference in the vast majority of cases.
-        self.reserveCapacity(minimumWritableBytes: 8 + datagram.data.readableBytes)
+        self.reserveCapacity(minimumWritableBytes: 8 + datagram.payload.readableBytes)
 
         var bytesWritten = 0
         let quarterStreamID = datagram.streamID.rawValue / 4
@@ -146,7 +146,7 @@ extension ByteBuffer {
         )
 
         bytesWritten += self.writeEncodedInteger(quarterStreamID, strategy: .quic)
-        bytesWritten += self.writeImmutableBuffer(datagram.data)
+        bytesWritten += self.writeImmutableBuffer(datagram.payload)
         return bytesWritten
     }
 }

--- a/Sources/NIOHTTP3/HTTP3Datagram.swift
+++ b/Sources/NIOHTTP3/HTTP3Datagram.swift
@@ -1,0 +1,152 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+internal import HTTP3
+public import NIOCore
+public import NIOQUICHelpers
+
+public struct HTTP3Datagram: @unchecked Sendable {
+    // Unchecked because this struct is backed by a class. Safe because it uses uniqueness checks.
+
+    // A seemingly unnecessary class in a struct? Outrageous! Unfortunately, for efficient message
+    // passing down NIO's channel pipeline, message types must be <= 24 bytes in size so that they
+    // can fit into the inline storage of an existential container. Unfortunately as a "normal"
+    // struct HTTP3Datagram would be 31 bytes (23 for the buffer, 8 for the stream ID) so it would
+    // miss the optimisation and require boxing every time the datagram is wrapped in a NIOAny. By
+    // using a backing class we still pay that cost but only once, on construction.
+    private final class Storage {
+        var streamID: QUICStreamID
+        var data: ByteBuffer
+
+        init(streamID: QUICStreamID, data: ByteBuffer) {
+            self.streamID = streamID
+            self.data = data
+        }
+
+        func copy() -> Storage {
+            Storage(streamID: self.streamID, data: self.data)
+        }
+    }
+
+    /// The underlying heap storage for the struct.
+    private var storage: Storage
+
+    private mutating func copyIfNotUniquelyReferenced() {
+        if !isKnownUniquelyReferenced(&self.storage) {
+            self.storage = self.storage.copy()
+        }
+    }
+
+    /// The ID of the stream that this datagram is associated with.
+    ///
+    /// - Note: this isn't the _quarter stream ID_ as outlined in RFC 9297.
+    public var streamID: QUICStreamID {
+        get { self.storage.streamID }
+        set {
+            self.copyIfNotUniquelyReferenced()
+            self.storage.streamID = newValue
+        }
+    }
+
+    /// The payload of the datagram.
+    public var data: ByteBuffer {
+        get { self.storage.data }
+        set {
+            self.copyIfNotUniquelyReferenced()
+            self.storage.data = newValue
+        }
+    }
+
+    /// Creates a new datagram.
+    ///
+    /// - Parameters:
+    ///   - streamID: The ID of the stream this datagram is associated with.
+    ///   - data: The payload of the datagram.
+    public init(streamID: QUICStreamID, data: ByteBuffer) {
+        self.storage = Storage(streamID: streamID, data: data)
+    }
+}
+
+extension HTTP3Datagram {
+    // RFC 9297 § 2.1: "the largest legal value of the Quarter Stream ID field is 2^60-1"
+    static var largestValidQuarterStreamID: UInt64 {
+        (1 << 60) - 1
+    }
+}
+
+extension ByteBuffer {
+    mutating func parseDatagram() throws(HTTP3Error) -> HTTP3Datagram {
+        guard let quarterStreamID = self.readEncodedInteger(as: UInt64.self, strategy: .quic) else {
+            // From RFC 9297 § 2.1:
+            //
+            // > Receipt of a QUIC DATAGRAM frame whose payload is too short to allow parsing the
+            // > Quarter Stream ID field MUST be treated as an HTTP/3 connection error of
+            // > type H3_DATAGRAM_ERROR (0x33).
+            throw HTTP3Error(
+                code: .remoteConnectionError,
+                message: "Datagram too short to parse",
+                cause: nil,
+                errorCode: .datagramError,
+                location: .here()
+            )
+        }
+
+        guard quarterStreamID <= HTTP3Datagram.largestValidQuarterStreamID else {
+            // From RFC 9297 § 2.1:
+            //
+            // > Receipt of an HTTP/3 Datagram that includes a larger value [than the largest valid
+            // > quarter stream ID] MUST be treated as an > HTTP/3 connection error of
+            // > type H3_DATAGRAM_ERROR (0x33).
+            throw HTTP3Error(
+                code: .remoteConnectionError,
+                message: "Invalid quarter stream ID",
+                cause: nil,
+                errorCode: .datagramError,
+                location: .here()
+            )
+        }
+
+        // This operation can't overflow: the quarter stream ID is small enough (verified above)
+        // to be multiplied by four without overflowing.
+        let rawStreamID = quarterStreamID &* 4
+
+        // TODO: QUICStreamID(rawValue:) preconditions on the size of the raw valaue; it'd be nice
+        // to have a variant which avoids this given we've validated it here.
+        let streamID = QUICStreamID(rawValue: rawStreamID)
+
+        let data = self.readSlice(length: self.readableBytes)!
+        return HTTP3Datagram(streamID: streamID, data: data)
+    }
+
+    @discardableResult
+    mutating func writeDatagram(_ datagram: HTTP3Datagram) -> Int {
+        // Assume largest sized integer for stream ID. Capacity is rounded up to the nearest power
+        // of two so using the largest size won't make any difference in the vast majority of cases.
+        self.reserveCapacity(minimumWritableBytes: 8 + datagram.data.readableBytes)
+
+        var bytesWritten = 0
+        let quarterStreamID = datagram.streamID.rawValue / 4
+
+        // The HTTP3 connection handler should reject invalid datagrams before encoding them, add
+        // a defensive check.
+        assert(
+            quarterStreamID * 4 == datagram.streamID.rawValue,
+            "Stream ID must be for a client initiated bidirectional stream"
+        )
+
+        bytesWritten += self.writeEncodedInteger(quarterStreamID, strategy: .quic)
+        bytesWritten += self.writeImmutableBuffer(datagram.data)
+        return bytesWritten
+    }
+}

--- a/Tests/HTTP3Tests/HTTP3FrameCodingTests.swift
+++ b/Tests/HTTP3Tests/HTTP3FrameCodingTests.swift
@@ -166,7 +166,8 @@ struct HTTP3FrameCodingTests {
     func testEncodeSettingsFrame() {
         let settings = HTTP3Settings(
             qpackMaximumTableCapacity: 151_288_809_941_952_652,
-            qpackBlockedStreams: 1
+            qpackBlockedStreams: 1,
+            h3Datagram: false
         )
         var buffer = ByteBuffer()
 

--- a/Tests/HTTP3Tests/HTTP3FrameDecoderStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3FrameDecoderStateMachineTests.swift
@@ -51,7 +51,7 @@ struct HTTP3FrameDecoderStateMachineTests {
 
     @Test
     func testPartialFrame() {
-        let testFrame = HTTP3PartialFrame.settings(.init(qpackMaximumTableCapacity: 1024))
+        let testFrame = HTTP3PartialFrame.settings(.init(qpackMaximumTableCapacity: 1024, h3Datagram: false))
         var encodedFrame = ByteBuffer()
         encodedFrame.writeHTTP3PartialFrame(testFrame, preferHuffmanEncoding: false)
         #expect(encodedFrame.readableBytes == 6)

--- a/Tests/HTTP3Tests/HTTP3SettingsTests.swift
+++ b/Tests/HTTP3Tests/HTTP3SettingsTests.swift
@@ -22,11 +22,13 @@ struct HTTP3SettingsTests {
         let settings = HTTP3Settings(
             qpackMaximumTableCapacity: 100,
             qpackBlockedStreams: 200,
-            maximumFieldSectionSize: 300
+            maximumFieldSectionSize: 300,
+            h3Datagram: true
         )
         #expect(settings.qpackMaximumTableCapacity == 100)
         #expect(settings.qpackBlockedStreams == 200)
         #expect(settings.maximumFieldSectionSize == 300)
+        #expect(settings.h3Datagram)
         #expect(settings.other == [])
     }
 
@@ -38,10 +40,12 @@ struct HTTP3SettingsTests {
             HTTP3Setting(identifier: .init(extensionSetting: 300)!, value: 30),
             HTTP3Setting(identifier: .qpackBlockedStreams, value: 40),
             HTTP3Setting(identifier: .qpackMaximumTableCapacity, value: 50),
+            HTTP3Setting(identifier: .h3Datagram, value: 0),
         ])
         #expect(settings.qpackBlockedStreams == 40)
         #expect(settings.qpackMaximumTableCapacity == 50)
         #expect(settings.maximumFieldSectionSize == nil)
+        #expect(settings.h3Datagram == false)
         #expect(
             settings.other
                 == [
@@ -57,12 +61,20 @@ struct HTTP3SettingsTests {
         #expect(HTTP3Setting.Identifier(extensionSetting: identifier) == nil)
     }
 
-    @Test
-    func duplicateKnownSetting() {
+    @Test(
+        arguments: [
+            HTTP3Setting.Identifier.qpackBlockedStreams,
+            .qpackMaximumTableCapacity,
+            .maximumFieldSectionSize,
+            .h3Datagram,
+        ]
+    )
+    func duplicateKnownSetting(identifier: HTTP3Setting.Identifier) {
         expectH3Error(code: .invalidFramePayload, h3ErrorCode: .settingsError) {
+            // A value of one is valid for every known setting.
             _ = try HTTP3Settings(parsing: [
-                .init(identifier: .qpackBlockedStreams, value: 30),
-                .init(identifier: .qpackBlockedStreams, value: 40),
+                .init(identifier: identifier, value: 1),
+                .init(identifier: identifier, value: 1),
             ])
         }
     }
@@ -84,17 +96,19 @@ struct HTTP3SettingsTests {
             HTTP3Setting(identifier: .qpackBlockedStreams, value: 1),
             HTTP3Setting(identifier: .qpackMaximumTableCapacity, value: 2),
             HTTP3Setting(identifier: .maximumFieldSectionSize, value: 3),
+            HTTP3Setting(identifier: .h3Datagram, value: 1),
             HTTP3Setting(identifier: .init(extensionSetting: 20)!, value: 4),
             HTTP3Setting(identifier: .init(extensionSetting: 30)!, value: 5),
         ])
         let writtenBytes = buffer.writeHTTP3Settings(settings)
-        #expect(writtenBytes == 10)
+        #expect(writtenBytes == 12)
         #expect(
             [UInt8](buffer: buffer)
                 == [
                     7, 1,
                     1, 2,
                     6, 3,
+                    0x33, 1,
                     20, 4,
                     30, 5,
                 ]
@@ -124,7 +138,7 @@ struct HTTP3SettingsTests {
 
     @Test
     func settingsCodingIgnoresDefault() {
-        let settings = HTTP3Settings(qpackBlockedStreams: 0)
+        let settings = HTTP3Settings(qpackBlockedStreams: 0, h3Datagram: false)
         var buffer = ByteBuffer()
         let writtenBytes = buffer.writeHTTP3Settings(settings)
         // The value is the default, so we don't need to write it out
@@ -138,6 +152,18 @@ struct HTTP3SettingsTests {
         #expect(empty.qpackMaximumTableCapacity == 0)
         #expect(empty.qpackBlockedStreams == 0)
         #expect(empty.maximumFieldSectionSize == nil)
+        #expect(empty.h3Datagram == false)
         #expect(empty.other == [])
+    }
+
+    @Test(arguments: [UInt64(2), 3, 42])
+    func h3DatagramSettingWithInvalidValue(value: UInt64) {
+        expectH3Error(
+            code: .invalidFramePayload,
+            h3ErrorCode: .settingsError,
+            message: "Settings contains invalid value \(value) for identifier \(HTTP3Setting.Identifier.h3Datagram)"
+        ) {
+            _ = try HTTP3Settings(parsing: [HTTP3Setting(identifier: .h3Datagram, value: value)])
+        }
     }
 }

--- a/Tests/HTTP3Tests/HTTP3SettingsTests.swift
+++ b/Tests/HTTP3Tests/HTTP3SettingsTests.swift
@@ -156,6 +156,12 @@ struct HTTP3SettingsTests {
         #expect(empty.other == [])
     }
 
+    @Test
+    func h3DatagramIsEnabledByDefault() {
+        let settings = HTTP3Settings(qpackMaximumTableCapacity: 1024)
+        #expect(settings.h3Datagram)
+    }
+
     @Test(arguments: [UInt64(2), 3, 42])
     func h3DatagramSettingWithInvalidValue(value: UInt64) {
         expectH3Error(

--- a/Tests/HTTP3Tests/HTTP3StreamStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3StreamStateMachineTests.swift
@@ -27,7 +27,8 @@ struct HTTP3StreamStateMachineTests {
 
     private let testSettings = HTTP3Settings(
         qpackMaximumTableCapacity: 151_288_809_941_952_652,
-        qpackBlockedStreams: 1
+        qpackBlockedStreams: 1,
+        h3Datagram: false
     )
 
     /// These bytes encode `testSettings`.

--- a/Tests/NIOHTTP3Tests/HTTP3DatagramTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3DatagramTests.swift
@@ -1,0 +1,133 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HTTP3
+import NIOCore
+import NIOQUICHelpers
+import Testing
+
+@testable import NIOHTTP3
+
+struct HTTP3DatagramTests {
+    @Test
+    func typeFitsInExistentialInlineStorage() {
+        #expect(MemoryLayout<HTTP3Datagram>.size <= 24)
+    }
+
+    @Test
+    func testCoWBehavior() {
+        let datagram1 = HTTP3Datagram(streamID: 1, data: ByteBuffer(string: "Hello"))
+        var datagram2 = datagram1
+        datagram2.streamID = 2
+
+        #expect(datagram1.streamID == 1)
+        #expect(datagram2.streamID == 2)
+        #expect(datagram1.data == datagram2.data)
+
+        var datagram3 = datagram1
+        datagram3.data.writeString(", Datagrams!")
+        #expect(datagram3.streamID == 1)
+        #expect(datagram3.data == ByteBuffer(string: "Hello, Datagrams!"))
+        #expect(datagram1.data == ByteBuffer(string: "Hello"))
+    }
+
+    @Test
+    func datagramFromEmptyBuffer() throws {
+        var buffer = ByteBuffer()
+
+        do {
+            _ = try buffer.parseDatagram()
+            Issue.record("Expected error")
+        } catch {
+            #expect(error.code == .remoteConnectionError)
+            #expect(error.h3ErrorCode == .datagramError)
+        }
+    }
+
+    @Test
+    func datagramWithInvalidQuarterStreamID() throws {
+        let invalidQuarterStreamID: UInt64 = 1 << 60
+        var buffer = ByteBuffer()
+        let bytesWritten = buffer.writeEncodedInteger(invalidQuarterStreamID, strategy: .quic)
+        #expect(bytesWritten > 0)
+
+        do {
+            _ = try buffer.parseDatagram()
+            Issue.record("Expected error")
+        } catch {
+            #expect(error.code == .remoteConnectionError)
+            #expect(error.h3ErrorCode == .datagramError)
+        }
+    }
+
+    @Test(arguments: [42, HTTP3Datagram.largestValidQuarterStreamID])
+    func datagramWithValidQuarterStreamID(quarterStreamID: UInt64) throws {
+        var buffer = ByteBuffer()
+        let bytesWritten = buffer.writeEncodedInteger(quarterStreamID, strategy: .quic)
+        #expect(bytesWritten > 0)
+        buffer.writeString("Hello, Datagram!")
+
+        let datagram = try buffer.parseDatagram()
+        #expect(datagram.streamID == QUICStreamID(rawValue: quarterStreamID * 4))
+        #expect(String(buffer: datagram.data) == "Hello, Datagram!")
+    }
+
+    @Test
+    func writeEmptyDatagramToBuffer() throws {
+        var buffer = ByteBuffer()
+        let bytesWritten = buffer.writeDatagram(HTTP3Datagram(streamID: 40, data: ByteBuffer()))
+        #expect(bytesWritten == 1)  // 42 can be encoded in a single byte.
+
+        let decoded = try buffer.parseDatagram()
+        #expect(decoded.streamID == 40)
+        #expect(decoded.data == ByteBuffer())
+    }
+
+    @Test
+    func writeNonEmptyDatagramToBuffer() throws {
+        let data = ByteBuffer(repeating: 1, count: 1024)
+
+        var buffer = ByteBuffer()
+        let bytesWritten = buffer.writeDatagram(HTTP3Datagram(streamID: 40, data: data))
+        #expect(bytesWritten == 1025)  // 1025 = 1 (streamID) + 1024 (data)
+
+        let decoded = try buffer.parseDatagram()
+        #expect(decoded.streamID == 40)
+        #expect(decoded.data == data)
+    }
+
+    @Test(.enableInDebugBuilds)
+    func writeInvalidStreamIDTrapsOnWrite() async {
+        @Sendable
+        func writeDatagramWithStreamID(_ streamID: QUICStreamID) {
+            let datagram = HTTP3Datagram(streamID: streamID, data: ByteBuffer())
+            var buffer = ByteBuffer()
+            buffer.writeDatagram(datagram)
+        }
+
+        // #expect(processExitsWith:expression:) can't capture the stream ID so it's not possible
+        // to parameterize these tests.
+        await #expect(processExitsWith: .failure) {
+            writeDatagramWithStreamID(1)
+        }
+
+        await #expect(processExitsWith: .failure) {
+            writeDatagramWithStreamID(2)
+        }
+
+        await #expect(processExitsWith: .failure) {
+            writeDatagramWithStreamID(3)
+        }
+    }
+}

--- a/Tests/NIOHTTP3Tests/HTTP3DatagramTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3DatagramTests.swift
@@ -33,26 +33,25 @@ struct HTTP3DatagramTests {
 
         #expect(datagram1.streamID == 1)
         #expect(datagram2.streamID == 2)
-        #expect(datagram1.data == datagram2.data)
+        #expect(datagram1.payload == datagram2.payload)
 
         var datagram3 = datagram1
-        datagram3.data.writeString(", Datagrams!")
+        datagram3.payload.writeString(", Datagrams!")
         #expect(datagram3.streamID == 1)
-        #expect(datagram3.data == ByteBuffer(string: "Hello, Datagrams!"))
-        #expect(datagram1.data == ByteBuffer(string: "Hello"))
+        #expect(datagram3.payload == ByteBuffer(string: "Hello, Datagrams!"))
+        #expect(datagram1.payload == ByteBuffer(string: "Hello"))
     }
 
     @Test
     func datagramFromEmptyBuffer() throws {
         var buffer = ByteBuffer()
 
-        do {
+        let error = try #require(throws: HTTP3Error.self) {
             _ = try buffer.parseDatagram()
-            Issue.record("Expected error")
-        } catch {
-            #expect(error.code == .remoteConnectionError)
-            #expect(error.h3ErrorCode == .datagramError)
         }
+
+        #expect(error.code == .remoteConnectionError)
+        #expect(error.h3ErrorCode == .datagramError)
     }
 
     @Test
@@ -62,13 +61,13 @@ struct HTTP3DatagramTests {
         let bytesWritten = buffer.writeEncodedInteger(invalidQuarterStreamID, strategy: .quic)
         #expect(bytesWritten > 0)
 
-        do {
+        let error = try #require(throws: HTTP3Error.self) {
             _ = try buffer.parseDatagram()
-            Issue.record("Expected error")
-        } catch {
-            #expect(error.code == .remoteConnectionError)
-            #expect(error.h3ErrorCode == .datagramError)
         }
+
+        #expect(error.code == .remoteConnectionError)
+        #expect(error.h3ErrorCode == .datagramError)
+
     }
 
     @Test(arguments: [42, HTTP3Datagram.largestValidQuarterStreamID])
@@ -80,7 +79,7 @@ struct HTTP3DatagramTests {
 
         let datagram = try buffer.parseDatagram()
         #expect(datagram.streamID == QUICStreamID(rawValue: quarterStreamID * 4))
-        #expect(String(buffer: datagram.data) == "Hello, Datagram!")
+        #expect(String(buffer: datagram.payload) == "Hello, Datagram!")
     }
 
     @Test
@@ -91,7 +90,7 @@ struct HTTP3DatagramTests {
 
         let decoded = try buffer.parseDatagram()
         #expect(decoded.streamID == 40)
-        #expect(decoded.data == ByteBuffer())
+        #expect(decoded.payload == ByteBuffer())
     }
 
     @Test
@@ -104,7 +103,7 @@ struct HTTP3DatagramTests {
 
         let decoded = try buffer.parseDatagram()
         #expect(decoded.streamID == 40)
-        #expect(decoded.data == data)
+        #expect(decoded.payload == data)
     }
 
     @Test(.enableInDebugBuilds)

--- a/Tests/NIOHTTP3Tests/HTTP3DatagramTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3DatagramTests.swift
@@ -87,7 +87,7 @@ struct HTTP3DatagramTests {
     func writeEmptyDatagramToBuffer() throws {
         var buffer = ByteBuffer()
         let bytesWritten = buffer.writeDatagram(HTTP3Datagram(streamID: 40, data: ByteBuffer()))
-        #expect(bytesWritten == 1)  // 42 can be encoded in a single byte.
+        #expect(bytesWritten == 1)  // 40 can be encoded in a single byte.
 
         let decoded = try buffer.parseDatagram()
         #expect(decoded.streamID == 40)

--- a/Tests/NIOHTTP3Tests/TestUtil.swift
+++ b/Tests/NIOHTTP3Tests/TestUtil.swift
@@ -17,6 +17,7 @@ public import HTTP3
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOExtras
+import Testing
 
 extension HTTP3GoawayID: ExpressibleByIntegerLiteral {
     public init(integerLiteral value: UInt64) {
@@ -215,6 +216,18 @@ extension DebugInboundEventsHandler.Event {
         switch self {
         case .read(let data): return data
         default: return nil
+        }
+    }
+}
+
+extension Trait where Self == ConditionTrait {
+    static var enableInDebugBuilds: Self {
+        .enabled {
+            #if DEBUG
+            return true
+            #else
+            return false
+            #endif
         }
     }
 }


### PR DESCRIPTION
Motivation:

To support HTTP/3 datagrams we'll need a few more types in place.

Modifications:

- Add HTTP3Datagram: a byte buffer tagged with the stream ID the datagram is for
- Add datagram settings
- Add appropriate error codes

Result:

New types are in place to support datagrams