### PR TITLE
HTTP3OutboundControlStreamHandler: on channel active flush just once

### DIFF
--- a/Sources/NIOHTTP3/HTTP3OutboundControlStreamHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3OutboundControlStreamHandler.swift
@@ -60,9 +60,12 @@ package final class HTTP3OutboundControlStreamHandler: ChannelInboundHandler {
         let action = self.state.channelActive()
         switch action {
         case .sendFrames(var frames):
+            guard !frames.isEmpty else { return }
             while let frame = frames.popFirst() {
-                context.writeAndFlush(self.wrapOutboundOut(frame), promise: nil)
+                context.write(self.wrapOutboundOut(frame), promise: nil)
             }
+            context.flush()
+
         case .none:
             break
         }


### PR DESCRIPTION
### Motivation

Less flushing means better performance.

### Modifications

- HTTP3OutboundControlStreamHandler: Flush just once on startup

### Result

HTTP3OutboundControlStreamHandler: Flushes just once on startup