### PR TITLE
Explicitly define package name in Benchmark Package.swift

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .macOS(.v13)
     ],
     dependencies: [
-        .package(path: "../"),
+        .package(name: "swift-nio-http3", path: "../"),
         .package(url: "https://github.com/apple/swift-http-types.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", branch: "main"),
         .package(url: "https://github.com/ordo-one/benchmark.git", from: "1.35.0"),


### PR DESCRIPTION
### Motivation

To be able to use git worktrees and run the benchmarks, we need to explicitly name the `swift-nio-http3` package in the Benchmarks/Package.swift

### Result

Benchmarks can be build & run inside a git worktree.
