### PR TITLE
Add a buffer for datagrams which arrive before their stream

### DIFF
--- a/Sources/NIOHTTP3/HTTP3DatagramBuffer.swift
+++ b/Sources/NIOHTTP3/HTTP3DatagramBuffer.swift
@@ -80,7 +80,9 @@ struct HTTP3DatagramBuffer {
 
     private func checkNotUnbuffered(_ streamID: QUICStreamID) {
         if self.unbuffered.contains(streamID) {
-            fatalError("\(streamID) has been discarded: you can't buffer data for a stream after it has been unbuffered")
+            fatalError(
+                "\(streamID) has been discarded: you can't buffer data for a stream after it has been unbuffered"
+            )
         }
     }
     #endif
@@ -234,13 +236,22 @@ extension [QUICStreamID: HTTP3DatagramBuffer.DatagramBatch] {
 
             var dropped = Dropped(bytes: 0, datagrams: 0)
 
-            while dropped.datagrams < maxDatagramsToDrop, dropped.bytes < bytesToDrop, let removed = batch!.popFirst() {
-                dropped.record(bytes: removed.payload.readableBytes)
-            }
-
-            // Empty: remove the batch from the dictionary.
-            if batch!.isEmpty {
+            // Fast-path: drop a whole batch.
+            if batch!.datagrams.count <= maxDatagramsToDrop, bytesToDrop <= batch!.totalSize {
+                dropped.datagrams = batch!.datagrams.count
+                dropped.record(bytes: batch!.totalSize)
                 batch = nil
+            } else {
+                while dropped.datagrams < maxDatagramsToDrop, dropped.bytes < bytesToDrop,
+                    let removed = batch!.popFirst()
+                {
+                    dropped.record(bytes: removed.payload.readableBytes)
+                }
+
+                // Empty: remove the batch from the dictionary.
+                if batch!.isEmpty {
+                    batch = nil
+                }
             }
 
             return dropped

--- a/Sources/NIOHTTP3/HTTP3DatagramBuffer.swift
+++ b/Sources/NIOHTTP3/HTTP3DatagramBuffer.swift
@@ -70,6 +70,21 @@ struct HTTP3DatagramBuffer {
     /// storing `N` contiguous entries where one would be sufficient.
     private var runs: Deque<StreamIDRun>
 
+    #if DEBUG
+    /// A set of stream IDs for which datagrams have already been discarded.
+    private var unbuffered: Set<QUICStreamID> = []
+
+    private mutating func markUnbuffered(_ streamID: QUICStreamID) {
+        self.unbuffered.insert(streamID)
+    }
+
+    private func checkNotUnbuffered(_ streamID: QUICStreamID) {
+        if self.unbuffered.contains(streamID) {
+            fatalError("\(streamID) has been discarded: you can't buffer data for a stream after it has been unbuffered")
+        }
+    }
+    #endif
+
     /// The total number of bytes currently stored in the buffer.
     private(set) var totalSize: Int
 
@@ -89,7 +104,14 @@ struct HTTP3DatagramBuffer {
     /// Append a datagram to the buffer.
     ///
     /// Datagrams may be evicted in order to make space for the new datagram.
+    ///
+    /// - Important: You must not append a datagram for a stream which has already had its
+    ///   frames unbuffered.
     mutating func append(_ datagram: HTTP3Datagram) {
+        #if DEBUG
+        self.checkNotUnbuffered(datagram.streamID)
+        #endif
+
         if self.runs.isEmpty || self.runs.last!.streamID != datagram.streamID {
             // New bucket.
             self.runs.append(StreamIDRun(streamID: datagram.streamID, count: 1))
@@ -108,6 +130,10 @@ struct HTTP3DatagramBuffer {
 
     /// Removes all datagrams for the given stream ID and return them, if they exist.
     mutating func unbufferDatagrams(forStream id: QUICStreamID) -> Deque<HTTP3Datagram>? {
+        #if DEBUG
+        self.markUnbuffered(id)
+        #endif
+
         guard let batch = self.storage.removeValue(forKey: id) else { return nil }
 
         self.totalSize -= batch.totalSize
@@ -116,6 +142,10 @@ struct HTTP3DatagramBuffer {
 
     /// Removes all datagrams for the given stream ID, if they exist.
     mutating func discardDatagrams(forStream id: QUICStreamID) {
+        #if DEBUG
+        self.markUnbuffered(id)
+        #endif
+
         if let batch = self.storage.removeValue(forKey: id) {
             self.totalSize -= batch.totalSize
         }
@@ -130,6 +160,12 @@ struct HTTP3DatagramBuffer {
 
     /// Removes all buffered datagrams.
     mutating func discardAllDatagrams() {
+        #if DEBUG
+        for id in self.storage.keys {
+            self.markUnbuffered(id)
+        }
+        #endif
+
         self.storage.removeAll()
         self.runs.removeAll()
         self.totalSize = 0

--- a/Sources/NIOHTTP3/HTTP3DatagramBuffer.swift
+++ b/Sources/NIOHTTP3/HTTP3DatagramBuffer.swift
@@ -247,6 +247,11 @@ extension [QUICStreamID: HTTP3DatagramBuffer.DatagramBatch] {
                 {
                     dropped.record(bytes: removed.payload.readableBytes)
                 }
+
+                // Empty: remove the batch from the dictionary.
+                if batch!.isEmpty {
+                    batch = nil
+                }
             }
 
             return dropped

--- a/Sources/NIOHTTP3/HTTP3DatagramBuffer.swift
+++ b/Sources/NIOHTTP3/HTTP3DatagramBuffer.swift
@@ -1,0 +1,220 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import DequeModule
+import NIOQUICHelpers
+
+struct HTTP3DatagramBuffer {
+    /// A batch of buffered datagrams for a given stream ID.
+    struct DatagramBatch {
+        /// The datagrams, in insertion order.
+        private(set) var datagrams: Deque<HTTP3Datagram>
+        /// The total size of the buffered datagrams in bytes.
+        private(set) var totalSize: Int
+
+        /// Whether the batch is empty.
+        var isEmpty: Bool {
+            self.datagrams.isEmpty
+        }
+
+        init() {
+            self.totalSize = 0
+            self.datagrams = []
+        }
+
+        /// Appends a datagram to the batch.
+        mutating func append(_ datagram: HTTP3Datagram) {
+            self.datagrams.append(datagram)
+            self.totalSize += datagram.payload.readableBytes
+        }
+
+        /// Pops the first datagram from the batch.
+        mutating func popFirst() -> HTTP3Datagram? {
+            guard let datagram = self.datagrams.popFirst() else { return nil }
+
+            self.totalSize &-= datagram.payload.readableBytes
+            return datagram
+        }
+
+        /// Remove all datagrams from the batch.
+        mutating func removeAll() {
+            self.totalSize = 0
+            self.datagrams.removeAll()
+        }
+    }
+
+    /// A run of contiguous stream IDs.
+    ///
+    /// Avoids storing `count` items when one would suffice.
+    struct StreamIDRun {
+        /// The stream ID associated with the run.
+        var streamID: QUICStreamID
+        /// The number of times the stream ID appears in the run.
+        var count: Int
+    }
+
+    /// Batches of datagrams keyed by the ID of the stream they are associated with.
+    private var storage: [QUICStreamID: DatagramBatch]
+    /// The insertion order of datagrams by stream ID. Stream IDs are batched into 'runs' to avoid
+    /// storing `N` contiguous entries where one would be sufficient.
+    private var runs: Deque<StreamIDRun>
+
+    /// The total number of bytes currently stored in the buffer.
+    private(set) var totalSize: Int
+
+    /// The maximum number of bytes allowed to be stored in the buffer at any one time.
+    private let maxAllowedSize: Int
+
+    /// Creates a new buffer, storing at most `maxAllowedSize` bytes at a given time. When the
+    /// limit is exceeded, buffered datagrams are evicted by insertion order until the total size
+    /// is within limit.
+    init(maxAllowedSize: Int) {
+        self.runs = []
+        self.storage = [:]
+        self.totalSize = 0
+        self.maxAllowedSize = maxAllowedSize
+    }
+
+    /// Append a datagram to the buffer.
+    ///
+    /// Datagrams may be evicted in order to make space for the new datagram.
+    mutating func append(_ datagram: HTTP3Datagram) {
+        if self.runs.isEmpty || self.runs.last!.streamID != datagram.streamID {
+            // New bucket.
+            self.runs.append(StreamIDRun(streamID: datagram.streamID, count: 1))
+        } else {
+            // Update an existing bucket.
+            let index = self.runs.index(before: self.runs.endIndex)
+            self.runs[index].count += 1
+        }
+
+        self.storage[datagram.streamID, default: DatagramBatch()].append(datagram)
+        self.totalSize += datagram.payload.readableBytes
+
+        self.dropLeadingRunsIfNecessary()
+        self.dropDatagramsIfNecessary()
+    }
+
+    /// Removes all datagrams for the given stream ID and return them, if they exist.
+    mutating func unbufferDatagrams(forStream id: QUICStreamID) -> Deque<HTTP3Datagram>? {
+        guard let batch = self.storage.removeValue(forKey: id) else { return nil }
+
+        self.totalSize -= batch.totalSize
+        return batch.datagrams
+    }
+
+    /// Removes all datagrams for the given stream ID, if they exist.
+    mutating func discardDatagrams(forStream id: QUICStreamID) {
+        if let batch = self.storage.removeValue(forKey: id) {
+            self.totalSize -= batch.totalSize
+        }
+    }
+
+    /// Removes all datagrams for streams with an ID greater than or equal to the given ID.
+    mutating func discardDatagrams(forStreamsAtOrAbove id: QUICStreamID) {
+        for streamID in self.storage.keys where streamID >= id {
+            self.discardDatagrams(forStream: streamID)
+        }
+    }
+
+    /// Removes all buffered datagrams.
+    mutating func discardAllDatagrams() {
+        self.storage.removeAll()
+        self.runs.removeAll()
+        self.totalSize = 0
+    }
+
+    private mutating func dropLeadingRunsIfNecessary() {
+        // Drop leading runs: this is done regardless of whether the max allowed size limit has
+        // been exceeded.
+        while let run = self.runs.first, !self.storage.keys.contains(run.streamID) {
+            self.runs.removeFirst()
+        }
+    }
+
+    private mutating func dropDatagramsIfNecessary() {
+        // Drop datagrams until the total size isn't exceeded.
+        while self.totalSize > self.maxAllowedSize && !self.runs.isEmpty {
+            let run = self.runs[self.runs.startIndex]
+
+            let dropped = self.storage.dropDatagrams(
+                forStreamID: run.streamID,
+                bytesToDrop: self.totalSize &- self.maxAllowedSize,
+                maxDatagramsToDrop: run.count
+            )
+
+            if let dropped {
+                self.totalSize &-= dropped.bytes
+                self.runs[self.runs.startIndex].count &-= dropped.datagrams
+
+                // The whole run was consumed: drop it.
+                if self.runs[self.runs.startIndex].count == 0 {
+                    self.runs.removeFirst()
+                } else {
+                    // The run is non-empty implying enough bytes were consumed. Leave it in place
+                    // and exit the loop.
+                    break
+                }
+            } else {
+                // Missing stream ID: datagrams for the given stream ID have been unbuffered.
+                self.runs.removeFirst()
+            }
+        }
+
+        assert(self.totalSize <= self.maxAllowedSize)
+    }
+}
+
+extension [QUICStreamID: HTTP3DatagramBuffer.DatagramBatch] {
+    struct Dropped {
+        var bytes: Int
+        var datagrams: Int
+
+        mutating func record(bytes: Int) {
+            self.bytes += bytes
+            self.datagrams += 1
+        }
+    }
+
+    fileprivate mutating func dropDatagrams(
+        forStreamID id: QUICStreamID,
+        bytesToDrop: Int,
+        maxDatagramsToDrop: Int
+    ) -> Dropped? {
+        self.withBatch(forStreamID: id) { batch -> Dropped? in
+            // No batch is fine: it means the datagrams have already been unbuffered.
+            if batch == nil { return nil }
+
+            var dropped = Dropped(bytes: 0, datagrams: 0)
+
+            while dropped.datagrams < maxDatagramsToDrop, dropped.bytes < bytesToDrop, let removed = batch!.popFirst() {
+                dropped.record(bytes: removed.payload.readableBytes)
+            }
+
+            // Empty: remove the batch from the dictionary.
+            if batch!.isEmpty {
+                batch = nil
+            }
+
+            return dropped
+        }
+    }
+
+    private mutating func withBatch(
+        forStreamID id: QUICStreamID,
+        mutate: (inout HTTP3DatagramBuffer.DatagramBatch?) -> Dropped?
+    ) -> Dropped? {
+        mutate(&self[id])
+    }
+}

--- a/Sources/NIOHTTP3/HTTP3DatagramBuffer.swift
+++ b/Sources/NIOHTTP3/HTTP3DatagramBuffer.swift
@@ -247,11 +247,6 @@ extension [QUICStreamID: HTTP3DatagramBuffer.DatagramBatch] {
                 {
                     dropped.record(bytes: removed.payload.readableBytes)
                 }
-
-                // Empty: remove the batch from the dictionary.
-                if batch!.isEmpty {
-                    batch = nil
-                }
             }
 
             return dropped

--- a/Sources/NIOHTTP3/HTTP3DatagramBuffer.swift
+++ b/Sources/NIOHTTP3/HTTP3DatagramBuffer.swift
@@ -237,7 +237,7 @@ extension [QUICStreamID: HTTP3DatagramBuffer.DatagramBatch] {
             var dropped = Dropped(bytes: 0, datagrams: 0)
 
             // Fast-path: drop a whole batch.
-            if batch!.datagrams.count <= maxDatagramsToDrop, bytesToDrop <= batch!.totalSize {
+            if maxDatagramsToDrop >= batch!.datagrams.count, bytesToDrop >= batch!.totalSize {
                 dropped.datagrams = batch!.datagrams.count
                 dropped.record(bytes: batch!.totalSize)
                 batch = nil

--- a/Tests/NIOHTTP3Tests/HTTP3DatagramBufferTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3DatagramBufferTests.swift
@@ -1,0 +1,173 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOQUICHelpers
+import Testing
+
+@testable import NIOHTTP3
+
+struct HTTP3DatagramBufferTests {
+    @Test
+    func emptyBuffer() {
+        var buffer = HTTP3DatagramBuffer(maxAllowedSize: 1024)
+        #expect(buffer.totalSize == 0)
+        #expect(buffer.unbufferDatagrams(forStream: 42) == nil)
+    }
+
+    @Test
+    func appendWithSpace() {
+        var buffer = HTTP3DatagramBuffer(maxAllowedSize: 1024)
+        buffer.append(.zeros(512, streamID: 1))
+        #expect(buffer.totalSize == 512)
+
+        buffer.append(.zeros(512, streamID: 1))
+        #expect(buffer.totalSize == 1024)
+    }
+
+    @Test
+    func appendDropsOversizedDatagram() {
+        var buffer = HTTP3DatagramBuffer(maxAllowedSize: 1024)
+        buffer.append(.zeros(2048, streamID: 1))
+        #expect(buffer.totalSize == 0)
+        #expect(buffer.unbufferDatagrams(forStream: 1) == nil)
+    }
+
+    @Test
+    func appendDropsOldDatagrams() {
+        var buffer = HTTP3DatagramBuffer(maxAllowedSize: 1024)
+        buffer.append(.zeros(256, streamID: 1))
+        #expect(buffer.totalSize == 256)
+
+        buffer.append(.zeros(512, streamID: 1))
+        #expect(buffer.totalSize == 768)
+
+        // First datagram (256B) gets dropped
+        buffer.append(.zeros(512, streamID: 1))
+        #expect(buffer.totalSize == 1024)
+    }
+
+    @Test
+    func discardDatagramsForStreamsAtOrAboveID() {
+        var buffer = HTTP3DatagramBuffer(maxAllowedSize: 1024)
+        buffer.append(.zeros(10, streamID: 0))
+        buffer.append(.zeros(20, streamID: 4))
+        buffer.append(.zeros(30, streamID: 8))
+        #expect(buffer.totalSize == 60)
+
+        buffer.discardDatagrams(forStreamsAtOrAbove: 4)
+        #expect(buffer.totalSize == 10)
+        #expect(buffer.unbufferDatagrams(forStream: 4) == nil)
+        #expect(buffer.unbufferDatagrams(forStream: 8) == nil)
+        #expect(buffer.unbufferDatagrams(forStream: 0)?.count == 1)
+    }
+
+    @Test
+    func discardAllDatagrams() {
+        var buffer = HTTP3DatagramBuffer(maxAllowedSize: 1024)
+        buffer.append(.zeros(10, streamID: 1))
+        buffer.append(.zeros(20, streamID: 2))
+        #expect(buffer.totalSize == 30)
+
+        buffer.discardAllDatagrams()
+        #expect(buffer.totalSize == 0)
+        #expect(buffer.unbufferDatagrams(forStream: 1) == nil)
+        #expect(buffer.unbufferDatagrams(forStream: 2) == nil)
+    }
+
+    @Test
+    func unbufferDatagrams() throws {
+        var buffer = HTTP3DatagramBuffer(maxAllowedSize: 1024)
+        buffer.append(.zeros(10, streamID: 1))
+        buffer.append(.zeros(20, streamID: 1))
+        buffer.append(.zeros(30, streamID: 1))
+        #expect(buffer.totalSize == 60)
+
+        buffer.append(.zeros(10, streamID: 2))
+        #expect(buffer.totalSize == 70)
+
+        let maybeDatagrams = buffer.unbufferDatagrams(forStream: 1)
+        #expect(buffer.totalSize == 10)
+
+        let datagrams = try #require(maybeDatagrams)
+        #expect(datagrams.count == 3)
+        #expect(datagrams.map { $0.streamID } == [1, 1, 1])
+        #expect(datagrams.map { $0.payload.readableBytes } == [10, 20, 30])
+    }
+
+    @Test
+    func appendDropsInInsertionOrderAcrossStreams() throws {
+        var buffer = HTTP3DatagramBuffer(maxAllowedSize: 60)
+        buffer.append(.zeros(10, streamID: 1))
+        buffer.append(.zeros(20, streamID: 2))
+        buffer.append(.zeros(30, streamID: 1))
+        #expect(buffer.totalSize == 60)
+
+        // Over limit by 5: the 10 byte datagram for stream 1 is the oldest, so it's dropped.
+        buffer.append(.zeros(5, streamID: 2))
+        #expect(buffer.totalSize == 55)
+
+        let maybeStreamOne = buffer.unbufferDatagrams(forStream: 1)
+        let streamOne = try #require(maybeStreamOne)
+        #expect(streamOne.map { $0.payload.readableBytes } == [30])
+
+        let maybeStreamTwo = buffer.unbufferDatagrams(forStream: 2)
+        let streamTwo = try #require(maybeStreamTwo)
+        #expect(streamTwo.map { $0.payload.readableBytes } == [20, 5])
+
+        #expect(buffer.totalSize == 0)
+    }
+
+    @Test
+    func appendDropsPartOfARun() throws {
+        var buffer = HTTP3DatagramBuffer(maxAllowedSize: 100)
+        buffer.append(.zeros(10, streamID: 1))
+        buffer.append(.zeros(10, streamID: 1))
+        buffer.append(.zeros(10, streamID: 1))
+
+        // Exceeds max size by 20: the first two datagrams from stream 1 should be dropped.
+        buffer.append(.zeros(90, streamID: 2))
+        #expect(buffer.totalSize == 100)
+
+        let maybeStreamOne = buffer.unbufferDatagrams(forStream: 1)
+        let streamOne = try #require(maybeStreamOne)
+        #expect(streamOne.map { $0.payload.readableBytes } == [10])
+        #expect(buffer.totalSize == 90)
+    }
+
+    @Test
+    func appendSkipsAlreadyUnbufferedStreamsWhenDropping() throws {
+        var buffer = HTTP3DatagramBuffer(maxAllowedSize: 1024)
+        buffer.append(.zeros(10, streamID: 1))
+        buffer.append(.zeros(10, streamID: 2))
+        #expect(buffer.unbufferDatagrams(forStream: 1)?.count == 1)
+        #expect(buffer.totalSize == 10)
+
+        // There's still a run for stream 1 recorded: dropping datagrams must skip it and evict
+        // stream 2's datagrams instead.
+        buffer.append(.zeros(1020, streamID: 3))
+        #expect(buffer.totalSize == 1020)
+        #expect(buffer.unbufferDatagrams(forStream: 2) == nil)
+
+        let maybeStreamThree = buffer.unbufferDatagrams(forStream: 3)
+        let streamThree = try #require(maybeStreamThree)
+        #expect(streamThree.map { $0.payload.readableBytes } == [1020])
+    }
+}
+
+extension HTTP3Datagram {
+    static func zeros(_ count: Int, streamID: QUICStreamID) -> HTTP3Datagram {
+        HTTP3Datagram(streamID: streamID, data: ByteBuffer(repeating: 0, count: count))
+    }
+}


### PR DESCRIPTION
Motivation:

Datagrams can arrive before a stream is opened. In such instances they should be buffered until the stream is opened. However, the amount of data buffered should be bounded.

Modifications:

Add a datagram buffer which stores datagrams in a buffer and discards datagrams in insertion order when the total number of bytes stored exceeds a threshold.

Result:

Can buffer datagrams