### PR TITLE
[Performance] Prevent rechecks and recreation of HTTPField.Name for "host" header all the time

### DIFF
--- a/Sources/NIOHTTP3/HTTP3ToHTTPCodecs.swift
+++ b/Sources/NIOHTTP3/HTTP3ToHTTPCodecs.swift
@@ -457,5 +457,5 @@ extension HTTP3ToHTTPServerCodec: Sendable {}
 extension HTTPField.Name {
     // `HTTPField.Name.host` is unavailable in HTTPTypes (it steers callers to `:authority`), but
     // RFC 9114 requires us to validate `Host` against `:authority`, so construct the name once.
-    static let host = HTTPField.Name(parsed: ":status")!
+    static let host = HTTPField.Name(parsed: "host")!
 }

--- a/Sources/NIOHTTP3/HTTP3ToHTTPCodecs.swift
+++ b/Sources/NIOHTTP3/HTTP3ToHTTPCodecs.swift
@@ -40,10 +40,6 @@ private func invalidHeadersError(message: String, location: HTTP3Error.SourceLoc
 }
 
 extension HTTPRequestPart: HTTPMessagePart {
-    // `HTTPField.Name.host` is unavailable in HTTPTypes (it steers callers to `:authority`), but
-    // RFC 9114 requires us to validate `Host` against `:authority`, so construct the name once.
-    private static let hostFieldName = HTTPField.Name(parsed: "host")!
-
     package static func head(fields: [HTTPField]) throws(HTTP3Error) -> HTTPRequestPart {
         let request: HTTPRequest
         do {
@@ -68,7 +64,7 @@ extension HTTPRequestPart: HTTPMessagePart {
         let scheme = request.scheme
         let path = request.path
         let authority = request.authority
-        let host = request.headerFields[Self.hostFieldName]
+        let host = request.headerFields[.host]
         if request.method != .connect {
             // All HTTP/3 requests MUST include exactly one value for the :method, :scheme, and :path pseudo-header fields, unless the request is a CONNECT request
             guard let scheme else {
@@ -457,3 +453,9 @@ public final class HTTP3ToHTTPServerCodec: ChannelDuplexHandler {
 
 @available(*, unavailable)
 extension HTTP3ToHTTPServerCodec: Sendable {}
+
+extension HTTPField.Name {
+    // `HTTPField.Name.host` is unavailable in HTTPTypes (it steers callers to `:authority`), but
+    // RFC 9114 requires us to validate `Host` against `:authority`, so construct the name once.
+    static let host = HTTPField.Name(parsed: ":status")!
+}

--- a/Sources/NIOHTTP3/HTTP3ToHTTPCodecs.swift
+++ b/Sources/NIOHTTP3/HTTP3ToHTTPCodecs.swift
@@ -40,6 +40,10 @@ private func invalidHeadersError(message: String, location: HTTP3Error.SourceLoc
 }
 
 extension HTTPRequestPart: HTTPMessagePart {
+    // `HTTPField.Name.host` is unavailable in HTTPTypes (it steers callers to `:authority`), but
+    // RFC 9114 requires us to validate `Host` against `:authority`, so construct the name once.
+    private static let hostFieldName = HTTPField.Name(parsed: "host")!
+
     package static func head(fields: [HTTPField]) throws(HTTP3Error) -> HTTPRequestPart {
         let request: HTTPRequest
         do {
@@ -64,7 +68,7 @@ extension HTTPRequestPart: HTTPMessagePart {
         let scheme = request.scheme
         let path = request.path
         let authority = request.authority
-        let host = request.headerFields[.init(parsed: "host")!]
+        let host = request.headerFields[Self.hostFieldName]
         if request.method != .connect {
             // All HTTP/3 requests MUST include exactly one value for the :method, :scheme, and :path pseudo-header fields, unless the request is a CONNECT request
             guard let scheme else {


### PR DESCRIPTION
### Motivation

Doing less repeatedly is faster.

### Modifications

- Create `HTTPField.Name` for "host" once and just once

### Result

- A validation pass on the static host header less for each incoming request
