### PR TITLE
Rename HTTP3Datagram initializer parameter

### DIFF
--- a/Sources/NIOHTTP3/HTTP3Datagram.swift
+++ b/Sources/NIOHTTP3/HTTP3Datagram.swift
@@ -29,13 +29,13 @@ public struct HTTP3Datagram: @unchecked Sendable {
         var streamID: QUICStreamID
         var payload: ByteBuffer
 
-        init(streamID: QUICStreamID, data: ByteBuffer) {
+        init(streamID: QUICStreamID, payload: ByteBuffer) {
             self.streamID = streamID
-            self.payload = data
+            self.payload = payload
         }
 
         func copy() -> Storage {
-            Storage(streamID: self.streamID, data: self.payload)
+            Storage(streamID: self.streamID, payload: self.payload)
         }
     }
 
@@ -72,9 +72,9 @@ public struct HTTP3Datagram: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - streamID: The ID of the stream this datagram is associated with.
-    ///   - data: The payload of the datagram.
-    public init(streamID: QUICStreamID, data: ByteBuffer) {
-        self.storage = Storage(streamID: streamID, data: data)
+    ///   - payload: The payload of the datagram.
+    public init(streamID: QUICStreamID, payload: ByteBuffer) {
+        self.storage = Storage(streamID: streamID, payload: payload)
     }
 }
 
@@ -125,8 +125,8 @@ extension ByteBuffer {
         // to have a variant which avoids this given we've validated it here.
         let streamID = QUICStreamID(rawValue: rawStreamID)
 
-        let data = self.readSlice(length: self.readableBytes)!
-        return HTTP3Datagram(streamID: streamID, data: data)
+        let payload = self.readSlice(length: self.readableBytes)!
+        return HTTP3Datagram(streamID: streamID, payload: payload)
     }
 
     @discardableResult

--- a/Tests/NIOHTTP3Tests/HTTP3DatagramBufferTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3DatagramBufferTests.swift
@@ -168,6 +168,6 @@ struct HTTP3DatagramBufferTests {
 
 extension HTTP3Datagram {
     static func zeros(_ count: Int, streamID: QUICStreamID) -> HTTP3Datagram {
-        HTTP3Datagram(streamID: streamID, data: ByteBuffer(repeating: 0, count: count))
+        HTTP3Datagram(streamID: streamID, payload: ByteBuffer(repeating: 0, count: count))
     }
 }

--- a/Tests/NIOHTTP3Tests/HTTP3DatagramTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3DatagramTests.swift
@@ -27,7 +27,7 @@ struct HTTP3DatagramTests {
 
     @Test
     func testCoWBehavior() {
-        let datagram1 = HTTP3Datagram(streamID: 1, data: ByteBuffer(string: "Hello"))
+        let datagram1 = HTTP3Datagram(streamID: 1, payload: ByteBuffer(string: "Hello"))
         var datagram2 = datagram1
         datagram2.streamID = 2
 
@@ -85,7 +85,7 @@ struct HTTP3DatagramTests {
     @Test
     func writeEmptyDatagramToBuffer() throws {
         var buffer = ByteBuffer()
-        let bytesWritten = buffer.writeDatagram(HTTP3Datagram(streamID: 40, data: ByteBuffer()))
+        let bytesWritten = buffer.writeDatagram(HTTP3Datagram(streamID: 40, payload: ByteBuffer()))
         #expect(bytesWritten == 1)  // 40 can be encoded in a single byte.
 
         let decoded = try buffer.parseDatagram()
@@ -98,7 +98,7 @@ struct HTTP3DatagramTests {
         let data = ByteBuffer(repeating: 1, count: 1024)
 
         var buffer = ByteBuffer()
-        let bytesWritten = buffer.writeDatagram(HTTP3Datagram(streamID: 40, data: data))
+        let bytesWritten = buffer.writeDatagram(HTTP3Datagram(streamID: 40, payload: data))
         #expect(bytesWritten == 1025)  // 1025 = 1 (streamID) + 1024 (data)
 
         let decoded = try buffer.parseDatagram()
@@ -110,7 +110,7 @@ struct HTTP3DatagramTests {
     func writeInvalidStreamIDTrapsOnWrite() async {
         @Sendable
         func writeDatagramWithStreamID(_ streamID: QUICStreamID) {
-            let datagram = HTTP3Datagram(streamID: streamID, data: ByteBuffer())
+            let datagram = HTTP3Datagram(streamID: streamID, payload: ByteBuffer())
             var buffer = ByteBuffer()
             buffer.writeDatagram(datagram)
         }

--- a/Tests/NIOHTTP3Tests/HTTP3DatagramTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3DatagramTests.swift
@@ -95,15 +95,15 @@ struct HTTP3DatagramTests {
 
     @Test
     func writeNonEmptyDatagramToBuffer() throws {
-        let data = ByteBuffer(repeating: 1, count: 1024)
+        let payload = ByteBuffer(repeating: 1, count: 1024)
 
         var buffer = ByteBuffer()
-        let bytesWritten = buffer.writeDatagram(HTTP3Datagram(streamID: 40, payload: data))
+        let bytesWritten = buffer.writeDatagram(HTTP3Datagram(streamID: 40, payload: payload))
         #expect(bytesWritten == 1025)  // 1025 = 1 (streamID) + 1024 (data)
 
         let decoded = try buffer.parseDatagram()
         #expect(decoded.streamID == 40)
-        #expect(decoded.payload == data)
+        #expect(decoded.payload == payload)
     }
 
     @Test(.enableInDebugBuilds)


### PR DESCRIPTION
### Motivation

[RFC 9297 § 2.1](https://datatracker.ietf.org/doc/html/rfc9297#section-2.1-3.4.1) uses the term "payload" to refer to the data contained inside an HTTP/3 datagram.

We should use the same terminology in the `HTTP3Datagram` type.

### Modifications

Renamed the `data` parameter to `payload` in the `HTTP3Datagram` initializer and updated all references.

### Result

Consistent naming.