### PR TITLE
Remove package access control

### DIFF
--- a/Sources/HTTP3/HTTP3ConnectionQuiescingStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionQuiescingStateMachine.swift
@@ -12,9 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import NIOQUICHelpers
+import NIOQUICHelpers
 
-package struct HTTP3ConnectionQuiescingStateMachine: ~Copyable {
+struct HTTP3ConnectionQuiescingStateMachine: ~Copyable {
     private enum State: ~Copyable {
         /// Neither side has started quiescing yet.
         case notQuiesced(NotQuiesced)
@@ -111,11 +111,11 @@ package struct HTTP3ConnectionQuiescingStateMachine: ~Copyable {
         self.state = state
     }
 
-    package init(type: HTTP3ConnectionType) {
+    init(type: HTTP3ConnectionType) {
         self.init(state: .notQuiesced(.init(type: type)))
     }
 
-    package enum ReceivedGoawayAction {
+    enum ReceivedGoawayAction {
         /// Streams with ids equal to or above the given id should be cancelled. If there are no such streams, the connection should be closed.
         case cancelStreamsOrCloseIfNone(lowestIDToCancel: QUICStreamID)
         case emitConnectionError(HTTP3Error)
@@ -155,7 +155,7 @@ package struct HTTP3ConnectionQuiescingStateMachine: ~Copyable {
         }
     }
 
-    package mutating func receivedGoaway(newGoawayID: HTTP3GoawayID) -> ReceivedGoawayAction? {
+    mutating func receivedGoaway(newGoawayID: HTTP3GoawayID) -> ReceivedGoawayAction? {
         @inline(never)
         func invalidGoawayStreamIDError(location: HTTP3Error.SourceLocation) -> HTTP3Error {
             HTTP3Error(
@@ -262,14 +262,14 @@ package struct HTTP3ConnectionQuiescingStateMachine: ~Copyable {
         }
     }
 
-    package enum SendGoawayAction {
+    enum SendGoawayAction {
         /// Write a GOAWAY frame
         case sendGoaway(id: HTTP3GoawayID)
         /// Throw an error: the caller of this function has made a mistake and gave us an invalid id.
         case throwError(HTTP3Error)
     }
 
-    package mutating func sendGoaway(goawayID: HTTP3GoawayID) -> SendGoawayAction {
+    mutating func sendGoaway(goawayID: HTTP3GoawayID) -> SendGoawayAction {
         switch self.connectionType {
         case .client:
             // We are sending the server a goaway, so the id represents a push id.
@@ -326,7 +326,7 @@ package struct HTTP3ConnectionQuiescingStateMachine: ~Copyable {
         }
     }
 
-    package enum ShouldCloseConnectionAction: Hashable {
+    enum ShouldCloseConnectionAction: Hashable {
         /// The connection should be closed if there are no open streams.
         case closeIfNoOpenStreams
         /// The connection should be closed if there are no open streams AND there can be no more streams below maxID (we already exhausted all the numbers).
@@ -337,7 +337,7 @@ package struct HTTP3ConnectionQuiescingStateMachine: ~Copyable {
 
     /// Determines whether or not to close the connection, and under which conditions.
     /// Call this whenever a request stream closes. It might be that it was the last one we were waiting for before closing the connection.
-    package func shouldCloseConnection() -> ShouldCloseConnectionAction {
+    func shouldCloseConnection() -> ShouldCloseConnectionAction {
         switch self.state {
         case .notQuiesced:
             // Neither side has quiesced, so there is nothing to do
@@ -384,7 +384,7 @@ package struct HTTP3ConnectionQuiescingStateMachine: ~Copyable {
         }
     }
 
-    package func inboundRequestStreamAllowed(incomingStreamID: QUICStreamID) -> Bool {
+    func inboundRequestStreamAllowed(incomingStreamID: QUICStreamID) -> Bool {
         switch self.state {
         case .notQuiesced: return true
         case .remotelyQuiesced: return true
@@ -396,12 +396,12 @@ package struct HTTP3ConnectionQuiescingStateMachine: ~Copyable {
         }
     }
 
-    package enum CreateOutboundRequestStreamAction {
+    enum CreateOutboundRequestStreamAction {
         case create
         case failToCreate(HTTP3Error)
     }
 
-    package func createOutboundRequestStream() -> CreateOutboundRequestStreamAction {
+    func createOutboundRequestStream() -> CreateOutboundRequestStreamAction {
         switch self.state {
         case .notQuiesced: return .create
         case .locallyQuiesced: return .create

--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import DequeModule
+public import DequeModule
 public import HTTPTypes
 public import Logging
 public import NIOQUICHelpers
@@ -381,11 +381,13 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
 
     // MARK: Outbound Streams
 
-    package enum OutboundEncoderStreamReadyAction: Hashable {
+    @_spi(PackageInternal)
+    public enum OutboundEncoderStreamReadyAction: Hashable {
         case sendEncoderInstruction(QPACKEncoderInstruction)
     }
 
-    package mutating func outboundEncoderStreamReady(streamID: QUICStreamID) -> OutboundEncoderStreamReadyAction? {
+    @_spi(PackageInternal)
+    public mutating func outboundEncoderStreamReady(streamID: QUICStreamID) -> OutboundEncoderStreamReadyAction? {
         precondition(streamID.isUnidirectional)
         switch consume self.state {
         case .initialized(var initializedState):
@@ -406,11 +408,13 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package enum OutboundDecoderStreamReadyAction: Hashable, Sendable {
+    @_spi(PackageInternal)
+    public enum OutboundDecoderStreamReadyAction: Hashable, Sendable {
         case sendDecoderInstructions(Deque<QPACKDecoderInstruction>)
     }
 
-    package mutating func outboundDecoderStreamReady(streamID: QUICStreamID) -> OutboundDecoderStreamReadyAction? {
+    @_spi(PackageInternal)
+    public mutating func outboundDecoderStreamReady(streamID: QUICStreamID) -> OutboundDecoderStreamReadyAction? {
         precondition(streamID.isUnidirectional)
         switch consume self.state {
         case .initialized(var initializedState):
@@ -431,13 +435,15 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package enum OutboundRequestStreamRequestedAction {
+    @_spi(PackageInternal)
+    public enum OutboundRequestStreamRequestedAction {
         case create
         case failedToCreateStream(HTTP3Error)
     }
 
     /// Call this before making a request stream. It will tell you whether or not you may create it.
-    package mutating func outboundRequestStreamRequested() -> OutboundRequestStreamRequestedAction {
+    @_spi(PackageInternal)
+    public mutating func outboundRequestStreamRequested() -> OutboundRequestStreamRequestedAction {
         switch consume self.state {
         case .initialized(let initializedState):
             switch initializedState.type {
@@ -479,7 +485,8 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package mutating func outboundRequestStreamReady(streamID: QUICStreamID) {
+    @_spi(PackageInternal)
+    public mutating func outboundRequestStreamReady(streamID: QUICStreamID) {
         precondition(streamID.isBidirectional)
         switch consume self.state {
         case .notStarted:
@@ -497,7 +504,8 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package mutating func outboundControlStreamReady(streamID: QUICStreamID) {
+    @_spi(PackageInternal)
+    public mutating func outboundControlStreamReady(streamID: QUICStreamID) {
         precondition(streamID.isUnidirectional)
         switch consume self.state {
         case .notStarted:
@@ -512,7 +520,8 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
 
     // MARK: Control stream
 
-    package enum ControlFrameReceivedAction {
+    @_spi(PackageInternal)
+    public enum ControlFrameReceivedAction {
         /// An outbound QPACK encoder instruction stream needs to be created.
         case makeEncoderInstructionStream
         /// A connection error should be emitted
@@ -523,7 +532,8 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         case closeConnection
     }
 
-    package mutating func receivedControlFrame(_ frame: HTTP3Frame) -> ControlFrameReceivedAction? {
+    @_spi(PackageInternal)
+    public mutating func receivedControlFrame(_ frame: HTTP3Frame) -> ControlFrameReceivedAction? {
         switch frame {
         case .settings(let payload):
             let settings = payload.settings
@@ -631,7 +641,8 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
 
     // MARK: QPACK
 
-    package enum IncomingEncoderInstructionAction {
+    @_spi(PackageInternal)
+    public enum IncomingEncoderInstructionAction {
         /// The new incoming instruction resulted in previously-blocked headers now being decodable.
         case sendDecoderInstruction(QPACKDecoderInstruction)
         case emitConnectionError(HTTP3Error)
@@ -639,7 +650,8 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
 
     /// Inform the state machine of a new incoming QPACK encoder instruction. After this, you should call ``checkPendingDecodes()`` because the new instruction
     /// may have unblocked a pending decode.
-    package mutating func receivedIncomingEncoderInstruction(
+    @_spi(PackageInternal)
+    public mutating func receivedIncomingEncoderInstruction(
         _ instruction: QPACKEncoderInstruction
     ) -> IncomingEncoderInstructionAction? {
         switch consume self.state {
@@ -665,11 +677,13 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package enum IncomingDecoderInstructionAction {
+    @_spi(PackageInternal)
+    public enum IncomingDecoderInstructionAction {
         case emitConnectionError(HTTP3Error)
     }
 
-    package mutating func receivedIncomingDecoderInstruction(
+    @_spi(PackageInternal)
+    public mutating func receivedIncomingDecoderInstruction(
         _ instruction: QPACKDecoderInstruction
     ) -> IncomingDecoderInstructionAction? {
         switch consume self.state {
@@ -692,7 +706,8 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package mutating func encodeHeaders(_ headers: [HTTPField], forStream streamID: QUICStreamID) -> QPACKEncodeResult {
+    @_spi(PackageInternal)
+    public mutating func encodeHeaders(_ headers: [HTTPField], forStream streamID: QUICStreamID) -> QPACKEncodeResult {
         switch consume self.state {
         case .notStarted:
             fatalError("Tried to encode headers before state machine started")

--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -123,12 +123,14 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
 
     // MARK: Initialization
 
-    package enum InitializeAction: Hashable, Sendable {
+    @_spi(PackageInternal)
+    public enum InitializeAction: Hashable, Sendable {
         case createControlAndDecoderStreams
         case createControlStream
     }
 
-    package mutating func initialize() -> InitializeAction? {
+    @_spi(PackageInternal)
+    public mutating func initialize() -> InitializeAction? {
         switch consume self.state {
         case .notStarted(let initializedState):
             let localSettings = initializedState.localSettings
@@ -155,13 +157,15 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
 
     // MARK: Inbound streams
 
-    package enum InboundRequestStreamReceivedAction {
+    @_spi(PackageInternal)
+    public enum InboundRequestStreamReceivedAction {
         case addHandlers
         case emitStreamError(HTTP3Error)
         case emitConnectionError(HTTP3Error)
     }
 
-    package mutating func inboundRequestStreamReceived(streamID: QUICStreamID) -> InboundRequestStreamReceivedAction {
+    @_spi(PackageInternal)
+    public mutating func inboundRequestStreamReceived(streamID: QUICStreamID) -> InboundRequestStreamReceivedAction {
         precondition(streamID.isBidirectional, "Stream ID \(streamID) was expected to be bidirectional")
         switch consume self.state {
         case .notStarted:
@@ -211,13 +215,15 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package enum InboundControlStreamReceivedAction {
+    @_spi(PackageInternal)
+    public enum InboundControlStreamReceivedAction {
         case addHandlers
         case emitConnectionError(HTTP3Error)
         case emitStreamError(HTTP3Error)
     }
 
-    package mutating func inboundControlStreamReceived(streamID: QUICStreamID) -> InboundControlStreamReceivedAction {
+    @_spi(PackageInternal)
+    public mutating func inboundControlStreamReceived(streamID: QUICStreamID) -> InboundControlStreamReceivedAction {
         precondition(streamID.isUnidirectional, "Stream ID \(streamID) was expected to be unidirectional")
         switch consume self.state {
         case .notStarted:
@@ -240,12 +246,14 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package enum InboundPushStreamReceivedAction {
+    @_spi(PackageInternal)
+    public enum InboundPushStreamReceivedAction {
         case emitConnectionError(HTTP3Error)
         case emitStreamError(HTTP3Error)
     }
 
-    package mutating func inboundPushStreamReceived(streamID: QUICStreamID) -> InboundPushStreamReceivedAction {
+    @_spi(PackageInternal)
+    public mutating func inboundPushStreamReceived(streamID: QUICStreamID) -> InboundPushStreamReceivedAction {
         precondition(streamID.isUnidirectional, "Stream ID \(streamID) was expected to be unidirectional")
         switch consume self.state {
         case .notStarted:
@@ -289,14 +297,17 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package enum InboundQPACKStreamReceivedAction {
+    @_spi(PackageInternal)
+    public enum InboundQPACKStreamReceivedAction {
         case addHandlers
         case emitConnectionError(HTTP3Error)
         case emitStreamError(HTTP3Error)
     }
 
-    package mutating func inboundQPACKDecoderStreamReceived(streamID: QUICStreamID) -> InboundQPACKStreamReceivedAction
-    {
+    @_spi(PackageInternal)
+    public mutating func inboundQPACKDecoderStreamReceived(
+        streamID: QUICStreamID
+    ) -> InboundQPACKStreamReceivedAction {
         precondition(streamID.isUnidirectional, "Stream ID \(streamID) was expected to be unidirectional")
         switch consume self.state {
         case .notStarted:
@@ -319,8 +330,8 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package mutating func inboundQPACKEncoderStreamReceived(streamID: QUICStreamID) -> InboundQPACKStreamReceivedAction
-    {
+    @_spi(PackageInternal)
+    public mutating func inboundQPACKEncoderStreamReceived(streamID: QUICStreamID) -> InboundQPACKStreamReceivedAction {
         precondition(streamID.isUnidirectional, "Stream ID \(streamID) was expected to be unidirectional")
         switch consume self.state {
         case .notStarted:
@@ -813,7 +824,8 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
 
     /// Check if any previously-queued decode is now decodable.
     /// This function should be called repeatedly after new input (eg. new incoming instructions) until it returns nil
-    package mutating func checkPendingQPACKDecodes() -> DecodeHeaderAction? {
+    @_spi(PackageInternal)
+    public mutating func checkPendingQPACKDecodes() -> DecodeHeaderAction? {
         switch consume self.state {
         case .notStarted:
             fatalError("Tried to decode headers before state machine started")
@@ -829,20 +841,12 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
 
     // MARK: Shutdown
 
-    package enum CloseAction {
-        /// Send a GOAWAY frame containing ``id`` and close any existing streams with an id in ``idsToCancel``
-        case sendGoaway(id: HTTP3GoawayID, idsToCancel: [QUICStreamID])
-        /// Throw an error: the caller of this function has made a mistake and gave us an invalid id.
-        case throwError(any Error)
-        /// Close the connection immediately.
-        case closeImmediately
-    }
-
     /// Whether a graceful shutdown can be initiated by this endpoint.
     ///
     /// Returns `false` if the connection is not yet open or has already finished, or if a graceful shutdown has already
     /// been initiated.
-    package func canInitiateGracefulShutdown() -> Bool {
+    @_spi(PackageInternal)
+    public func canInitiateGracefulShutdown() -> Bool {
         switch self.state {
         case .notStarted:
             return false
@@ -855,7 +859,18 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package mutating func sendGoaway(goawayID newLocalMaxID: HTTP3GoawayID) -> CloseAction? {
+    @_spi(PackageInternal)
+    public enum CloseAction {
+        /// Send a GOAWAY frame containing ``id`` and close any existing streams with an id in ``idsToCancel``
+        case sendGoaway(id: HTTP3GoawayID, idsToCancel: [QUICStreamID])
+        /// Throw an error: the caller of this function has made a mistake and gave us an invalid id.
+        case throwError(any Error)
+        /// Close the connection immediately.
+        case closeImmediately
+    }
+
+    @_spi(PackageInternal)
+    public mutating func sendGoaway(goawayID newLocalMaxID: HTTP3GoawayID) -> CloseAction? {
         switch consume self.state {
         case .notStarted:
             self = .init(state: .finished)
@@ -891,7 +906,8 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
 
     /// Returns the next expected client-initiated bidirectional stream ID, or `nil` if the connection is not in the
     /// `.initialized` state.
-    package func nextExpectedClientInitiatedBidirectionalStreamID() -> QUICStreamID? {
+    @_spi(PackageInternal)
+    public func nextExpectedClientInitiatedBidirectionalStreamID() -> QUICStreamID? {
         switch self.state {
         case .notStarted:
             return nil
@@ -1011,13 +1027,15 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package enum ShutdownCompleteAction: Hashable {
+    @_spi(PackageInternal)
+    public enum ShutdownCompleteAction: Hashable {
         /// The connection should be closed now
         case shutdown
     }
 
     /// Call this when the connection has been completely shut down for any reason.
-    package mutating func shutdownConnectionImmediately() -> ShutdownCompleteAction {
+    @_spi(PackageInternal)
+    public mutating func shutdownConnectionImmediately() -> ShutdownCompleteAction {
         // TODO: verify that we really did close all bidi streams?
         // There will still be open streams here if the connection channel was closed suddenly rather than gracefully.
         self = .init(state: .finished)
@@ -1039,13 +1057,15 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package enum EmitConnectionErrorAction {
+    @_spi(PackageInternal)
+    public enum EmitConnectionErrorAction {
         case emitConnectionError(HTTP3Error)
         case none
     }
 
     /// Call this when a stream wants to emit a connection-level error.
-    package mutating func emitConnectionErrorFromStream(error: HTTP3Error) -> EmitConnectionErrorAction {
+    @_spi(PackageInternal)
+    public mutating func emitConnectionErrorFromStream(error: HTTP3Error) -> EmitConnectionErrorAction {
         switch consume self.state {
         case .finished:
             // We already finished, so emitting a connection error is now pointless.
@@ -1059,13 +1079,15 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package enum CaughtRemoteErrorAction {
+    @_spi(PackageInternal)
+    public enum CaughtRemoteErrorAction {
         /// Cancel these streams because the remote closed the connection.
         case cancelStreams([QUICStreamID])
     }
 
     /// Call this when the remote sends us an error.
-    package mutating func caughtRemoteError(_: HTTP3Error) -> CaughtRemoteErrorAction? {
+    @_spi(PackageInternal)
+    public mutating func caughtRemoteError(_: HTTP3Error) -> CaughtRemoteErrorAction? {
         switch consume self.state {
         case .initialized(let initializedState):
             let idsToCancel = initializedState.streamIDTracker.getOpenStreamIDs {

--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -13,17 +13,19 @@
 //===----------------------------------------------------------------------===//
 
 package import DequeModule
-package import HTTPTypes
-package import Logging
-package import NIOQUICHelpers
-package import QPACK
+public import HTTPTypes
+public import Logging
+public import NIOQUICHelpers
+@_spi(PackageInternal) public import QPACK
 
-package enum HTTP3ConnectionType {
+@_spi(PackageInternal)
+public enum HTTP3ConnectionType: Sendable {
     case client
     case server
 }
 
-package struct HTTP3ConnectionStateMachine: ~Copyable {
+@_spi(PackageInternal)
+public struct HTTP3ConnectionStateMachine: ~Copyable {
     struct InboundStreamCreationState: ~Copyable {
         private enum State: ~Copyable {
             case notCreated
@@ -106,7 +108,8 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
 
     private let state: State
 
-    package init(settings: HTTP3Settings, type: HTTP3ConnectionType) {
+    @_spi(PackageInternal)
+    public init(settings: HTTP3Settings, type: HTTP3ConnectionType) {
         let qpackState = QPACKStateMachine(
             decoderMaxTableSize: Int(clamping: settings.qpackMaximumTableCapacity),
             decoderMaxBlockedStreams: Int(clamping: settings.qpackBlockedStreams)
@@ -340,11 +343,13 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package enum InboundUnknownStreamAction {
+    @_spi(PackageInternal)
+    public enum InboundUnknownStreamAction {
         case emitStreamError(HTTP3Error)
     }
 
-    package mutating func inboundUnknownStreamReceived(
+    @_spi(PackageInternal)
+    public mutating func inboundUnknownStreamReceived(
         streamID: QUICStreamID,
         streamType: HTTP3StreamType.Unidirectional
     ) -> InboundUnknownStreamAction {
@@ -700,7 +705,8 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package enum DecodeHeaderAction {
+    @_spi(PackageInternal)
+    public enum DecodeHeaderAction {
         /// Send this qpack decode result to the relevant stream.
         case informDecodeResult(InformDecodeResult)
 
@@ -709,13 +715,20 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
 
         /// Send a connection-level error.
         case emitConnectionError(HTTP3Error)
-        package struct InformDecodeResult: Hashable, Sendable {
-            package var fields: [HTTPField]
-            package var headers: HTTP3PartialFrame.Headers
-            package var streamID: QUICStreamID
-            package var instructionToWrite: QPACKDecoderInstruction?
 
-            package init(
+        @_spi(PackageInternal)
+        public struct InformDecodeResult: Hashable, Sendable {
+            @_spi(PackageInternal)
+            public var fields: [HTTPField]
+            @_spi(PackageInternal)
+            public var headers: HTTP3PartialFrame.Headers
+            @_spi(PackageInternal)
+            public var streamID: QUICStreamID
+            @_spi(PackageInternal)
+            public var instructionToWrite: QPACKDecoderInstruction?
+
+            @_spi(PackageInternal)
+            public init(
                 fields: [HTTPField],
                 headers: HTTP3PartialFrame.Headers,
                 streamID: QUICStreamID,
@@ -728,12 +741,17 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
             }
         }
 
-        package struct InformDecodeError {
-            package var error: HTTP3Error
-            package var headers: HTTP3PartialFrame.Headers
-            package var streamID: QUICStreamID
+        @_spi(PackageInternal)
+        public struct InformDecodeError {
+            @_spi(PackageInternal)
+            public var error: HTTP3Error
+            @_spi(PackageInternal)
+            public var headers: HTTP3PartialFrame.Headers
+            @_spi(PackageInternal)
+            public var streamID: QUICStreamID
 
-            package init(error: HTTP3Error, headers: HTTP3PartialFrame.Headers, streamID: QUICStreamID) {
+            @_spi(PackageInternal)
+            public init(error: HTTP3Error, headers: HTTP3PartialFrame.Headers, streamID: QUICStreamID) {
                 self.error = error
                 self.headers = headers
                 self.streamID = streamID
@@ -759,7 +777,8 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package mutating func decodeHeaders(
+    @_spi(PackageInternal)
+    public mutating func decodeHeaders(
         _ header: HTTP3PartialFrame.Headers,
         forStream streamID: QUICStreamID
     ) -> DecodeHeaderAction? {
@@ -870,7 +889,8 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
-    package enum StreamClosedAction {
+    @_spi(PackageInternal)
+    public enum StreamClosedAction {
         case sendDecoderInstruction(QPACKDecoderInstruction, shouldCloseConnection: Bool)
         case closeConnection
         case emitConnectionError(HTTP3Error)
@@ -882,7 +902,8 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
     ///   - seenEOF: Whether or not we saw an input close before the stream closed. That means we didn't drop any incoming data.
     ///   - streamType: The type of the stream which was closed.
     /// - Returns: The next action to take.
-    package mutating func streamClosed(
+    @_spi(PackageInternal)
+    public mutating func streamClosed(
         streamID: QUICStreamID,
         seenEOF: Bool,
         streamType: HTTP3StreamType
@@ -989,7 +1010,8 @@ package struct HTTP3ConnectionStateMachine: ~Copyable {
     }
 
     /// Assert that there are no open streams right now.
-    package func assertNoOpenStreams(logger: Logger) {
+    @_spi(PackageInternal)
+    public func assertNoOpenStreams(logger: Logger) {
         switch self.state {
         case .initialized(let initialized):
             let openStreams = initialized.streamIDTracker.openStreams

--- a/Sources/HTTP3/HTTP3Error.swift
+++ b/Sources/HTTP3/HTTP3Error.swift
@@ -41,7 +41,8 @@ public struct HTTP3Error: Error, Sendable {
     /// The location from which this error was thrown.
     public var location: SourceLocation
 
-    package init(
+    @_spi(PackageInternal)
+    public init(
         code: Code,
         message: String,
         cause: (any Error)?,
@@ -296,7 +297,8 @@ extension HTTP3Error {
             self.line = line
         }
 
-        package static func here(function: String = #function, file: String = #fileID, line: Int = #line) -> Self {
+        @_spi(PackageInternal)
+        public static func here(function: String = #function, file: String = #fileID, line: Int = #line) -> Self {
             SourceLocation(function: function, file: file, line: line)
         }
     }

--- a/Sources/HTTP3/HTTP3ErrorCode+QUICApplicationErrorCode.swift
+++ b/Sources/HTTP3/HTTP3ErrorCode+QUICApplicationErrorCode.swift
@@ -12,13 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIOQUICHelpers
+public import NIOQUICHelpers
 
 extension QUICApplicationErrorCode {
     /// Create a ``QUICApplicationErrorCode`` from an ``HTTP3ErrorCode``.
     ///
     /// HTTP/3 error codes are small constants (max `0x0202`) so this conversion is always valid.
-    package init(_ errorCode: HTTP3ErrorCode) {
+    @_spi(PackageInternal)
+    public init(_ errorCode: HTTP3ErrorCode) {
         self = QUICApplicationErrorCode(errorCode.rawValue)!
     }
 }

--- a/Sources/HTTP3/HTTP3Frame.swift
+++ b/Sources/HTTP3/HTTP3Frame.swift
@@ -89,13 +89,15 @@ public enum HTTP3PartialFrame: Hashable {
 }
 
 /// A representation of a single HTTP/3 frame type.
-package enum HTTP3FrameType: Hashable {
+@_spi(PackageInternal)
+public enum HTTP3FrameType: Hashable, Sendable {
     /// Attempts to parse a frame type.
     /// RFC 9114 § 7.2.8: Frame types that were used in HTTP/2 where there is no corresponding HTTP/3 frame have also been reserved (Section 11.2.1).
     /// These frame types MUST NOT be sent, and their receipt MUST be treated as a connection error of type H3\_FRAME\_UNEXPECTED.
     /// - Precondition: The value must be a QUIC-encodable integer, that means it must be between 1 and 2^62-1. Otherwise, this function will trap.
     /// - Throws: If given a forbidden frame type.
-    package init(rawValue: UInt64) throws(HTTP3Error) {
+    @_spi(PackageInternal)
+    public init(rawValue: UInt64) throws(HTTP3Error) {
         precondition(rawValue <= QUICEncodableInteger.maxValue, "Invalid frame type \(rawValue)")
         @inline(never)
         func forbiddenTypeError(
@@ -126,7 +128,8 @@ package enum HTTP3FrameType: Hashable {
         }
     }
 
-    package var rawValue: UInt64 {
+    @_spi(PackageInternal)
+    public var rawValue: UInt64 {
         switch self {
         case .data: return 0x00
         case .headers: return 0x01
@@ -318,7 +321,8 @@ extension HTTP3Frame.Headers {
     /// status code.
     ///
     /// - SeeAlso: https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2.
-    package var representsInterimResponse: Bool {
+    @_spi(PackageInternal)
+    public var representsInterimResponse: Bool {
         guard let status = self.fields.first(where: { $0.name == .status })?.value, let code = Int(status) else {
             return false
         }
@@ -327,27 +331,33 @@ extension HTTP3Frame.Headers {
 }
 
 extension HTTP3Frame {
-    package static func data(_ payload: ByteBuffer) -> Self {
+    @_spi(PackageInternal)
+    public static func data(_ payload: ByteBuffer) -> Self {
         .data(.init(payload: payload))
     }
 
-    package static func headers(_ fields: [HTTPField]) -> Self {
+    @_spi(PackageInternal)
+    public static func headers(_ fields: [HTTPField]) -> Self {
         .headers(.init(fields: fields))
     }
 
-    package static func settings(_ settings: HTTP3Settings) -> Self {
+    @_spi(PackageInternal)
+    public static func settings(_ settings: HTTP3Settings) -> Self {
         .settings(.init(settings: settings))
     }
 
-    package static func cancelPush(_ id: HTTP3PushID) -> Self {
+    @_spi(PackageInternal)
+    public static func cancelPush(_ id: HTTP3PushID) -> Self {
         .cancelPush(CancelPush(pushID: id))
     }
 
-    package static func maxPushID(_ id: HTTP3PushID) -> Self {
+    @_spi(PackageInternal)
+    public static func maxPushID(_ id: HTTP3PushID) -> Self {
         .maxPushID(.init(id: id))
     }
 
-    package static func goaway(_ id: HTTP3GoawayID) -> Self {
+    @_spi(PackageInternal)
+    public static func goaway(_ id: HTTP3GoawayID) -> Self {
         .goaway(.init(id: id))
     }
 }

--- a/Sources/HTTP3/HTTP3Frame.swift
+++ b/Sources/HTTP3/HTTP3Frame.swift
@@ -13,31 +13,40 @@
 //===----------------------------------------------------------------------===//
 
 public import HTTPTypes
-package import QPACK
+@_spi(PackageInternal) public import QPACK
 
 public import struct NIOCore.ByteBuffer
 
 /// Represents a HTTP3 frame which has not been through the qpack decoder yet.
 ///
 /// The types are identical to ``HTTP3Frame`` except that the ``HTTP3PartialFrame/headers(_:)`` and ``HTTP3PartialFrame/pushPromise(_:)`` cases hold encoded field sections instead of fields.
-package enum HTTP3PartialFrame: Hashable {
+@_spi(PackageInternal)
+public enum HTTP3PartialFrame: Hashable {
     /// A headers frame for which we don't have the dynamic table references yet.
     /// Pass this to a QPACK decoder to get the full HTTP3Frame.
-    package struct Headers: Hashable, Sendable {
-        package let fieldSection: FieldSection
+    @_spi(PackageInternal)
+    public struct Headers: Hashable, Sendable {
+        @_spi(PackageInternal)
+        public let fieldSection: FieldSection
 
-        package init(fieldSection: FieldSection) {
+        @_spi(PackageInternal)
+        public init(fieldSection: FieldSection) {
             self.fieldSection = fieldSection
         }
     }
 
     /// A push promise frame for which we don't have the dynamic table references yet.
     /// Pass this to a QPACK decoder to get the full HTTP3Frame.
-    package struct PushPromise: Hashable, Sendable {
-        package let pushID: HTTP3PushID
-        package let fieldSection: FieldSection
+    @_spi(PackageInternal)
+    public struct PushPromise: Hashable, Sendable {
+        @_spi(PackageInternal)
+        public let pushID: HTTP3PushID
 
-        package init(pushID: HTTP3PushID, fieldSection: FieldSection) {
+        @_spi(PackageInternal)
+        public let fieldSection: FieldSection
+
+        @_spi(PackageInternal)
+        init(pushID: HTTP3PushID, fieldSection: FieldSection) {
             self.pushID = pushID
             self.fieldSection = fieldSection
         }
@@ -281,23 +290,23 @@ public enum HTTP3Frame: Hashable, Sendable {
 // because they are impossible to evolve, hence having structs in the first place.
 
 extension HTTP3PartialFrame {
-    package static func data(_ payload: ByteBuffer) -> Self {
+    static func data(_ payload: ByteBuffer) -> Self {
         .data(.init(payload: payload))
     }
 
-    package static func settings(_ settings: HTTP3Settings) -> Self {
+    static func settings(_ settings: HTTP3Settings) -> Self {
         .settings(.init(settings: settings))
     }
 
-    package static func cancelPush(_ id: HTTP3PushID) -> Self {
+    static func cancelPush(_ id: HTTP3PushID) -> Self {
         .cancelPush(.init(pushID: id))
     }
 
-    package static func maxPushID(_ id: HTTP3PushID) -> Self {
+    static func maxPushID(_ id: HTTP3PushID) -> Self {
         .maxPushID(.init(id: id))
     }
 
-    package static func goaway(_ id: HTTP3GoawayID) -> Self {
+    static func goaway(_ id: HTTP3GoawayID) -> Self {
         .goaway(.init(id: id))
     }
 }

--- a/Sources/HTTP3/HTTP3FrameDecoder.swift
+++ b/Sources/HTTP3/HTTP3FrameDecoder.swift
@@ -12,13 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import QPACK
+@_spi(PackageInternal) import QPACK
 
-package import struct NIOCore.ByteBuffer
+import struct NIOCore.ByteBuffer
 
 /// A decoder for ``HTTP3PartialFrame``.
-package struct HTTP3FrameDecoder: ~Copyable {
-    package typealias InboundOut = HTTP3PartialFrame
+struct HTTP3FrameDecoder: ~Copyable {
+    typealias InboundOut = HTTP3PartialFrame
 
     /// An enum indicating the next step when decoding HTTP/3 frames.
     private enum NextStep: Hashable {
@@ -46,11 +46,11 @@ package struct HTTP3FrameDecoder: ~Copyable {
     /// Indicates the next decoding step.
     private var nextStep: NextStep = .decodeFrameType
 
-    package init() {}
+    init() {}
 
     /// - Note: Any error thrown from here should be treated as a connection-level error.
     /// - Returns: A frame if one can be decoded from the available bytes, or `nil` if more bytes are needed.
-    package mutating func decode(buffer: inout ByteBuffer) throws(HTTP3Error) -> HTTP3PartialFrameOrUnknown? {
+    mutating func decode(buffer: inout ByteBuffer) throws(HTTP3Error) -> HTTP3PartialFrameOrUnknown? {
         while true {
             switch try self.next(buffer: &buffer) {
             case .returnFrame(let frame):
@@ -66,7 +66,7 @@ package struct HTTP3FrameDecoder: ~Copyable {
     }
 
     /// True if this decoder has consumed some bytes to start building up a frame, but has not completed doing so
-    package var hasPartialFrame: Bool {
+    var hasPartialFrame: Bool {
         switch self.nextStep {
         case .decodeFrameType:
             // The frame type is the first thing. If we're waiting for a frame type then we aren't mid-frame
@@ -278,7 +278,7 @@ extension ByteBuffer {
     }
 }
 
-package enum HTTP3PartialFrameOrUnknown: Hashable {
+enum HTTP3PartialFrameOrUnknown: Hashable {
     case known(HTTP3PartialFrame)
     case unknown
 }

--- a/Sources/HTTP3/HTTP3FrameDecoderStateMachine.swift
+++ b/Sources/HTTP3/HTTP3FrameDecoderStateMachine.swift
@@ -12,14 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import struct NIOCore.ByteBuffer
+import struct NIOCore.ByteBuffer
 
 /// Calls the decoder, and buffers bytes until a frame is ready.
 ///
 /// Call readBytes to give the decoder some bytes.
 /// Call decodeNext to get back one HTTP3PartialFrame at a time.
 /// This does not handle QPACK at all, hence returning partial frames.
-package struct HTTP3FrameDecoderStateMachine: ~Copyable {
+struct HTTP3FrameDecoderStateMachine: ~Copyable {
     enum State: ~Copyable {
         /// We have no unprocessed bytes.
         case idle
@@ -73,7 +73,7 @@ package struct HTTP3FrameDecoderStateMachine: ~Copyable {
 
     private let state: State
 
-    package init() {
+    init() {
         self.init(state: .idle)
     }
 
@@ -82,7 +82,7 @@ package struct HTTP3FrameDecoderStateMachine: ~Copyable {
     }
 
     /// Put bytes into the decoder. To get the resulting frames, call decodeNext.
-    package mutating func buffer(_ buffer: ByteBuffer) {
+    mutating func buffer(_ buffer: ByteBuffer) {
         switch consume self.state {
         case .idle:
             let decoder = HTTP3FrameDecoder()
@@ -144,7 +144,7 @@ package struct HTTP3FrameDecoderStateMachine: ~Copyable {
     /// Mark the input as closed.
     /// This consumes the state machine: you cannot do anything after closing the input.
     /// - Returns: True if there were buffered bytes which hadn't been used yet, which have now been lost.
-    package consuming func inputClosed() -> Bool {
+    consuming func inputClosed() -> Bool {
         switch consume self.state {
         case .idle:
             return false
@@ -180,19 +180,19 @@ extension HTTP3FrameDecoderStateMachine {
 
     /// The decoding buffer's `readerIndex`, or `nil` if not in the decoding state.
     /// - Note: This property is only intended to be used in tests.
-    package var _testOnlyBufferReaderIndex: Int? {
+    var _testOnlyBufferReaderIndex: Int? {
         self._testOnlyBuffer?.readerIndex
     }
 
     /// The decoding buffer's `writerIndex`, or `nil` if not in the decoding state.
     /// - Note: This property is only intended to be used in tests.
-    package var _testOnlyBufferWriterIndex: Int? {
+    var _testOnlyBufferWriterIndex: Int? {
         self._testOnlyBuffer?.writerIndex
     }
 
     /// The decoding buffer's `capacity`, or `nil` if not in the decoding state.
     /// - Note: This property is only intended to be used in tests.
-    package var _testOnlyBufferCapacity: Int? {
+    var _testOnlyBufferCapacity: Int? {
         self._testOnlyBuffer?.capacity
     }
 }

--- a/Sources/HTTP3/HTTP3FrameDecoderStateMachine.swift
+++ b/Sources/HTTP3/HTTP3FrameDecoderStateMachine.swift
@@ -97,7 +97,7 @@ package struct HTTP3FrameDecoderStateMachine: ~Copyable {
         }
     }
 
-    package enum DecodeAction {
+    enum DecodeAction {
         /// A frame has been read from the incoming bytes. You should call decodeNext() again to check if there are more frames available.
         case returnFrame(HTTP3PartialFrame)
         /// A frame of unknown type has been read from the incoming bytes. You should call decodeNext() again to check if there are more frames available.
@@ -112,7 +112,7 @@ package struct HTTP3FrameDecoderStateMachine: ~Copyable {
 
     /// Read out one decoded frame from the bytes previously put into the decoder.
     /// Call this in a loop to get all frames, until it returns none.
-    package mutating func decodeNext() -> DecodeAction {
+    mutating func decodeNext() -> DecodeAction {
         switch consume self.state {
         case .decoding(var decodingState):
             do {

--- a/Sources/HTTP3/HTTP3FrameEncoder.swift
+++ b/Sources/HTTP3/HTTP3FrameEncoder.swift
@@ -13,9 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import HTTPTypes
-import QPACK
+@_spi(PackageInternal) import QPACK
 
-package import struct NIOCore.ByteBuffer
+import struct NIOCore.ByteBuffer
 
 extension ByteBuffer {
     /// Write a single ``HTTP3PartialFrame`` into the ByteBuffer, and move the writer index to just after the frame.
@@ -26,7 +26,7 @@ extension ByteBuffer {
     /// - Parameters:
     /// - frame: The frame to be written to the `ByteBuffer`.
     /// - preferHuffmanEncoding: If true, huffman coding will be preferred where applicable, e.g. header field sections. It will not be used if doing so would use more space than not.
-    package mutating func writeHTTP3PartialFrame(_ frame: HTTP3PartialFrame, preferHuffmanEncoding: Bool) {
+    mutating func writeHTTP3PartialFrame(_ frame: HTTP3PartialFrame, preferHuffmanEncoding: Bool) {
         switch frame {
         case .data(let payload):
             self.writeEncodedInteger(HTTP3FrameType.data.rawValue, strategy: .quic)

--- a/Sources/HTTP3/HTTP3FrameValidator.swift
+++ b/Sources/HTTP3/HTTP3FrameValidator.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Validates incoming and outgoing frames to be a valid sequence for a given stream type.
-package enum HTTP3FrameValidator: ~Copyable {
+enum HTTP3FrameValidator: ~Copyable {
     case incomingControlStream(IncomingControlStreamValidator)
     case outgoingControlStream(OutgoingControlStreamValidator)
     case incomingPushStream(IncomingPushStreamValidator)
@@ -24,7 +24,7 @@ package enum HTTP3FrameValidator: ~Copyable {
     /// Checks the order of frames is valid for a control stream.
     /// I.e. first the settings, and then anything but settings after that.
     /// This works for outbound and inbound streams.
-    package struct ControlStreamSequenceValidator: ~Copyable {
+    struct ControlStreamSequenceValidator: ~Copyable {
         private enum State: ~Copyable {
             case awaitingSettings
             case gotSettings
@@ -128,7 +128,7 @@ package enum HTTP3FrameValidator: ~Copyable {
     /// Checks the order of frames is valid for a push stream.
     /// TODO: https://github.com/apple/swift-nio-http3/issues/1
     /// Not implemented yet,  only validates the frame types. This works for outbound and inbound streams.
-    package struct PushStreamSequenceValidator: ~Copyable {
+    struct PushStreamSequenceValidator: ~Copyable {
         private enum State: ~Copyable {
             case none
             case previousError
@@ -453,7 +453,7 @@ package enum HTTP3FrameValidator: ~Copyable {
     }
 
     /// The action to take when the inbound side of a stream closes.
-    package enum InboundClosedAction {
+    enum InboundClosedAction {
         /// We received the full request or response before the inbound closed. As such, there is nothing to do.
         case doNothing
 
@@ -466,54 +466,54 @@ package enum HTTP3FrameValidator: ~Copyable {
         case resetStream(HTTP3Error)
     }
 
-    package struct ServerRequestStreamValidator: ~Copyable {
+    struct ServerRequestStreamValidator: ~Copyable {
         private var underlying = RequestStreamValidator()
 
         /// Validates an inbound request frame.
-        package mutating func processInboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
+        mutating func processInboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
             self.underlying.processRequestFrame(frame)
         }
 
         /// Validates an outbound response frame.
-        package mutating func processOutboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
+        mutating func processOutboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
             self.underlying.processResponseFrame(frame)
         }
 
         /// Records that the inbound request stream has closed.
-        package mutating func processInboundClosed() -> InboundClosedAction {
+        mutating func processInboundClosed() -> InboundClosedAction {
             self.underlying.processInboundRequestStreamClosed()
         }
     }
 
-    package struct ClientRequestStreamValidator: ~Copyable {
+    struct ClientRequestStreamValidator: ~Copyable {
         private var underlying = RequestStreamValidator()
 
         /// Validates an inbound response frame.
-        package mutating func processInboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
+        mutating func processInboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
             self.underlying.processResponseFrame(frame)
         }
 
         /// Validates an outbound request frame.
-        package mutating func processOutboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
+        mutating func processOutboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
             self.underlying.processRequestFrame(frame)
         }
 
         /// Records that the inbound response stream has closed.
-        package func processInboundClosed() -> InboundClosedAction {
+        func processInboundClosed() -> InboundClosedAction {
             self.underlying.processInboundResponseStreamClosed()
         }
     }
 
     /// Checks that incoming frames are in the right order for a control stream, and that there are no outgoing frames.
-    package struct IncomingControlStreamValidator: ~Copyable {
+    struct IncomingControlStreamValidator: ~Copyable {
         private var sequenceValidator = ControlStreamSequenceValidator()
 
-        package mutating func processInboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
+        mutating func processInboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
             // The only thing to check is the ordering, we don't need to do anything more than the sequence validator
             self.sequenceValidator.processNextFrame(frame)
         }
 
-        package mutating func processOutboundFrame(_: HTTP3Frame) -> ProcessFrameAction {
+        mutating func processOutboundFrame(_: HTTP3Frame) -> ProcessFrameAction {
             .emitConnectionError(
                 HTTP3Error(
                     code: .invalidStream,
@@ -525,16 +525,16 @@ package enum HTTP3FrameValidator: ~Copyable {
             )
         }
 
-        package mutating func processInboundUnknownFrame() -> UnknownFrameAction {
+        mutating func processInboundUnknownFrame() -> UnknownFrameAction {
             self.sequenceValidator.processUnknownFrame()
         }
     }
 
     /// Checks that outgoing frames are in the right order for a control stream, and there are no incoming frames.
-    package struct OutgoingControlStreamValidator: ~Copyable {
+    struct OutgoingControlStreamValidator: ~Copyable {
         private var sequenceValidator = ControlStreamSequenceValidator()
 
-        package mutating func processInboundFrame(_: HTTP3Frame) -> ProcessFrameAction {
+        mutating func processInboundFrame(_: HTTP3Frame) -> ProcessFrameAction {
             .emitConnectionError(
                 HTTP3Error(
                     code: .invalidStream,
@@ -546,12 +546,12 @@ package enum HTTP3FrameValidator: ~Copyable {
             )
         }
 
-        package mutating func processOutboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
+        mutating func processOutboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
             // The only thing to check is the ordering, we don't need to do anything more than the sequence validator
             self.sequenceValidator.processNextFrame(frame)
         }
 
-        package mutating func processInboundUnknownFrame() -> UnknownFrameAction {
+        mutating func processInboundUnknownFrame() -> UnknownFrameAction {
             .emitConnectionError(
                 HTTP3Error(
                     code: .invalidStream,
@@ -565,15 +565,15 @@ package enum HTTP3FrameValidator: ~Copyable {
     }
 
     /// Checks that incoming frames are in the right order for a push stream, and there are no outgoing frames.
-    package struct IncomingPushStreamValidator: ~Copyable {
+    struct IncomingPushStreamValidator: ~Copyable {
         private var sequenceValidator = PushStreamSequenceValidator()
 
-        package mutating func processInboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
+        mutating func processInboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
             // The only thing to check is the ordering, we don't need to do anything more than the sequence validator
             self.sequenceValidator.processNextFrame(frame)
         }
 
-        package mutating func processOutboundFrame(_: HTTP3Frame) -> ProcessFrameAction {
+        mutating func processOutboundFrame(_: HTTP3Frame) -> ProcessFrameAction {
             .emitConnectionError(
                 HTTP3Error(
                     code: .invalidStream,
@@ -587,10 +587,10 @@ package enum HTTP3FrameValidator: ~Copyable {
     }
 
     /// Checks that outgoing frames are in the right order for a push stream, and there are no incoming frames.
-    package struct OutgoingPushStreamValidator: ~Copyable {
+    struct OutgoingPushStreamValidator: ~Copyable {
         private var sequenceValidator = PushStreamSequenceValidator()
 
-        package mutating func processInboundFrame(_: HTTP3Frame) -> ProcessFrameAction {
+        mutating func processInboundFrame(_: HTTP3Frame) -> ProcessFrameAction {
             .emitConnectionError(
                 HTTP3Error(
                     code: .invalidStream,
@@ -602,7 +602,7 @@ package enum HTTP3FrameValidator: ~Copyable {
             )
         }
 
-        package mutating func processOutboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
+        mutating func processOutboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
             // The only thing to check is the ordering, we don't need to do anything more than the sequence validator
             self.sequenceValidator.processNextFrame(frame)
         }
@@ -619,14 +619,14 @@ package enum HTTP3FrameValidator: ~Copyable {
         }
     }
 
-    package enum ProcessFrameAction {
+    enum ProcessFrameAction {
         case forwardFrame(HTTP3Frame)
         case emitConnectionError(HTTP3Error)
         case emitStreamError(HTTP3Error)
         case previousError
     }
 
-    package mutating func processInboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
+    mutating func processInboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
         switch consume self {
         case .incomingControlStream(var v):
             let result = v.processInboundFrame(frame)
@@ -655,7 +655,7 @@ package enum HTTP3FrameValidator: ~Copyable {
         }
     }
 
-    package mutating func processOutboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
+    mutating func processOutboundFrame(_ frame: HTTP3Frame) -> ProcessFrameAction {
         switch consume self {
         case .incomingControlStream(var v):
             let result = v.processOutboundFrame(frame)
@@ -684,13 +684,13 @@ package enum HTTP3FrameValidator: ~Copyable {
         }
     }
 
-    package enum UnknownFrameAction {
+    enum UnknownFrameAction {
         case dropFrame
         case emitConnectionError(HTTP3Error)
         case previousError
     }
 
-    package mutating func processInboundUnknownFrame() -> UnknownFrameAction {
+    mutating func processInboundUnknownFrame() -> UnknownFrameAction {
         // Only the control stream cares about unknown frames, the other streams can just drop it.
         switch consume self {
         case .incomingControlStream(var v):
@@ -717,7 +717,7 @@ package enum HTTP3FrameValidator: ~Copyable {
     }
 
     /// Records that the inbound side of the stream has closed.
-    package mutating func processInboundClosed() -> InboundClosedAction {
+    mutating func processInboundClosed() -> InboundClosedAction {
         switch self {
         case .incomingRequestStream(var validator):
             let result = validator.processInboundClosed()
@@ -749,7 +749,8 @@ package enum HTTP3FrameValidator: ~Copyable {
 }
 
 extension HTTP3Frame {
-    package var type: HTTP3FrameType {
+    @_spi(PackageInternal)
+    public var type: HTTP3FrameType {
         switch self {
         case .headers: return .headers
         case .data: return .data

--- a/Sources/HTTP3/HTTP3FrameValidator.swift
+++ b/Sources/HTTP3/HTTP3FrameValidator.swift
@@ -608,7 +608,7 @@ package enum HTTP3FrameValidator: ~Copyable {
         }
     }
 
-    package init(streamType: HTTP3StreamType.Framed, incoming: Bool) {
+    init(streamType: HTTP3StreamType.Framed, incoming: Bool) {
         switch (streamType, incoming) {
         case (.control, true): self = .incomingControlStream(.init())
         case (.request, true): self = .incomingRequestStream(.init())

--- a/Sources/HTTP3/HTTP3GoawayID.swift
+++ b/Sources/HTTP3/HTTP3GoawayID.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import NIOQUICHelpers
+import NIOQUICHelpers
 
 /// A struct representing the payload of a GOAWAY frame.
 ///
@@ -47,11 +47,11 @@ extension HTTP3GoawayID: CustomDebugStringConvertible {
 /// We need to be able to compare goaways internally, but we'll not conform to Comparable publicly.
 /// That is because comparing goaways is weird because a goaway id could represent a stream id or a push id and we don't know which it is.
 extension HTTP3GoawayID {
-    package static func < (lhs: HTTP3GoawayID, rhs: HTTP3GoawayID) -> Bool {
+    static func < (lhs: HTTP3GoawayID, rhs: HTTP3GoawayID) -> Bool {
         lhs.rawValue < rhs.rawValue
     }
 
-    package static func <= (lhs: HTTP3GoawayID, rhs: HTTP3GoawayID) -> Bool {
+    static func <= (lhs: HTTP3GoawayID, rhs: HTTP3GoawayID) -> Bool {
         lhs.rawValue <= rhs.rawValue
     }
 }
@@ -66,14 +66,14 @@ extension HTTP3GoawayID {
 
 extension QUICStreamID {
     /// A goaway ID sent from a server to a client represents a ``QUICStreamID``.
-    package init(goawayID: HTTP3GoawayID) {
+    init(goawayID: HTTP3GoawayID) {
         self.init(rawValue: goawayID.rawValue)
     }
 }
 
 extension HTTP3PushID {
     /// A goaway ID sent from a client to a server represents an ``HTTP3PushID``.
-    package init(goawayID: HTTP3GoawayID) {
+    init(goawayID: HTTP3GoawayID) {
         self.init(rawValue: goawayID.rawValue)
     }
 }

--- a/Sources/HTTP3/HTTP3Settings.swift
+++ b/Sources/HTTP3/HTTP3Settings.swift
@@ -54,7 +54,7 @@ public struct HTTP3Settings: Hashable, Sendable {
     }
 
     /// Make an empty settings instance.
-    package init() {}
+    init() {}
 
     /// Create a new HTTP3Settings.
     /// Any parameter which is set to nil or omitted will result in the default value being used as per RFC 9114.
@@ -210,7 +210,7 @@ extension ByteBuffer {
     ///
     /// - Warning: There must not be any extra readable bytes beyond a valid set of settings.
     /// - Throws: If there are any extra readable bytes beyond a valid set of settings, or any of the integers are unparseable.
-    package mutating func readHTTP3Settings() throws(HTTP3Error) -> HTTP3Settings {
+    mutating func readHTTP3Settings() throws(HTTP3Error) -> HTTP3Settings {
         var settings = HTTP3Settings()
 
         // We are going to decode the next setting until we have read the payload length
@@ -253,7 +253,7 @@ extension ByteBuffer {
     ///
     /// - Parameter settings: The settings to write.
     /// - Returns: The number of bytes written.
-    package mutating func writeHTTP3Settings(_ settings: HTTP3Settings) -> Int {
+    mutating func writeHTTP3Settings(_ settings: HTTP3Settings) -> Int {
         var bytesWritten = 0
         if settings.qpackBlockedStreams != 0 {
             bytesWritten += self.writeHTTP3Setting(

--- a/Sources/HTTP3/HTTP3StreamStateMachine.swift
+++ b/Sources/HTTP3/HTTP3StreamStateMachine.swift
@@ -458,7 +458,8 @@ package struct HTTP3StreamStateMachine: ~Copyable {
 
     private let state: State
 
-    package init(
+    @_spi(PackageInternal)
+    public init(
         streamType: HTTP3StreamType.Framed,
         incoming: Bool,
         preferHuffmanEncoding: Bool
@@ -474,7 +475,8 @@ package struct HTTP3StreamStateMachine: ~Copyable {
         self.state = state
     }
 
-    package enum WriteFrameAction {
+    @_spi(PackageInternal)
+    public enum WriteFrameAction {
         /// The frame's bytes were appended to the buffer you provided.
         case wroteBytes
         /// You should encode the given headers and call back with the result.
@@ -490,7 +492,8 @@ package struct HTTP3StreamStateMachine: ~Copyable {
     }
 
     /// Write out a frame by appending its encoded bytes to `buffer`.
-    package mutating func writeFrame(frame: HTTP3Frame, into buffer: inout ByteBuffer) -> WriteFrameAction {
+    @_spi(PackageInternal)
+    public mutating func writeFrame(frame: HTTP3Frame, into buffer: inout ByteBuffer) -> WriteFrameAction {
         switch self.state {
         case .idle(var idleState):
             guard idleState.readState.checkCanWrite() else {
@@ -528,7 +531,8 @@ package struct HTTP3StreamStateMachine: ~Copyable {
         }
     }
 
-    package enum HeaderEncodeResultAction {
+    @_spi(PackageInternal)
+    public enum HeaderEncodeResultAction {
         /// The header's bytes were appended to the buffer you provided.
         case wroteBytes
         /// This header can't be encoded because the stream is already in an error state.
@@ -537,7 +541,8 @@ package struct HTTP3StreamStateMachine: ~Copyable {
         case alreadyClosed
     }
 
-    package mutating func gotHeaderEncodeResult(
+    @_spi(PackageInternal)
+    public mutating func gotHeaderEncodeResult(
         _ result: HTTP3PartialFrame.Headers,
         from: [HTTPField],
         into buffer: inout ByteBuffer
@@ -564,7 +569,8 @@ package struct HTTP3StreamStateMachine: ~Copyable {
     }
 
     /// Tell the machine about incoming bytes.
-    package mutating func buffer(_ buffer: ByteBuffer) {
+    @_spi(PackageInternal)
+    public mutating func buffer(_ buffer: ByteBuffer) {
         // Buffer the bytes into the decoder as long as we didn't already hit an error
         switch self.state {
         case .idle(var idleState):
@@ -578,7 +584,8 @@ package struct HTTP3StreamStateMachine: ~Copyable {
         }
     }
 
-    package enum DecodeNextAction {
+    @_spi(PackageInternal)
+    public enum DecodeNextAction {
         /// A full frame is ready.
         case returnFrame(HTTP3Frame)
         /// An error happened at the connection level.
@@ -615,7 +622,8 @@ package struct HTTP3StreamStateMachine: ~Copyable {
     /// Read out the next frame if it is ready. This may ask you to run qpack on some partial headers.
     ///
     /// - Returns: The next action to be performed.
-    package mutating func decodeNext() -> DecodeNextAction {
+    @_spi(PackageInternal)
+    public mutating func decodeNext() -> DecodeNextAction {
         switch self.state {
         case .idle(var idleState):
             let readStateResult = idleState.readState.decodeNext()
@@ -693,7 +701,8 @@ package struct HTTP3StreamStateMachine: ~Copyable {
 
     /// Inform the state machine of a qpack decode result that has been previously been asked for.
     /// It is an error to call this function with a result for a partial header which wasn't asked for.
-    package mutating func gotHeaderDecodeResult(_ decoded: [HTTPField], from: HTTP3PartialFrame.Headers) {
+    @_spi(PackageInternal)
+    public mutating func gotHeaderDecodeResult(_ decoded: [HTTPField], from: HTTP3PartialFrame.Headers) {
         switch self.state {
         case .finished:
             // Ignore it, we don't care anymore
@@ -709,7 +718,8 @@ package struct HTTP3StreamStateMachine: ~Copyable {
     /// Inform the state machine of a qpack decode error for a header that the machine previously asked to decode.
     /// It is an error to call this function with a result for a partial header which wasn't asked for.
     /// This error will fail the stream. Connection-level errors should not be sent here.
-    package mutating func gotHeaderDecodeError(_ error: HTTP3Error, from: HTTP3PartialFrame.Headers) {
+    @_spi(PackageInternal)
+    public mutating func gotHeaderDecodeError(_ error: HTTP3Error, from: HTTP3PartialFrame.Headers) {
         switch self.state {
         case .finished:
             // Ignore it, we don't care anymore

--- a/Sources/HTTP3/HTTP3StreamStateMachine.swift
+++ b/Sources/HTTP3/HTTP3StreamStateMachine.swift
@@ -12,12 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import HTTPTypes
+public import HTTPTypes
 
-package import struct NIOCore.ByteBuffer
-package import struct NIOQUICHelpers.QUICApplicationErrorCode
+public import struct NIOCore.ByteBuffer
+public import struct NIOQUICHelpers.QUICApplicationErrorCode
 
-package struct HTTP3StreamStateMachine: ~Copyable {
+@_spi(PackageInternal)
+public struct HTTP3StreamStateMachine: ~Copyable {
     /// This state machine handles the reading side of the stream only.
     /// You call `buffer` to give it bytes, and continually call `decodeNext` to get out frames.
     /// Sometimes, decodeNext will return the `decodeHeader` action, in which case you need to decode those headers.
@@ -303,7 +304,8 @@ package struct HTTP3StreamStateMachine: ~Copyable {
             }
         }
 
-        package enum FinishType {
+        @_spi(PackageInternal)
+        public enum FinishType {
             /// We had seen EOF before the close.
             case sawEOF
             /// We hadn't seen EOF before the close.
@@ -605,7 +607,8 @@ package struct HTTP3StreamStateMachine: ~Copyable {
         /// The decodeNext() function should be called again to get the next action.
         case callAgain
 
-        package enum InputClosedAction {
+        @_spi(PackageInternal)
+        public enum InputClosedAction {
             /// A complete request/response was received before the input was closed. As such, we should just deliver
             /// the `inputClosed` event downstream.
             case emitEvent
@@ -732,7 +735,8 @@ package struct HTTP3StreamStateMachine: ~Copyable {
         }
     }
 
-    package mutating func inputClosed() {
+    @_spi(PackageInternal)
+    public mutating func inputClosed() {
         switch consume self.state {
         case .finished:
             // Why are we getting input closed after already closed?
@@ -746,12 +750,14 @@ package struct HTTP3StreamStateMachine: ~Copyable {
         }
     }
 
-    package enum ErrorCaughtAction {
+    @_spi(PackageInternal)
+    public enum ErrorCaughtAction {
         case emitStreamError(HTTP3Error)
     }
 
     /// Inform the state machine of a stream error which was caught on this stream.
-    package mutating func streamErrorCaught(errorCode: QUICApplicationErrorCode) -> ErrorCaughtAction? {
+    @_spi(PackageInternal)
+    public mutating func streamErrorCaught(errorCode: QUICApplicationErrorCode) -> ErrorCaughtAction? {
         // Preserve the peer's error code verbatim for reporting, even if it is
         // not one this library recognizes. The reaction is a generic stream
         // error (`.remoteStreamError`), which already satisfies RFC 9114 § 8's
@@ -786,14 +792,16 @@ package struct HTTP3StreamStateMachine: ~Copyable {
         }
     }
 
-    package enum FinishedAction: Hashable, Sendable {
+    @_spi(PackageInternal)
+    public enum FinishedAction: Hashable, Sendable {
         /// The stream has been closed. If `seenEOF` is false, then we potentially dropped incoming data.
         case streamClosed(seenEOF: Bool)
     }
 
     /// Inform the state machine that the stream is no longer open.
     /// - Note: You should call ``decodeNext()`` to unbuffer as much as possible before calling this function.
-    package mutating func closed() -> FinishedAction {
+    @_spi(PackageInternal)
+    public mutating func closed() -> FinishedAction {
         switch consume self.state {
         case .idle(let idle):
             let finishState = idle.readState.closed()

--- a/Sources/HTTP3/HTTP3StreamType.swift
+++ b/Sources/HTTP3/HTTP3StreamType.swift
@@ -12,12 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-package enum HTTP3StreamType: Sendable {
+@_spi(PackageInternal)
+public enum HTTP3StreamType: Sendable {
     case unidirectional(Unidirectional)
     case request  // Bidirectional streams must be request streams
 
     /// Unidirectional stream types.
-    package enum Unidirectional: Hashable, RawRepresentable, CustomStringConvertible, Sendable {
+    @_spi(PackageInternal)
+    public enum Unidirectional: Hashable, RawRepresentable, CustomStringConvertible, Sendable {
         /// Type 0x00. Carries HTTP3 frames such as settings, goaway, etc.
         case control
         /// Type 0x01. Carries HTTP3 frames to fulfill a previously promised push.
@@ -30,7 +32,8 @@ package enum HTTP3StreamType: Sendable {
         case unknown(raw: UInt64)
 
         /// RFC 9114 § 6.2 specifies the mapping.
-        package var rawValue: UInt64 {
+        @_spi(PackageInternal)
+        public var rawValue: UInt64 {
             switch self {
             case .control: return 0
             case .push: return 1
@@ -40,7 +43,8 @@ package enum HTTP3StreamType: Sendable {
             }
         }
 
-        package var description: String {
+        @_spi(PackageInternal)
+        public var description: String {
             switch self {
             case .control: return "control"
             case .push: return "push"
@@ -50,7 +54,8 @@ package enum HTTP3StreamType: Sendable {
             }
         }
 
-        package init(rawValue: UInt64) {
+        @_spi(PackageInternal)
+        public init(rawValue: UInt64) {
             precondition(rawValue <= QUICEncodableInteger.maxValue, "Invalid stream type \(rawValue)")
             switch rawValue {
             case 0:
@@ -70,12 +75,14 @@ package enum HTTP3StreamType: Sendable {
 
 extension HTTP3StreamType {
     /// Stream types which carry HTTP3 frames (other streams, e.g. qpack streams, do not). This is a subset of ``HTTP3StreamType``.
-    package enum Framed: Hashable, CustomStringConvertible, Sendable {
+    @_spi(PackageInternal)
+    public enum Framed: Hashable, CustomStringConvertible, Sendable {
         case request
         case push
         case control
 
-        package var description: String {
+        @_spi(PackageInternal)
+        public var description: String {
             switch self {
             case .request: return "request"
             case .push: return "push"
@@ -84,7 +91,8 @@ extension HTTP3StreamType {
         }
     }
 
-    package init(_ framed: Framed) {
+    @_spi(PackageInternal)
+    public init(_ framed: Framed) {
         switch framed {
         case .request:
             self = .request

--- a/Sources/HTTP3/PseudoHeaders.swift
+++ b/Sources/HTTP3/PseudoHeaders.swift
@@ -12,12 +12,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import HTTPTypes
+import HTTPTypes
 
 extension HTTPField.Name {
-    package static var method: HTTPField.Name { .init(parsed: ":method")! }
-    package static var scheme: HTTPField.Name { .init(parsed: ":scheme")! }
-    package static var authority: HTTPField.Name { .init(parsed: ":authority")! }
-    package static var path: HTTPField.Name { .init(parsed: ":path")! }
-    package static var status: HTTPField.Name { .init(parsed: ":status")! }
+    static var method: HTTPField.Name { .init(parsed: ":method")! }
+    static var scheme: HTTPField.Name { .init(parsed: ":scheme")! }
+    static var authority: HTTPField.Name { .init(parsed: ":authority")! }
+    static var path: HTTPField.Name { .init(parsed: ":path")! }
+    static var status: HTTPField.Name { .init(parsed: ":status")! }
 }

--- a/Sources/HTTP3/QPACK/FieldSectionQueue.swift
+++ b/Sources/HTTP3/QPACK/FieldSectionQueue.swift
@@ -21,20 +21,20 @@ package enum FieldSectionQueueError: Error, Hashable, Sendable {
 }
 
 /// A queue of FieldSections which cannot yet be decoded.
-package struct FieldSectionQueue {
+struct FieldSectionQueue {
     /// An entry in the queue.
     /// `Comparable` and `Equatable` are implemented based on the ``FieldSectionPrefix/requiredInsertCount`` only.
-    package struct Entry: Sendable, Comparable {
+    struct Entry: Sendable, Comparable {
         /// The original full headers.
-        package var headers: HTTP3PartialFrame.Headers
+        var headers: HTTP3PartialFrame.Headers
         /// The prefix of the message to be decoded.
-        package var prefix: FieldSectionPrefix
+        var prefix: FieldSectionPrefix
         /// The field lines to decode.
-        package var lines: [FieldLine]
+        var lines: [FieldLine]
         /// The id of the stream we received this message on.
-        package var streamID: QUICStreamID
+        var streamID: QUICStreamID
 
-        package init(
+        init(
             headers: HTTP3PartialFrame.Headers,
             prefix: FieldSectionPrefix,
             lines: [FieldLine],
@@ -46,11 +46,11 @@ package struct FieldSectionQueue {
             self.streamID = streamID
         }
 
-        package static func < (lhs: Entry, rhs: Entry) -> Bool {
+        static func < (lhs: Entry, rhs: Entry) -> Bool {
             lhs.prefix.requiredInsertCount < rhs.prefix.requiredInsertCount
         }
 
-        package static func == (lhs: Entry, rhs: Entry) -> Bool {
+        static func == (lhs: Entry, rhs: Entry) -> Bool {
             lhs.prefix.requiredInsertCount == rhs.prefix.requiredInsertCount
         }
     }
@@ -66,7 +66,7 @@ package struct FieldSectionQueue {
     }
 
     /// Pop an entry with a required insert count ≤ `availableInsertCount`, if any such entry exists.
-    package mutating func popIfDecodable(availableInsertCount: Int) -> Entry? {
+    mutating func popIfDecodable(availableInsertCount: Int) -> Entry? {
         guard let nextItem = entries.min, nextItem.prefix.requiredInsertCount <= availableInsertCount else {
             return nil
         }
@@ -75,7 +75,7 @@ package struct FieldSectionQueue {
     }
 
     /// Add an entry to the queue.
-    package mutating func add(_ entry: Entry) throws(FieldSectionQueueError) {
+    mutating func add(_ entry: Entry) throws(FieldSectionQueueError) {
         if self.entries.count == self.maxItems {
             throw FieldSectionQueueError.reachedMaxSize
         }
@@ -86,14 +86,14 @@ package struct FieldSectionQueue {
     }
 
     /// Remove all entries in the queue which correspond to the given streamID.
-    package mutating func removeAll(forStream streamID: QUICStreamID) {
+    mutating func removeAll(forStream streamID: QUICStreamID) {
         // Fairly expensive operation, but only called when a stream closes uncleanly, which should be rare.
         // Also, this heap should never be very big anyway, at most equal to the number of open streams.
         self.entries = .init(self.entries.unordered.filter { $0.streamID != streamID })
     }
 
     /// - Parameter maxItems: The maximum number of items that may be in the queue at any one time.
-    package init(maxItems: Int) {
+    init(maxItems: Int) {
         self.maxItems = maxItems
     }
 }

--- a/Sources/HTTP3/QPACK/FieldSectionQueue.swift
+++ b/Sources/HTTP3/QPACK/FieldSectionQueue.swift
@@ -14,7 +14,7 @@
 
 import HeapModule
 package import NIOQUICHelpers
-package import QPACK
+@_spi(PackageInternal) import QPACK
 
 package enum FieldSectionQueueError: Error, Hashable, Sendable {
     case reachedMaxSize

--- a/Sources/HTTP3/QPACK/FieldSectionQueue.swift
+++ b/Sources/HTTP3/QPACK/FieldSectionQueue.swift
@@ -13,10 +13,10 @@
 //===----------------------------------------------------------------------===//
 
 import HeapModule
-package import NIOQUICHelpers
+import NIOQUICHelpers
 @_spi(PackageInternal) import QPACK
 
-package enum FieldSectionQueueError: Error, Hashable, Sendable {
+enum FieldSectionQueueError: Error, Hashable, Sendable {
     case reachedMaxSize
 }
 
@@ -61,7 +61,7 @@ struct FieldSectionQueue {
     private var entries: Heap<Entry> = .init()
 
     /// Exposed for testing. A list of all the entries in the queue. Not in any particular order.
-    package var _allEntries: [Entry] {
+    var _allEntries: [Entry] {
         self.entries.unordered
     }
 

--- a/Sources/HTTP3/QPACK/QPACKStateMachine.swift
+++ b/Sources/HTTP3/QPACK/QPACKStateMachine.swift
@@ -12,10 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import DequeModule
-package import HTTPTypes
+import DequeModule
+import HTTPTypes
 import Logging
-package import NIOQUICHelpers
+import NIOQUICHelpers
 @_spi(PackageInternal) import QPACK
 
 /// A state machine which holds qpack encoder and decoder.

--- a/Sources/HTTP3/QPACK/QPACKStateMachine.swift
+++ b/Sources/HTTP3/QPACK/QPACKStateMachine.swift
@@ -21,7 +21,7 @@ package import QPACK
 /// A state machine which holds qpack encoder and decoder.
 /// You can ask it to encode/decode things, and inform it of incoming instructions.
 /// It will then return actions to be taken.
-package struct QPACKStateMachine: ~Copyable {
+struct QPACKStateMachine: ~Copyable {
     struct EncoderStateMachine: ~Copyable {
         private enum State: ~Copyable {
             /// The remote side has not yet told us what dynamic table size to use, so we must assume 0, ie use a static encoder.
@@ -284,19 +284,19 @@ package struct QPACKStateMachine: ~Copyable {
     private var decoderQueue: FieldSectionQueue
     private var outboundDecoderInstructionQueue: OutboundDecoderInstructionQueue
 
-    package init(decoderMaxTableSize: Int, decoderMaxBlockedStreams: Int) {
+    init(decoderMaxTableSize: Int, decoderMaxBlockedStreams: Int) {
         self.encoderState = .init()
         self.qpackDecoder = .init(dynamicTableMaxCapacity: decoderMaxTableSize)
         self.decoderQueue = .init(maxItems: decoderMaxBlockedStreams)
         self.outboundDecoderInstructionQueue = .init()
     }
 
-    package enum GotRemoteSettingsAction {
+    enum GotRemoteSettingsAction {
         case makeEncoderInstructionStream
     }
 
     /// Call this when the settings have been received from the remote. This must never be called more than once.
-    package mutating func receivedRemoteSettings(
+    mutating func receivedRemoteSettings(
         maxQueueSize: Int,
         effectiveDynamicTableSize: Int
     ) -> GotRemoteSettingsAction? {
@@ -306,24 +306,24 @@ package struct QPACKStateMachine: ~Copyable {
         )
     }
 
-    package enum OutboundEncoderStreamReadyAction: Hashable, Sendable {
+    enum OutboundEncoderStreamReadyAction: Hashable, Sendable {
         case sendEncoderInstruction(QPACKEncoderInstruction?)
     }
 
     /// Call this when the outbound encoder stream is ready. It is an error to call this when not asked for (via ``GotRemoteSettingsAction``).
     /// It is also an error to call this twice.
-    package mutating func outboundEncoderStreamReady() -> OutboundEncoderStreamReadyAction {
+    mutating func outboundEncoderStreamReady() -> OutboundEncoderStreamReadyAction {
         switch self.encoderState.outboundEncoderStreamReady() {
         case .sendEncoderInstruction(let instruction):
             return .sendEncoderInstruction(instruction)
         }
     }
 
-    package enum OutboundDecoderStreamReadyAction: Hashable, Sendable {
+    enum OutboundDecoderStreamReadyAction: Hashable, Sendable {
         case sendDecoderInstructions(Deque<QPACKDecoderInstruction>)
     }
 
-    package mutating func outboundDecoderStreamReady() -> OutboundDecoderStreamReadyAction? {
+    mutating func outboundDecoderStreamReady() -> OutboundDecoderStreamReadyAction? {
         switch self.outboundDecoderInstructionQueue.outboundDecoderStreamReady() {
         case .sendDecoderInstructions(let instructions):
             return .sendDecoderInstructions(instructions)
@@ -332,11 +332,11 @@ package struct QPACKStateMachine: ~Copyable {
         }
     }
 
-    package mutating func encodeHeaders(_ headers: [HTTPField], forStream streamID: QUICStreamID) -> QPACKEncodeResult {
+    mutating func encodeHeaders(_ headers: [HTTPField], forStream streamID: QUICStreamID) -> QPACKEncodeResult {
         self.encoderState.encodeHeaders(headers, forStream: streamID)
     }
 
-    package enum DecodeHeaderAction {
+    enum DecodeHeaderAction {
         /// Send this qpack decode result to the relevant stream.
         case informDecodeResult(InformDecodeResult)
 
@@ -346,13 +346,13 @@ package struct QPACKStateMachine: ~Copyable {
         /// Send a connection-level error.
         case emitConnectionError(HTTP3Error)
 
-        package struct InformDecodeResult: Hashable, Sendable {
-            package var fields: [HTTPField]
-            package var headers: HTTP3PartialFrame.Headers
-            package var streamID: QUICStreamID
-            package var instructionToWrite: QPACKDecoderInstruction?
+        struct InformDecodeResult: Hashable, Sendable {
+            var fields: [HTTPField]
+            var headers: HTTP3PartialFrame.Headers
+            var streamID: QUICStreamID
+            var instructionToWrite: QPACKDecoderInstruction?
 
-            package init(
+            init(
                 fields: [HTTPField],
                 headers: HTTP3PartialFrame.Headers,
                 streamID: QUICStreamID,
@@ -365,7 +365,7 @@ package struct QPACKStateMachine: ~Copyable {
             }
         }
 
-        package struct InformDecodeError {
+        struct InformDecodeError {
             package var error: HTTP3Error
             package var headers: HTTP3PartialFrame.Headers
             package var streamID: QUICStreamID
@@ -378,7 +378,7 @@ package struct QPACKStateMachine: ~Copyable {
         }
     }
 
-    package mutating func decodeHeaders(
+    mutating func decodeHeaders(
         _ headers: HTTP3PartialFrame.Headers,
         forStream streamID: QUICStreamID
     ) -> DecodeHeaderAction? {
@@ -455,7 +455,7 @@ package struct QPACKStateMachine: ~Copyable {
 
     /// Check if any previously-queued decode is now decodable.
     /// This function should be called repeatedly after new input (eg. new incoming instructions) until it returns nil
-    package mutating func checkPendingDecodes() -> DecodeHeaderAction? {
+    mutating func checkPendingDecodes() -> DecodeHeaderAction? {
         guard let entry = self.decoderQueue.popIfDecodable(availableInsertCount: self.qpackDecoder.insertCount) else {
             return nil
         }
@@ -536,7 +536,7 @@ package struct QPACKStateMachine: ~Copyable {
         }
     }
 
-    package enum IncomingEncoderInstructionAction {
+    enum IncomingEncoderInstructionAction {
         /// The new incoming instruction resulted in previously-blocked headers now being decodable.
         case sendDecoderInstruction(QPACKDecoderInstruction)
         case emitConnectionError(HTTP3Error)
@@ -544,7 +544,7 @@ package struct QPACKStateMachine: ~Copyable {
 
     /// Inform the state machine of a new incoming instruction. After this, you should call ``checkPendingDecodes()`` because the new instruction
     /// may have unblocked a pending decode.
-    package mutating func receivedIncomingEncoderInstruction(
+    mutating func receivedIncomingEncoderInstruction(
         _ instruction: QPACKEncoderInstruction
     ) -> IncomingEncoderInstructionAction? {
         @inline(never)
@@ -573,11 +573,11 @@ package struct QPACKStateMachine: ~Copyable {
         }
     }
 
-    package enum IncomingDecoderInstructionAction {
+    enum IncomingDecoderInstructionAction {
         case emitConnectionError(HTTP3Error)
     }
 
-    package mutating func receivedIncomingDecoderInstruction(
+    mutating func receivedIncomingDecoderInstruction(
         _ instruction: QPACKDecoderInstruction
     ) -> IncomingDecoderInstructionAction? {
         switch self.encoderState.receivedIncomingDecoderInstruction(instruction) {
@@ -588,7 +588,7 @@ package struct QPACKStateMachine: ~Copyable {
         }
     }
 
-    package enum RequestStreamClosedAction: Hashable, Sendable {
+    enum RequestStreamClosedAction: Hashable, Sendable {
         case sendDecoderInstruction(QPACKDecoderInstruction)
     }
 
@@ -601,7 +601,7 @@ package struct QPACKStateMachine: ~Copyable {
     ///     knows not to expect acks from any field sections it may have sent on this stream.
     ///     See RFC 9204 § 2.2.2.2 for more info.
     /// - Returns: Actions to take next.
-    package mutating func requestStreamClosed(streamID: QUICStreamID, seenEOF: Bool) -> RequestStreamClosedAction? {
+    mutating func requestStreamClosed(streamID: QUICStreamID, seenEOF: Bool) -> RequestStreamClosedAction? {
         if seenEOF {
             // We currently don't need to do anything for cleanly-closed streams
             return nil

--- a/Sources/HTTP3/QPACK/QPACKStateMachine.swift
+++ b/Sources/HTTP3/QPACK/QPACKStateMachine.swift
@@ -16,7 +16,7 @@ package import DequeModule
 package import HTTPTypes
 import Logging
 package import NIOQUICHelpers
-package import QPACK
+@_spi(PackageInternal) import QPACK
 
 /// A state machine which holds qpack encoder and decoder.
 /// You can ask it to encode/decode things, and inform it of incoming instructions.

--- a/Sources/HTTP3/QPACK/QPACKStateMachine.swift
+++ b/Sources/HTTP3/QPACK/QPACKStateMachine.swift
@@ -366,11 +366,11 @@ struct QPACKStateMachine: ~Copyable {
         }
 
         struct InformDecodeError {
-            package var error: HTTP3Error
-            package var headers: HTTP3PartialFrame.Headers
-            package var streamID: QUICStreamID
+            var error: HTTP3Error
+            var headers: HTTP3PartialFrame.Headers
+            var streamID: QUICStreamID
 
-            package init(error: HTTP3Error, headers: HTTP3PartialFrame.Headers, streamID: QUICStreamID) {
+            init(error: HTTP3Error, headers: HTTP3PartialFrame.Headers, streamID: QUICStreamID) {
                 self.error = error
                 self.headers = headers
                 self.streamID = streamID

--- a/Sources/HTTP3/QUICStreamID+Extensions.swift
+++ b/Sources/HTTP3/QUICStreamID+Extensions.swift
@@ -12,10 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import NIOQUICHelpers
+public import NIOQUICHelpers
 
 extension QUICStreamID {
-    package var isUnidirectional: Bool {
+    var isUnidirectional: Bool {
         switch self.type {
         case .clientInitiatedUnidirectional, .serverInitiatedUnidirectional:
             return true
@@ -24,11 +24,12 @@ extension QUICStreamID {
         }
     }
 
-    package var isBidirectional: Bool {
+    @_spi(PackageInternal)
+    public var isBidirectional: Bool {
         !self.isUnidirectional
     }
 
-    package var isClientInitiated: Bool {
+    var isClientInitiated: Bool {
         switch self.type {
         case .clientInitiatedUnidirectional, .clientInitiatedBidirectional:
             return true
@@ -37,7 +38,7 @@ extension QUICStreamID {
         }
     }
 
-    package var isServerInitiated: Bool {
+    var isServerInitiated: Bool {
         !self.isClientInitiated
     }
 }

--- a/Sources/HTTP3/StreamIDTracker.swift
+++ b/Sources/HTTP3/StreamIDTracker.swift
@@ -12,10 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import NIOQUICHelpers
+import NIOQUICHelpers
 
 /// Keeps track of what streams are open.
-package struct StreamIDTracker {
+struct StreamIDTracker {
     /// All currently open streams
     private(set) var openStreams = Set<QUICStreamID>()
 
@@ -28,10 +28,10 @@ package struct StreamIDTracker {
     /// So index 0 is client-initiated bidi, index 1 is server-initiated bidi, index 2 is client-initiated uni and index 3 is server-initiated uni.
     private var highestIDSeenByType: [QUICStreamID?] = [nil, nil, nil, nil]
 
-    package init() {}
+    init() {}
 
     /// Call this whenever a new stream (of any type) opens.
-    package mutating func streamOpened(id: QUICStreamID) {
+    mutating func streamOpened(id: QUICStreamID) {
         assert(!self.openStreams.contains(id))
         self.openStreams.insert(id)
 
@@ -49,7 +49,7 @@ package struct StreamIDTracker {
 
     /// Call this when a stream is closed. Returns true if that stream actually existed.
     @discardableResult
-    package mutating func streamClosed(id: QUICStreamID) -> Bool {
+    mutating func streamClosed(id: QUICStreamID) -> Bool {
         if self.openStreams.remove(id) == nil {
             return false
         }
@@ -60,11 +60,11 @@ package struct StreamIDTracker {
     }
 
     /// - Returns: `true` if there are any open bidirectional streams, regardless of initiator
-    package func hasOpenRequestStreams() -> Bool {
+    func hasOpenRequestStreams() -> Bool {
         self.openBidirectionalStreamCount > 0
     }
 
-    package func getOpenStreamIDs(where predicate: (QUICStreamID) -> Bool) -> [QUICStreamID] {
+    func getOpenStreamIDs(where predicate: (QUICStreamID) -> Bool) -> [QUICStreamID] {
         self.openStreams.filter(predicate)
     }
 
@@ -73,7 +73,7 @@ package struct StreamIDTracker {
     ///
     /// If no client-initiated bidirectional streams have been received yet, returns stream ID 0, the lowest possible
     /// client-initiated bidirectional stream ID.
-    package func nextExpectedClientInitiatedBidirectionalStreamID() -> QUICStreamID {
+    func nextExpectedClientInitiatedBidirectionalStreamID() -> QUICStreamID {
         // Index 0 represents client-initiated bidirectional streams in `self.highestIDSeenByType`.
         if let highest = self.highestIDSeenByType[0] {
             return QUICStreamID(rawValue: highest.rawValue + 4)
@@ -83,7 +83,7 @@ package struct StreamIDTracker {
     }
 
     /// - Returns: `true` if the next id of the same type as the provided one would be equal to or greater than the provided one.
-    package func hasExhaustedSameTypeStreams(withIDsLessThan givenID: QUICStreamID) -> Bool {
+    func hasExhaustedSameTypeStreams(withIDsLessThan givenID: QUICStreamID) -> Bool {
         /// The stream type for the id we were given. This is determined by the last 2 bits. See RFC 9000 § 2.1
         let givenIDType = Int(givenID.rawValue & 0b11)
         /// The highest ID that we have seen so far for streams of this type

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -12,12 +12,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@_spi(PackageInternal) import HTTP3
 import HTTPTypes
 import Logging
 import NIOCore
 import NIOQUICHelpers
-import QPACK
+@_spi(PackageInternal) import QPACK
 
 /// This class owns the connection state machine and is responsible for opening streams and sending frames.
 /// I.e. it coordinates everything across the connection, including qpack.

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -30,7 +30,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
     private let streamCreator: QUICStreamCreator
     /// Send the connection error out to the peer. We should only call this if the connection state machine says so.
     /// If we want to send a connection error, it needs to go through the connection state machine first.
-    package var emitConnectionError: (HTTP3Error) -> Void
+    var emitConnectionError: (HTTP3Error) -> Void
     private let preferHuffmanEncoding: Bool
     private let logger: Logger
     /// Instances of stream handlers which need to be pinged whenever a dynamic table entry is added.

--- a/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
@@ -150,7 +150,7 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
     ///   - inboundRequestStreamInitializer: A closure which will be called for every incoming request stream.
     ///   - internalInboundStreamInitializer: A closure which will be called for every incoming non-request stream.
     /// - Returns: A ``HTTP3ConnectionHandler``.
-    package static func server(
+    static func server(
         eventLoop: any EventLoop,
         configuration: HTTP3ServerConfiguration,
         settings: HTTP3Settings,
@@ -275,7 +275,7 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
     ///   - inboundPushStreamInitializer: A closure which will be called for every incoming push stream.
     ///   - internalInboundStreamInitializer: A closure which will be called for every incoming non-push stream.
     /// - Returns: A ``HTTP3ConnectionHandler``.
-    package static func client(
+    static func client(
         eventLoop: any EventLoop,
         configuration: HTTP3ClientConfiguration,
         settings: HTTP3Settings,
@@ -442,7 +442,7 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
     }
 
     /// Exposed for testing
-    package func createUnidirectionalStream<InitializerOutput: Sendable>(
+    func createUnidirectionalStream<InitializerOutput: Sendable>(
         ofType type: HTTP3StreamType.Unidirectional,
         streamInitializer: @escaping (HTTP3StreamInitializerParameters) -> EventLoopFuture<InitializerOutput>
     ) -> EventLoopFuture<InitializerOutput> {

--- a/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
@@ -12,13 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-public import HTTP3
+@_spi(PackageInternal) public import HTTP3
 public import Logging
 public import NIOCore
 public import NIOQUICHelpers
 
 /// What to do when a new stream comes inbound.
-package enum H3InboundStreamInitializer {
+enum H3InboundStreamInitializer {
     /// Call yield on a multiplexer to give it the new stream channel.
     case multiplexer(any StreamMultiplexerContinuation)
     /// Call a closure with the new stream channel.

--- a/Sources/NIOHTTP3/HTTP3ConnectionMultiplexer.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionMultiplexer.swift
@@ -138,7 +138,7 @@ public struct HTTP3ClientConnection<
 /// Internal type to abstract away the `Output` type of the multiplexer. This means we are going through an existential
 /// in the `HTTP3ConnectionHandler` when yielding a new `Channel`. However, this is okay for now otherwise
 /// we would need to make the handler generic as well.
-package protocol StreamMultiplexerContinuation: Sendable {
+protocol StreamMultiplexerContinuation: Sendable {
     /// We have to do a bit of an awkward dance here to carry the `Output` between the initializer and the continuation where
     /// we yield to. That's why we are using `Any` here to avoid making the handler generic.
     func initialize(parameters: HTTP3StreamInitializerParameters) -> EventLoopFuture<any Sendable>

--- a/Sources/NIOHTTP3/HTTP3ConnectionMultiplexer.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionMultiplexer.swift
@@ -148,15 +148,15 @@ protocol StreamMultiplexerContinuation: Sendable {
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension HTTP3ServerConnection: StreamMultiplexerContinuation {
-    package func initialize(parameters: HTTP3StreamInitializerParameters) -> EventLoopFuture<any Sendable> {
+    func initialize(parameters: HTTP3StreamInitializerParameters) -> EventLoopFuture<any Sendable> {
         self.inboundStreamInitializer(parameters).map { $0 as any Sendable }
     }
 
-    package func yield(output: any Sendable) {
+    func yield(output: any Sendable) {
         self.inboundStreamsContinuation.yield(output as! Output)
     }
 
-    package func finish() {
+    func finish() {
         self.inboundStreamsContinuation.finish()
     }
 }
@@ -284,7 +284,7 @@ public struct HTTP3ClientConnectionMultiplexer<
     ///   - connectionInitializer: Use this to add handlers to the outgoing connection channel.
     ///   - inboundPushStreamInitializer: Called for each incoming push stream.
     /// - Returns: The future containing the result of the connection initializer, and the underlying connection channel.
-    package func createConnection<Output>(
+    func createConnection<Output>(
         serverName: String,
         remoteAddress: SocketAddress,
         connectionInitializer: (@Sendable (any Channel) -> EventLoopFuture<Void>)?,
@@ -307,7 +307,7 @@ public struct HTTP3ClientConnectionMultiplexer<
         }
     }
 
-    package func createConnectionChannel(
+    func createConnectionChannel(
         serverName: String,
         remoteAddress: SocketAddress,
         connectionInitializer: (@Sendable (any Channel) -> EventLoopFuture<Void>)?

--- a/Sources/NIOHTTP3/HTTP3Datagram.swift
+++ b/Sources/NIOHTTP3/HTTP3Datagram.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-internal import HTTP3
+@_spi(PackageInternal) import HTTP3
 public import NIOCore
 public import NIOQUICHelpers
 

--- a/Sources/NIOHTTP3/HTTP3OutboundControlStateMachine.swift
+++ b/Sources/NIOHTTP3/HTTP3OutboundControlStateMachine.swift
@@ -12,11 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import DequeModule
-package import HTTP3
+import DequeModule
+@_spi(PackageInternal) import HTTP3
 
 /// State machine used by the handler which is on the outbound control stream.
-package struct HTTP3OutboundControlStreamStateMachine: ~Copyable {
+struct HTTP3OutboundControlStreamStateMachine: ~Copyable {
     private enum State: ~Copyable {
         /// The handler isn't active yet. Any frame which we have tried to send so far gets buffered here.
         /// The first of those should be the settings.
@@ -27,7 +27,7 @@ package struct HTTP3OutboundControlStreamStateMachine: ~Copyable {
 
     private let state: State
 
-    package init(settings: HTTP3Settings) {
+    init(settings: HTTP3Settings) {
         // First frame must always be settings
         self.init(state: .inactive(buffer: [.settings(settings)]))
     }
@@ -36,11 +36,11 @@ package struct HTTP3OutboundControlStreamStateMachine: ~Copyable {
         self.state = state
     }
 
-    package enum ChannelActiveAction: Hashable, Sendable {
+    enum ChannelActiveAction: Hashable, Sendable {
         case sendFrames(Deque<HTTP3Frame>)
     }
 
-    package mutating func channelActive() -> ChannelActiveAction? {
+    mutating func channelActive() -> ChannelActiveAction? {
         switch consume self.state {
         case .inactive(let buffer):
             self = .init(state: .active)
@@ -50,11 +50,11 @@ package struct HTTP3OutboundControlStreamStateMachine: ~Copyable {
         }
     }
 
-    package enum SendGoawayAction: Hashable, Sendable {
+    enum SendGoawayAction: Hashable, Sendable {
         case send
     }
 
-    package mutating func sendGoaway(id: HTTP3GoawayID) -> SendGoawayAction? {
+    mutating func sendGoaway(id: HTTP3GoawayID) -> SendGoawayAction? {
         switch consume self.state {
         case .inactive(var buffer):
             // We're not active yet so we have to buffer the goaway (behind the settings, and any other goaways)

--- a/Sources/NIOHTTP3/HTTP3OutboundControlStreamHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3OutboundControlStreamHandler.swift
@@ -12,25 +12,25 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import HTTP3
-package import NIOCore
+@_spi(PackageInternal) import HTTP3
+import NIOCore
 
 /// Handler to be used on the outbound control stream only.
 /// Will send the initial settings frame when the channel is ready.
-package final class HTTP3OutboundControlStreamHandler: ChannelInboundHandler {
-    package typealias OutboundIn = HTTP3Frame
-    package typealias OutboundOut = HTTP3Frame
-    package typealias InboundIn = Never
+final class HTTP3OutboundControlStreamHandler: ChannelInboundHandler {
+    typealias OutboundIn = HTTP3Frame
+    typealias OutboundOut = HTTP3Frame
+    typealias InboundIn = Never
 
     private var context: ChannelHandlerContext?
 
     private var state: HTTP3OutboundControlStreamStateMachine
 
-    package init(settings: HTTP3Settings) {
+    init(settings: HTTP3Settings) {
         self.state = .init(settings: settings)
     }
 
-    package func handlerAdded(context: ChannelHandlerContext) {
+    func handlerAdded(context: ChannelHandlerContext) {
         guard self.context == nil else {
             fatalError("HTTP3OutboundControlStreamHandler must only be added to one Channel")
         }
@@ -40,18 +40,18 @@ package final class HTTP3OutboundControlStreamHandler: ChannelInboundHandler {
         }
     }
 
-    package func channelInactive(context: ChannelHandlerContext) {
+    func channelInactive(context: ChannelHandlerContext) {
         // Break reference cycle
         self.context = nil
         context.fireChannelInactive()
     }
 
-    package func handlerRemoved(context: ChannelHandlerContext) {
+    func handlerRemoved(context: ChannelHandlerContext) {
         // Break reference cycle
         self.context = nil
     }
 
-    package func channelActive(context: ChannelHandlerContext) {
+    func channelActive(context: ChannelHandlerContext) {
         self.handleChannelActive(context: context)
         context.fireChannelActive()
     }
@@ -73,7 +73,7 @@ package final class HTTP3OutboundControlStreamHandler: ChannelInboundHandler {
 
     /// Send a GOAWAY frame to the peer.
     /// - Parameter id: The ID to be sent. If the remote is a client, this should be a client-initiated, bidirectional stream ID. If the remote is a server, this should be a push ID.
-    package func sendGoaway(id: HTTP3GoawayID) {
+    func sendGoaway(id: HTTP3GoawayID) {
         switch self.state.sendGoaway(id: id) {
         case .send:
             guard let context = self.context else {

--- a/Sources/NIOHTTP3/HTTP3StreamHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3StreamHandler.swift
@@ -12,16 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import HTTP3
-package import HTTPTypes
-package import Logging
+import HTTP3
+import HTTPTypes
+import Logging
 package import NIOCore
-package import NIOQUICHelpers
+import NIOQUICHelpers
 
 /// This handler should be added to every incoming and outgoing HTTP/3 stream which carries HTTP frames.
 /// It handles encoding and decoding of these frames.
 /// It will only pass through valid frames, and handles things such as QPACK header decoding.
-package final class HTTP3StreamHandler: ChannelDuplexHandler {
+final class HTTP3StreamHandler: ChannelDuplexHandler {
     package typealias InboundIn = ByteBuffer
     package typealias InboundOut = HTTP3Frame
 

--- a/Sources/NIOHTTP3/HTTP3StreamHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3StreamHandler.swift
@@ -15,18 +15,18 @@
 @_spi(PackageInternal) import HTTP3
 import HTTPTypes
 import Logging
-package import NIOCore
+import NIOCore
 import NIOQUICHelpers
 
 /// This handler should be added to every incoming and outgoing HTTP/3 stream which carries HTTP frames.
 /// It handles encoding and decoding of these frames.
 /// It will only pass through valid frames, and handles things such as QPACK header decoding.
 final class HTTP3StreamHandler: ChannelDuplexHandler {
-    package typealias InboundIn = ByteBuffer
-    package typealias InboundOut = HTTP3Frame
+    typealias InboundIn = ByteBuffer
+    typealias InboundOut = HTTP3Frame
 
-    package typealias OutboundIn = HTTP3Frame
-    package typealias OutboundOut = ByteBuffer
+    typealias OutboundIn = HTTP3Frame
+    typealias OutboundOut = ByteBuffer
 
     private let streamID: QUICStreamID
     private let streamType: HTTP3StreamType.Framed
@@ -56,7 +56,7 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
 
     private let logger: Logger
 
-    package init(
+    init(
         stateMachine: consuming HTTP3StreamStateMachine,
         streamID: QUICStreamID,
         streamType: HTTP3StreamType.Framed,
@@ -76,14 +76,14 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
         self.logger = logger
     }
 
-    package func handlerAdded(context: ChannelHandlerContext) {
+    func handlerAdded(context: ChannelHandlerContext) {
         guard self.context == nil else {
             fatalError("HTTP3StreamHandler must only be added to one Channel")
         }
         self.context = context
     }
 
-    package func channelInactive(context: ChannelHandlerContext) {
+    func channelInactive(context: ChannelHandlerContext) {
         self.logger.trace("HTTP3StreamHandler.channelInactive")
 
         // Don't leak the pending promise.
@@ -157,7 +157,7 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
         context.fireChannelInactive()
     }
 
-    package func handlerRemoved(context: ChannelHandlerContext) {
+    func handlerRemoved(context: ChannelHandlerContext) {
         // Don't leak the pending promise.
         self.pendingBytes = nil
         self.pendingPromise.take()?.fail(ChannelError.ioOnClosedChannel)
@@ -166,13 +166,13 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
         self.context = nil
     }
 
-    package func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let bytes = self.unwrapInboundIn(data)
         self.logger.trace("HTTP3StreamHandler.channelRead", metadata: [LoggingKeys.bytes: "\(bytes.readableBytes)"])
         self.stateMachine.buffer(bytes)
     }
 
-    package func channelReadComplete(context: ChannelHandlerContext) {
+    func channelReadComplete(context: ChannelHandlerContext) {
         self.logger.trace("HTTP3StreamHandler.channelReadComplete")
         // In channelRead, we buffer bytes into the state machine.
         // Now it's time to try and read out as many full frames as possible.
@@ -227,7 +227,7 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
         }
     }
 
-    package func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let frame = self.unwrapOutboundIn(data)
         self.logger.trace("HTTP3StreamHandler.write", metadata: [LoggingKeys.h3FrameType: "\(frame.type)"])
 
@@ -283,12 +283,12 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
         }
     }
 
-    package func flush(context: ChannelHandlerContext) {
+    func flush(context: ChannelHandlerContext) {
         self.emitPendingBytes(context: context)
         context.flush()
     }
 
-    package func close(
+    func close(
         context: ChannelHandlerContext,
         mode: CloseMode,
         promise: EventLoopPromise<Void>?
@@ -310,7 +310,7 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
         }
     }
 
-    package func errorCaught(context: ChannelHandlerContext, error: any Error) {
+    func errorCaught(context: ChannelHandlerContext, error: any Error) {
         switch error {
         case let error as QUICStreamResetError:
             self.logger.trace("Caught RESET_STREAM")
@@ -347,7 +347,7 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
     }
 
     /// Call this when `header` has been decoded.
-    package func onQPACKDecodeResult(fields: [HTTPField], forHeaders headers: HTTP3PartialFrame.Headers) {
+    func onQPACKDecodeResult(fields: [HTTPField], forHeaders headers: HTTP3PartialFrame.Headers) {
         self.logger.trace("HTTP3StreamHandler.onQPACKDecodeResult")
         guard let context = self.context else {
             // The stream must have been created and registered to get QPACK events and thus already have
@@ -361,7 +361,7 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
     }
 
     /// Call this if an error is encountered whilst trying to decode `header`.
-    package func onQPACKDecodeError(_ error: HTTP3Error, forHeaders headers: HTTP3PartialFrame.Headers) {
+    func onQPACKDecodeError(_ error: HTTP3Error, forHeaders headers: HTTP3PartialFrame.Headers) {
         guard let context = self.context else {
             // The stream must have been created an registered to get QPACK events and thus already have
             // the context available. Since pending decodes are dropped when the stream closes it must
@@ -373,7 +373,7 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
         self.channelReadComplete(context: context)
     }
 
-    package func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+    func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
         if (event as? ChannelEvent) == ChannelEvent.inputClosed {
             // We don't pass this through immediately, we buffer it behind any buffered reads to prevent overtaking.
             self.logger.trace("HTTP3StreamHandler intercepted inputClosed")
@@ -386,7 +386,7 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
 
     /// A GOAWAY frame was sent with an ID lower than or equal to that of this stream.
     /// I.e., we will NOT process this stream, and we should just close it.
-    package func cancelStreamDueToSendingGoaway() {
+    func cancelStreamDueToSendingGoaway() {
         guard let context = self.context else {
             assertionFailure("Tried to send cancel stream before handler was added")
             return
@@ -414,7 +414,7 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
 
     /// A GOAWAY frame was received with an ID lower than or equal to that of this stream.
     /// I.e., the remote will NOT process this stream, and we should just close it.
-    package func cancelStreamDueToReceivedGoaway() {
+    func cancelStreamDueToReceivedGoaway() {
         guard let context = self.context else {
             assertionFailure("Tried to propagate stream cancelation before handler was added")
             return
@@ -440,7 +440,7 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
     }
 
     /// The remote closed the connection (CONNECTION_CLOSE). All active streams must be cancelled.
-    package func cancelStreamDueToConnectionClose() {
+    func cancelStreamDueToConnectionClose() {
         guard let context = self.context else {
             assertionFailure("Tried to cancel stream before handler was added")
             return

--- a/Sources/NIOHTTP3/HTTP3StreamHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3StreamHandler.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@_spi(PackageInternal) import HTTP3
 import HTTPTypes
 import Logging
 package import NIOCore

--- a/Sources/NIOHTTP3/HTTP3ToHTTPCodecs.swift
+++ b/Sources/NIOHTTP3/HTTP3ToHTTPCodecs.swift
@@ -187,7 +187,7 @@ extension HTTPResponsePart: HTTPMessagePart {
         }
     }
 
-    package static func end() -> HTTPResponsePart {
+    static func end() -> HTTPResponsePart {
         .end(nil)
     }
 }

--- a/Sources/NIOHTTP3/HTTP3ToHTTPCodecs.swift
+++ b/Sources/NIOHTTP3/HTTP3ToHTTPCodecs.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public import HTTP3
+@_spi(PackageInternal) public import HTTP3
 import HTTPTypes
 public import NIOCore
 public import NIOHTTPTypes

--- a/Sources/NIOHTTP3/HTTP3ToHTTPCodecs.swift
+++ b/Sources/NIOHTTP3/HTTP3ToHTTPCodecs.swift
@@ -13,11 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 public import HTTP3
-package import HTTPTypes
+import HTTPTypes
 public import NIOCore
 public import NIOHTTPTypes
 
-package protocol HTTPMessagePart {
+protocol HTTPMessagePart {
     static func head(fields: [HTTPField]) throws(HTTP3Error) -> Self
     static func body(buffer: ByteBuffer) -> Self
     static func end(trailers: [HTTPField]) throws(HTTP3Error) -> Self
@@ -40,7 +40,7 @@ private func invalidHeadersError(message: String, location: HTTP3Error.SourceLoc
 }
 
 extension HTTPRequestPart: HTTPMessagePart {
-    package static func head(fields: [HTTPField]) throws(HTTP3Error) -> HTTPRequestPart {
+    static func head(fields: [HTTPField]) throws(HTTP3Error) -> HTTPRequestPart {
         let request: HTTPRequest
         do {
             request = try HTTPRequest(parsed: fields)
@@ -115,11 +115,11 @@ extension HTTPRequestPart: HTTPMessagePart {
         return .head(request)
     }
 
-    package static func body(buffer: ByteBuffer) -> HTTPRequestPart {
+    static func body(buffer: ByteBuffer) -> HTTPRequestPart {
         .body(buffer)
     }
 
-    package static func end(trailers: [HTTPField]) throws(HTTP3Error) -> HTTPRequestPart {
+    static func end(trailers: [HTTPField]) throws(HTTP3Error) -> HTTPRequestPart {
         if trailers.isEmpty {
             return .end(nil)
         } else {
@@ -137,13 +137,13 @@ extension HTTPRequestPart: HTTPMessagePart {
         }
     }
 
-    package static func end() -> HTTPRequestPart {
+    static func end() -> HTTPRequestPart {
         .end(nil)
     }
 }
 
 extension HTTPResponsePart: HTTPMessagePart {
-    package static func head(fields: [HTTPField]) throws(HTTP3Error) -> HTTPResponsePart {
+    static func head(fields: [HTTPField]) throws(HTTP3Error) -> HTTPResponsePart {
         let response: HTTPResponse
         do {
             response = try HTTPResponse(parsed: fields)
@@ -165,11 +165,11 @@ extension HTTPResponsePart: HTTPMessagePart {
         return .head(response)
     }
 
-    package static func body(buffer: ByteBuffer) -> HTTPResponsePart {
+    static func body(buffer: ByteBuffer) -> HTTPResponsePart {
         .body(buffer)
     }
 
-    package static func end(trailers: [HTTPField]) throws(HTTP3Error) -> HTTPResponsePart {
+    static func end(trailers: [HTTPField]) throws(HTTP3Error) -> HTTPResponsePart {
         if trailers.isEmpty {
             return .end(nil)
         } else {
@@ -194,7 +194,7 @@ extension HTTPResponsePart: HTTPMessagePart {
 
 /// Process HTTP3Frames into HTTPMessageParts.
 /// Use this to convert incoming frames into message parts.
-package struct HTTPMessageParsingStateMachine<Part: HTTPMessagePart> {
+struct HTTPMessageParsingStateMachine<Part: HTTPMessagePart> {
     enum State {
         case awaitingHeaders
         case awaitingBodyOrTrailers
@@ -204,14 +204,14 @@ package struct HTTPMessageParsingStateMachine<Part: HTTPMessagePart> {
 
     private var state = State.awaitingHeaders
 
-    package init() {}
+    init() {}
 
-    package enum ProcessFrameAction {
+    enum ProcessFrameAction {
         case returnPart(Part)
         case emitError(HTTP3Error)
     }
 
-    package mutating func processFrame(frame: HTTP3Frame) -> ProcessFrameAction? {
+    mutating func processFrame(frame: HTTP3Frame) -> ProcessFrameAction? {
         switch self.state {
         case .failed:
             return .none
@@ -262,11 +262,11 @@ package struct HTTPMessageParsingStateMachine<Part: HTTPMessagePart> {
         }
     }
 
-    package enum InputClosedAction {
+    enum InputClosedAction {
         case returnPart(Part)
     }
 
-    package mutating func inputClosed() -> InputClosedAction? {
+    mutating func inputClosed() -> InputClosedAction? {
         switch self.state {
         case .awaitingHeaders:
             // The input was closed without even receiving a head part. This case is handled appropriately by

--- a/Sources/NIOHTTP3/HTTP3UnidirectionalStreamTypeDecoderHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3UnidirectionalStreamTypeDecoderHandler.swift
@@ -40,8 +40,7 @@ final class HTTP3UnidirectionalStreamTypeDecoderHandler: ChannelInboundHandler, 
     private var state = HTTP3UnidirectionalStreamTypeDecoderStateMachine()
     private var context: ChannelHandlerContext?
 
-    init(logger: Logger, callback: @escaping (HTTP3StreamType.Unidirectional) -> EventLoopFuture<DecodeResult>)
-    {
+    init(logger: Logger, callback: @escaping (HTTP3StreamType.Unidirectional) -> EventLoopFuture<DecodeResult>) {
         self.logger = logger
         self.callback = callback
     }

--- a/Sources/NIOHTTP3/HTTP3UnidirectionalStreamTypeDecoderHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3UnidirectionalStreamTypeDecoderHandler.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import HTTP3
+@_spi(PackageInternal) package import HTTP3
 package import Logging
 package import NIOCore
 import NIOQUICHelpers

--- a/Sources/NIOHTTP3/HTTP3UnidirectionalStreamTypeDecoderHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3UnidirectionalStreamTypeDecoderHandler.swift
@@ -12,20 +12,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(PackageInternal) package import HTTP3
-package import Logging
-package import NIOCore
+@_spi(PackageInternal) import HTTP3
+import Logging
+import NIOCore
 import NIOQUICHelpers
 
 /// Read the incoming stream header (the first byte). Inform the callback when the stream type is known.
 /// Buffers all data after the stream type until told to release the queue.
 /// This is only used for unidirectional streams. Bidirectional streams do not send a stream header. Their type is always request.
 /// See RFC 9114 § 6.2 for more information.
-package final class HTTP3UnidirectionalStreamTypeDecoderHandler: ChannelInboundHandler, RemovableChannelHandler {
-    package typealias InboundIn = ByteBuffer
-    package typealias InboundOut = ByteBuffer
+final class HTTP3UnidirectionalStreamTypeDecoderHandler: ChannelInboundHandler, RemovableChannelHandler {
+    typealias InboundIn = ByteBuffer
+    typealias InboundOut = ByteBuffer
 
-    package enum DecodeResult {
+    enum DecodeResult {
         /// Return this from the callback when the stream type is valid, and the pipeline is ready to receive data.
         case ready
     }
@@ -40,26 +40,26 @@ package final class HTTP3UnidirectionalStreamTypeDecoderHandler: ChannelInboundH
     private var state = HTTP3UnidirectionalStreamTypeDecoderStateMachine()
     private var context: ChannelHandlerContext?
 
-    package init(logger: Logger, callback: @escaping (HTTP3StreamType.Unidirectional) -> EventLoopFuture<DecodeResult>)
+    init(logger: Logger, callback: @escaping (HTTP3StreamType.Unidirectional) -> EventLoopFuture<DecodeResult>)
     {
         self.logger = logger
         self.callback = callback
     }
 
-    package func handlerAdded(context: ChannelHandlerContext) {
+    func handlerAdded(context: ChannelHandlerContext) {
         guard self.context == nil else {
             fatalError("HTTP3UnidirectionalStreamTypeDecoderHandler must only be added to one Channel")
         }
         self.context = context
     }
 
-    package func channelInactive(context: ChannelHandlerContext) {
+    func channelInactive(context: ChannelHandlerContext) {
         // Break reference cycle
         self.context = nil
         context.fireChannelInactive()
     }
 
-    package func handlerRemoved(context: ChannelHandlerContext) {
+    func handlerRemoved(context: ChannelHandlerContext) {
         // Break reference cycle
         self.context = nil
     }
@@ -106,7 +106,7 @@ package final class HTTP3UnidirectionalStreamTypeDecoderHandler: ChannelInboundH
         )
     }
 
-    package func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let data = self.unwrapInboundIn(data)
         switch self.state.buffer(data: data) {
         case .none: break

--- a/Sources/NIOHTTP3/HTTP3UnidirectionalStreamTypeDecoderStateMachine.swift
+++ b/Sources/NIOHTTP3/HTTP3UnidirectionalStreamTypeDecoderStateMachine.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import DequeModule
-package import HTTP3
+@_spi(PackageInternal) import HTTP3
 
 package import struct NIOCore.ByteBuffer
 
@@ -97,13 +97,13 @@ package struct HTTP3UnidirectionalStreamTypeDecoderStateMachine: ~Copyable {
         }
     }
 
-    package enum ChannelReadAction: Hashable {
+    enum ChannelReadAction: Hashable {
         /// Stream type should be sent to the callback.
         case gotStreamType(HTTP3StreamType.Unidirectional)
     }
 
     /// The handler has received data.
-    package mutating func buffer(data: ByteBuffer) -> ChannelReadAction? {
+    mutating func buffer(data: ByteBuffer) -> ChannelReadAction? {
         switch consume self.state {
         case .idle:
             // No existing queue, no existing stream type. Try to get it.

--- a/Sources/NIOHTTP3/HTTP3UnidirectionalStreamTypeDecoderStateMachine.swift
+++ b/Sources/NIOHTTP3/HTTP3UnidirectionalStreamTypeDecoderStateMachine.swift
@@ -15,7 +15,7 @@
 import DequeModule
 @_spi(PackageInternal) import HTTP3
 
-package import struct NIOCore.ByteBuffer
+import struct NIOCore.ByteBuffer
 
 /// This state machine helps to decode the type of an incoming unidirectional stream.
 /// The first bytes received on the stream tell us the type of the stream (they form a length-prefixed integer).
@@ -25,7 +25,7 @@ package import struct NIOCore.ByteBuffer
 /// Once you know the type, and have set up downstream handlers accordingly, you must call `unbufferElement` to get the bytes out from this state machines buffers.
 /// `unbufferElement` must be called repeatedly until it returns nil.
 /// Once it returns nil, no method on this state machine should ever be called again, and the handler holding it should be removed from the pipeline.
-package struct HTTP3UnidirectionalStreamTypeDecoderStateMachine: ~Copyable {
+struct HTTP3UnidirectionalStreamTypeDecoderStateMachine: ~Copyable {
     private enum State: ~Copyable {
         /// Nothing has happened yet. We don't know the stream type.
         case idle
@@ -41,7 +41,7 @@ package struct HTTP3UnidirectionalStreamTypeDecoderStateMachine: ~Copyable {
 
     private let state: State
 
-    package init() {
+    init() {
         self.init(state: .idle)
     }
 
@@ -49,7 +49,7 @@ package struct HTTP3UnidirectionalStreamTypeDecoderStateMachine: ~Copyable {
         self.state = state
     }
 
-    package enum UnbufferAction: Hashable {
+    enum UnbufferAction: Hashable {
         /// The given bytebuffer should be fired down the pipeline.
         case release(ByteBuffer)
         /// There is nothing left in the queue. You should not call any method on this state machine again.
@@ -61,7 +61,7 @@ package struct HTTP3UnidirectionalStreamTypeDecoderStateMachine: ~Copyable {
     /// Do not call before stream type is known.
     /// Call this in a loop until .done is returned.
     /// Do not call after .done is returned.
-    package mutating func unbufferElement() -> UnbufferAction {
+    mutating func unbufferElement() -> UnbufferAction {
         switch consume self.state {
         case .readIncompleteStreamType:
             fatalError("Can't unbuffer element before knowing the stream type")
@@ -82,7 +82,7 @@ package struct HTTP3UnidirectionalStreamTypeDecoderStateMachine: ~Copyable {
         }
     }
 
-    package mutating func abortReading() {
+    mutating func abortReading() {
         switch consume self.state {
         case .readIncompleteStreamType:
             fatalError("Can't abort reading before knowing the stream type")

--- a/Sources/NIOHTTP3/QPACK+NIO.swift
+++ b/Sources/NIOHTTP3/QPACK+NIO.swift
@@ -12,11 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIOCore
-package import QPACK
+public import NIOCore
+@_spi(PackageInternal) public import QPACK
 
 extension QPACKDecoderInstructionDecoder: NIOSingleStepByteToMessageDecoder {}
 extension QPACKEncoderInstructionDecoder: NIOSingleStepByteToMessageDecoder {}
 
+@_spi(PackageInternal)
 extension QPACKDecoderInstructionEncoder: MessageToByteEncoder {}
+
+@_spi(PackageInternal)
 extension QPACKEncoderInstructionEncoder: MessageToByteEncoder {}

--- a/Sources/NIOHTTP3/QPACK+SPI.swift
+++ b/Sources/NIOHTTP3/QPACK+SPI.swift
@@ -14,7 +14,7 @@
 
 public import HTTPTypes
 public import NIOQUICHelpers
-@_spi(PackageInternal) private import QPACK
+@_spi(PackageInternal) @_spi(Benchmarks) private import QPACK
 
 // QPACK isn't a library product, so add entry points for benchmarks here under SPI.
 @_spi(Benchmarks)

--- a/Sources/NIOHTTP3/QPACK+SPI.swift
+++ b/Sources/NIOHTTP3/QPACK+SPI.swift
@@ -14,7 +14,7 @@
 
 public import HTTPTypes
 public import NIOQUICHelpers
-private import QPACK
+@_spi(PackageInternal) private import QPACK
 
 // QPACK isn't a library product, so add entry points for benchmarks here under SPI.
 @_spi(Benchmarks)

--- a/Sources/NIOHTTP3/QPACKInboundDecoderStreamHandler.swift
+++ b/Sources/NIOHTTP3/QPACKInboundDecoderStreamHandler.swift
@@ -12,14 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import NIOCore
+import NIOCore
 @_spi(PackageInternal) import QPACK
 
 /// Read decoder instructions from a channel and give them to a callback.
 /// This belongs on the incoming decoder stream.
 /// The decoder instructions come from the remote decoder and should be fed into the local encoder.
 final class QPACKInboundDecoderStreamHandler: ChannelInboundHandler {
-    package typealias InboundIn = QPACKDecoderInstruction
+    typealias InboundIn = QPACKDecoderInstruction
 
     /// Called when an incoming instruction is successfully read.
     private var onReceivedInstruction: (QPACKDecoderInstruction) -> Void

--- a/Sources/NIOHTTP3/QPACKInboundDecoderStreamHandler.swift
+++ b/Sources/NIOHTTP3/QPACKInboundDecoderStreamHandler.swift
@@ -13,12 +13,12 @@
 //===----------------------------------------------------------------------===//
 
 package import NIOCore
-package import QPACK
+@_spi(PackageInternal) import QPACK
 
 /// Read decoder instructions from a channel and give them to a callback.
 /// This belongs on the incoming decoder stream.
 /// The decoder instructions come from the remote decoder and should be fed into the local encoder.
-package final class QPACKInboundDecoderStreamHandler: ChannelInboundHandler {
+final class QPACKInboundDecoderStreamHandler: ChannelInboundHandler {
     package typealias InboundIn = QPACKDecoderInstruction
 
     /// Called when an incoming instruction is successfully read.
@@ -26,7 +26,7 @@ package final class QPACKInboundDecoderStreamHandler: ChannelInboundHandler {
     /// Called when an error is caught on this channel.
     private var onError: (any Error) -> Void
 
-    package init(
+    init(
         onReceivedInstruction: @escaping (QPACKDecoderInstruction) -> Void,
         onError: @escaping (any Error) -> Void
     ) {
@@ -34,12 +34,12 @@ package final class QPACKInboundDecoderStreamHandler: ChannelInboundHandler {
         self.onError = onError
     }
 
-    package func errorCaught(context: ChannelHandlerContext, error: any Error) {
+    func errorCaught(context: ChannelHandlerContext, error: any Error) {
         self.onError(error)
         context.fireErrorCaught(error)
     }
 
-    package func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let instruction = unwrapInboundIn(data)
         self.onReceivedInstruction(instruction)
         context.fireChannelRead(data)

--- a/Sources/NIOHTTP3/QPACKInboundEncoderStreamHandler.swift
+++ b/Sources/NIOHTTP3/QPACKInboundEncoderStreamHandler.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import NIOCore
+import NIOCore
 @_spi(PackageInternal) import QPACK
 
 /// Read encoder instructions from a channel and give them to a callback.
@@ -34,12 +34,12 @@ final class QPACKInboundEncoderStreamHandler: ChannelInboundHandler {
         self.onError = onError
     }
 
-    package func errorCaught(context: ChannelHandlerContext, error: any Error) {
+    func errorCaught(context: ChannelHandlerContext, error: any Error) {
         self.onError(error)
         context.fireErrorCaught(error)
     }
 
-    package func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let instruction = unwrapInboundIn(data)
         self.onReceivedInstruction(instruction)
         context.fireChannelRead(data)

--- a/Sources/NIOHTTP3/QPACKInboundEncoderStreamHandler.swift
+++ b/Sources/NIOHTTP3/QPACKInboundEncoderStreamHandler.swift
@@ -13,20 +13,20 @@
 //===----------------------------------------------------------------------===//
 
 package import NIOCore
-package import QPACK
+@_spi(PackageInternal) import QPACK
 
 /// Read encoder instructions from a channel and give them to a callback.
 /// This belongs on the incoming encoder stream.
 /// The encoder instructions come from the remote encoder and should be fed into the local decoder.
-package final class QPACKInboundEncoderStreamHandler: ChannelInboundHandler {
-    package typealias InboundIn = QPACKEncoderInstruction
+final class QPACKInboundEncoderStreamHandler: ChannelInboundHandler {
+    typealias InboundIn = QPACKEncoderInstruction
 
     /// Called when an incoming instruction is successfully read.
     private var onReceivedInstruction: (QPACKEncoderInstruction) -> Void
     /// Called when an error is caught on this channel.
     private var onError: (any Error) -> Void
 
-    package init(
+    init(
         onReceivedInstruction: @escaping (QPACKEncoderInstruction) -> Void,
         onError: @escaping (any Error) -> Void
     ) {

--- a/Sources/NIOHTTP3/QPACKOutboundDecoderStreamHandler.swift
+++ b/Sources/NIOHTTP3/QPACKOutboundDecoderStreamHandler.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import NIOCore
+import NIOCore
 @_spi(PackageInternal) import QPACK
 
 final class QPACKOutboundDecoderStreamHandler: ChannelOutboundHandler {

--- a/Sources/NIOHTTP3/QPACKOutboundDecoderStreamHandler.swift
+++ b/Sources/NIOHTTP3/QPACKOutboundDecoderStreamHandler.swift
@@ -13,22 +13,22 @@
 //===----------------------------------------------------------------------===//
 
 package import NIOCore
-package import QPACK
+@_spi(PackageInternal) import QPACK
 
-package final class QPACKOutboundDecoderStreamHandler: ChannelOutboundHandler {
-    package typealias OutboundIn = QPACKDecoderInstruction
-    package typealias OutboundOut = QPACKDecoderInstruction
+final class QPACKOutboundDecoderStreamHandler: ChannelOutboundHandler {
+    typealias OutboundIn = QPACKDecoderInstruction
+    typealias OutboundOut = QPACKDecoderInstruction
 
     private var context: ChannelHandlerContext?
 
-    package init() {}
+    init() {}
 
-    package func handlerAdded(context: ChannelHandlerContext) {
+    func handlerAdded(context: ChannelHandlerContext) {
         assert(self.context == nil)
         self.context = context
     }
 
-    package func sendInstruction(_ instruction: QPACKDecoderInstruction) {
+    func sendInstruction(_ instruction: QPACKDecoderInstruction) {
         guard let context = self.context else {
             // This won't happen because the QPACK state machine will buffer outgoing instructions until the stream is ready
             assertionFailure("Tried to send instruction before handler was added")
@@ -37,7 +37,7 @@ package final class QPACKOutboundDecoderStreamHandler: ChannelOutboundHandler {
         context.writeAndFlush(self.wrapOutboundOut(instruction), promise: nil)
     }
 
-    package func sendInstructions(_ instructions: some Collection<QPACKDecoderInstruction>) {
+    func sendInstructions(_ instructions: some Collection<QPACKDecoderInstruction>) {
         guard !instructions.isEmpty else { return }
         guard let context = self.context else {
             // This won't happen because the QPACK state machine will buffer outgoing instructions until the stream is ready

--- a/Sources/NIOHTTP3/QPACKOutboundEncoderStreamHandler.swift
+++ b/Sources/NIOHTTP3/QPACKOutboundEncoderStreamHandler.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import NIOCore
+import NIOCore
 @_spi(PackageInternal) import QPACK
 
 final class QPACKOutboundEncoderStreamHandler: ChannelOutboundHandler {

--- a/Sources/NIOHTTP3/QPACKOutboundEncoderStreamHandler.swift
+++ b/Sources/NIOHTTP3/QPACKOutboundEncoderStreamHandler.swift
@@ -13,33 +13,33 @@
 //===----------------------------------------------------------------------===//
 
 package import NIOCore
-package import QPACK
+@_spi(PackageInternal) import QPACK
 
-package final class QPACKOutboundEncoderStreamHandler: ChannelOutboundHandler {
-    package typealias OutboundIn = QPACKEncoderInstruction
-    package typealias OutboundOut = QPACKEncoderInstruction
+final class QPACKOutboundEncoderStreamHandler: ChannelOutboundHandler {
+    typealias OutboundIn = QPACKEncoderInstruction
+    typealias OutboundOut = QPACKEncoderInstruction
 
     private var context: ChannelHandlerContext?
 
-    package init() {}
+    init() {}
 
-    package func handlerAdded(context: ChannelHandlerContext) {
+    func handlerAdded(context: ChannelHandlerContext) {
         assert(self.context == nil)
         self.context = context
     }
 
-    package func channelInactive(context: ChannelHandlerContext) {
+    func channelInactive(context: ChannelHandlerContext) {
         // Break reference cycle
         self.context = nil
         context.fireChannelInactive()
     }
 
-    package func handlerRemoved(context: ChannelHandlerContext) {
+    func handlerRemoved(context: ChannelHandlerContext) {
         // Break reference cycle
         self.context = nil
     }
 
-    package func sendInstructions(_ instructions: some Collection<QPACKEncoderInstruction>) {
+    func sendInstructions(_ instructions: some Collection<QPACKEncoderInstruction>) {
         guard !instructions.isEmpty else { return }
         guard let context = self.context else {
             // This won't happen because we don't use a dynamic QPACK encoder (and therefore don't send instructions) until
@@ -53,7 +53,7 @@ package final class QPACKOutboundEncoderStreamHandler: ChannelOutboundHandler {
         context.flush()
     }
 
-    package func sendInstruction(_ instruction: QPACKEncoderInstruction) {
+    func sendInstruction(_ instruction: QPACKEncoderInstruction) {
         guard let context = self.context else {
             // This won't happen because we don't use a dynamic QPACK encoder (and therefore don't send instructions) until
             // the encoder instruction stream is ready and this handler has been added

--- a/Sources/NIOHTTP3/StreamClosedHandler.swift
+++ b/Sources/NIOHTTP3/StreamClosedHandler.swift
@@ -15,7 +15,7 @@
 import Logging
 import NIOCore
 
-package struct StreamClosedHandlerStateMachine: ~Copyable {
+struct StreamClosedHandlerStateMachine: ~Copyable {
     private enum State: ~Copyable {
         // We have never been active.
         case notActive
@@ -31,16 +31,16 @@ package struct StreamClosedHandlerStateMachine: ~Copyable {
         self.state = state
     }
 
-    package init() {
+    init() {
         self.init(state: .notActive)
     }
 
-    package enum ChannelInactiveAction: Hashable {
+    enum ChannelInactiveAction: Hashable {
         case callOnStreamClosed
         case none
     }
 
-    package mutating func channelInactive() -> ChannelInactiveAction {
+    mutating func channelInactive() -> ChannelInactiveAction {
         switch consume self.state {
         case .active:
             // We were active and now we're not, so we're closed.
@@ -56,7 +56,7 @@ package struct StreamClosedHandlerStateMachine: ~Copyable {
         }
     }
 
-    package mutating func handlerAdded(isChannelActive: Bool) {
+    mutating func handlerAdded(isChannelActive: Bool) {
         switch consume self.state {
         case .active:
             assertionFailure("Handler added after channel active")
@@ -73,7 +73,7 @@ package struct StreamClosedHandlerStateMachine: ~Copyable {
         }
     }
 
-    package mutating func channelActive() {
+    mutating func channelActive() {
         switch consume self.state {
         case .active:
             assertionFailure("Handler active twice")
@@ -86,12 +86,12 @@ package struct StreamClosedHandlerStateMachine: ~Copyable {
         }
     }
 
-    package enum HandlerRemovedAction: Hashable {
+    enum HandlerRemovedAction: Hashable {
         case callOnStreamClosed
         case none
     }
 
-    package mutating func handlerRemoved() -> HandlerRemovedAction {
+    mutating func handlerRemoved() -> HandlerRemovedAction {
         switch consume self.state {
         case .notActive:
             // We were never active, and we've been removed, so we're 'closed'.

--- a/Sources/QPACK/DecodedValue.swift
+++ b/Sources/QPACK/DecodedValue.swift
@@ -17,7 +17,8 @@ package struct Decoded<Value: Sendable & Hashable>: Sendable, Hashable {
     var bytesRead: Int
 }
 
-package enum IntegerReadingError: Error, Hashable {
+@_spi(PackageInternal)
+public enum IntegerReadingError: Error, Hashable {
     /// The integer cannot be represented in the desired type.
     case unrepresentable
 }

--- a/Sources/QPACK/DecodedValue.swift
+++ b/Sources/QPACK/DecodedValue.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-package struct Decoded<Value: Sendable & Hashable>: Sendable, Hashable {
+struct Decoded<Value: Sendable & Hashable>: Sendable, Hashable {
     var value: Value
     var bytesRead: Int
 }

--- a/Sources/QPACK/FieldLineCoding.swift
+++ b/Sources/QPACK/FieldLineCoding.swift
@@ -369,7 +369,8 @@ extension ByteBuffer {
     ///   - maxCapacity: The maximum capacity of the dynamic table.
     /// - Returns: The number of bytes written.
     @discardableResult
-    package mutating func writeFieldSectionPrefix(_ prefix: EncodedFieldSectionPrefix) -> Int {
+    @_spi(PackageInternal)
+    public mutating func writeFieldSectionPrefix(_ prefix: EncodedFieldSectionPrefix) -> Int {
         var bytesWritten = 0
         bytesWritten += self.writeQPACKPrefixedInteger(
             prefix.encodedRequiredInsertCount,

--- a/Sources/QPACK/FieldLineCoding.swift
+++ b/Sources/QPACK/FieldLineCoding.swift
@@ -12,20 +12,25 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct NIOCore.ByteBuffer
+public import struct NIOCore.ByteBuffer
 
 /// Represents a FieldSectionPrefix as per RFC 9204 § 4.5.1.
-package struct FieldSectionPrefix: Sendable, Hashable {
-    package let requiredInsertCount: Int
-    package let base: Int
+@_spi(PackageInternal)
+public struct FieldSectionPrefix: Sendable, Hashable {
+    @_spi(PackageInternal)
+    public let requiredInsertCount: Int
+    @_spi(PackageInternal)
+    public let base: Int
 
-    package init(requiredInsertCount: Int, base: Int) {
+    @_spi(PackageInternal)
+    public init(requiredInsertCount: Int, base: Int) {
         precondition(base >= 0)
         self.requiredInsertCount = requiredInsertCount
         self.base = base
     }
 
-    package func encode(maxCapacity: Int) -> EncodedFieldSectionPrefix {
+    @_spi(PackageInternal)
+    public func encode(maxCapacity: Int) -> EncodedFieldSectionPrefix {
         // 4.5.1.1.
         // The encoder transforms the Required Insert Count as follows before encoding:
         // if ReqInsertCount == 0:
@@ -54,19 +59,25 @@ package struct FieldSectionPrefix: Sendable, Hashable {
 /// Represents an EncodedFieldSectionPrefix as per RFC 9204 § 4.5.1.
 /// Here, the requiredInsertCount is stored with an encoding as per RFC 9204 § 4.5.1.1.
 /// The deltaBase can be used to get the base relative to the decoded requiredInsertCount.
-package struct EncodedFieldSectionPrefix: Sendable, Hashable {
-    package let encodedRequiredInsertCount: Int
-    package let deltaBase: Int
+@_spi(PackageInternal)
+public struct EncodedFieldSectionPrefix: Sendable, Hashable {
+    @_spi(PackageInternal)
+    public let encodedRequiredInsertCount: Int
+    @_spi(PackageInternal)
+    public let deltaBase: Int
     /// If true, the base is encodedRequiredInsertCount - deltaBase - 1. Otherwise base is encodedRequiredInsertCount + deltaBase.
-    package let signBit: Bool
+    @_spi(PackageInternal)
+    public let signBit: Bool
 
-    package init(encodedRequiredInsertCount: Int, deltaBase: Int, signBit: Bool) {
+    @_spi(PackageInternal)
+    public init(encodedRequiredInsertCount: Int, deltaBase: Int, signBit: Bool) {
         self.encodedRequiredInsertCount = encodedRequiredInsertCount
         self.deltaBase = deltaBase
         self.signBit = signBit
     }
 
-    package func decode(totalInserts: Int, maxCapacity: Int) -> FieldSectionPrefix? {
+    @_spi(PackageInternal)
+    public func decode(totalInserts: Int, maxCapacity: Int) -> FieldSectionPrefix? {
         // 4.5.1.1.
         // FullRange = 2 * MaxEntries
         // if EncodedInsertCount == 0:
@@ -131,7 +142,8 @@ package struct EncodedFieldSectionPrefix: Sendable, Hashable {
 }
 
 /// Represents a single field line as per RFC 9204 § 4.5.
-package enum FieldLine: Sendable, Hashable {
+@_spi(PackageInternal)
+public enum FieldLine: Sendable, Hashable {
     /// 4.5.2. Indexed Field Line.
     case indexed(QPACKReferenceTable, index: Int)
     /// 4.5.3. Indexed Field Line with Post-Base Index.
@@ -150,13 +162,17 @@ package enum FieldLine: Sendable, Hashable {
 }
 
 /// Represents a full field section as per RFC 9204 § 4.5.
-package struct FieldSection: Sendable, Hashable {
+@_spi(PackageInternal)
+public struct FieldSection: Sendable, Hashable {
     /// The field section prefix.
-    package var prefix: EncodedFieldSectionPrefix
+    @_spi(PackageInternal)
+    public var prefix: EncodedFieldSectionPrefix
     /// Each line of the field section. A line represents a header.
-    package var lines: [FieldLine]
+    @_spi(PackageInternal)
+    public var lines: [FieldLine]
 
-    package init(prefix: EncodedFieldSectionPrefix, lines: [FieldLine]) {
+    @_spi(PackageInternal)
+    public init(prefix: EncodedFieldSectionPrefix, lines: [FieldLine]) {
         self.prefix = prefix
         self.lines = lines
     }
@@ -165,7 +181,7 @@ package struct FieldSection: Sendable, Hashable {
 extension ByteBuffer {
     /// Read a single ``FieldLine`` from this `ByteBuffer`.
     /// - Returns: The instruction, or nil if it cannot be decoded.
-    package mutating func readFieldLine() throws(IntegerReadingError) -> FieldLine? {
+    mutating func readFieldLine() throws(IntegerReadingError) -> FieldLine? {
         guard let result = try self.getFieldLine(at: self.readerIndex) else { return nil }
         self.moveReaderIndex(forwardBy: result.bytesRead)
         return result.value
@@ -264,7 +280,8 @@ extension ByteBuffer {
     ///   - preferHuffmanEncoding: Whether to use huffman coding for strings (where applicable and where it would be more efficient to do so).
     /// - Returns: The number of bytes written.
     @discardableResult
-    package mutating func writeFieldLine(_ fieldLine: FieldLine, preferHuffmanEncoding: Bool) -> Int {
+    @_spi(PackageInternal)
+    public mutating func writeFieldLine(_ fieldLine: FieldLine, preferHuffmanEncoding: Bool) -> Int {
         switch fieldLine {
         case .indexed(let table, let index):
             // First bit is 1. Then T. Then index
@@ -305,7 +322,7 @@ extension ByteBuffer {
 
     /// Read a single ``FieldSectionPrefix`` from this `ByteBuffer`.
     /// - Returns: The section, or nil if it cannot be decoded.
-    package mutating func readFieldSectionPrefix() throws(IntegerReadingError) -> EncodedFieldSectionPrefix? {
+    mutating func readFieldSectionPrefix() throws(IntegerReadingError) -> EncodedFieldSectionPrefix? {
         guard let result = try self.getFieldSectionPrefix(at: self.readerIndex) else { return nil }
         self.moveReaderIndex(forwardBy: result.bytesRead)
         return result.value
@@ -363,7 +380,8 @@ extension ByteBuffer {
         return bytesWritten
     }
 
-    package mutating func readFieldSection() throws(IntegerReadingError) -> FieldSection? {
+    @_spi(PackageInternal)
+    public mutating func readFieldSection() throws(IntegerReadingError) -> FieldSection? {
         guard let prefix = try self.readFieldSectionPrefix() else {
             return nil
         }

--- a/Sources/QPACK/Headers/DynamicHeaderTable.swift
+++ b/Sources/QPACK/Headers/DynamicHeaderTable.swift
@@ -12,9 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import HTTPTypes
+import HTTPTypes
 
-package enum DynamicHeaderTableError: Error, Sendable, Hashable {
+enum DynamicHeaderTableError: Error, Sendable, Hashable {
     /// The insert count has been incremented by a value which is too low to be valid.
     case incrementTooLow
     /// The insert count has been incremented by a value which is too high to be valid.
@@ -28,7 +28,7 @@ package enum DynamicHeaderTableError: Error, Sendable, Hashable {
     case capacityTooHigh
 }
 
-package struct DynamicTableLookupResult: Sendable, Hashable {
+struct DynamicTableLookupResult: Sendable, Hashable {
     /// Relative index of the entry in the table.
     package var relativeIndex: Int
     /// Absolute index of the entry in the table.
@@ -44,7 +44,7 @@ package struct DynamicTableLookupResult: Sendable, Hashable {
 /// Implements the dynamic part of the QPACK header table, as defined in
 /// [RFC 9204 § 3.2](https://httpwg.org/specs/rfc9204.html#header-table-dynamic).
 @usableFromInline
-package struct DynamicHeaderTable: Sendable {
+struct DynamicHeaderTable: Sendable {
     /// The actual table, with items looked up by index.
     private var storage: HeaderTableStorage
 
@@ -80,14 +80,14 @@ package struct DynamicHeaderTable: Sendable {
     /// E.g. if you set to 0.1, we won't reference anything in the last (oldest) tenth of the table.
     /// This means we avoid references to entries nearing eviction, which can reduce blocking.
     /// This is not a guarantee, if requests come too fast we won't be able to maintain this fraction.
-    package var targetEvictableFraction: Double {
+    var targetEvictableFraction: Double {
         didSet {
             assert(self.targetEvictableFraction >= 0 && self.targetEvictableFraction < 1)
         }
     }
 
     /// Should be true for decoder, false for encoder.
-    package var assumeAllEntriesReceived: Bool
+    var assumeAllEntriesReceived: Bool
 
     /// Entries with absolute index higher than this must not be evicted.
     /// Entries with absolute index equal to or lower than this have been received, and can be evicted as long
@@ -105,7 +105,7 @@ package struct DynamicHeaderTable: Sendable {
         }
     }
 
-    package init(
+    init(
         maximumCapacity: Int,
         initialCapacity: Int,
         targetEvictableFraction: Double,
@@ -120,7 +120,7 @@ package struct DynamicHeaderTable: Sendable {
     }
 
     /// Retrieve an entry with a given relative index (zero-based).
-    package func get(relativeIndex: Int) -> HeaderTableEntry? {
+    func get(relativeIndex: Int) -> HeaderTableEntry? {
         if relativeIndex >= self.count || relativeIndex < 0 {
             return nil
         }
@@ -129,7 +129,7 @@ package struct DynamicHeaderTable: Sendable {
 
     /// Retrieve an entry with a given absolute index (zero-based).
     /// Can return nil if the entry doesn't exist (May have never existed or may have been evicted).
-    package func get(absoluteIndex: Int) -> HeaderTableEntry? {
+    func get(absoluteIndex: Int) -> HeaderTableEntry? {
         guard let firstEntry = self.get(relativeIndex: 0) else {
             return nil
         }
@@ -151,7 +151,7 @@ package struct DynamicHeaderTable: Sendable {
     /// - Returns: A tuple containing the matching relative index and, if a value was specified as a
     ///            parameter, an indication whether that value was also found. Returns `nil`
     ///            if no matching header name could be located.
-    package func findExistingHeader(
+    func findExistingHeader(
         named name: HTTPField.Name,
         value: String?
     ) -> DynamicTableLookupResult? {
@@ -205,7 +205,7 @@ package struct DynamicHeaderTable: Sendable {
     /// - Throws: If the header cannot fit in the storage.
     /// - Returns: The absolute index of the added header.
     @discardableResult
-    package mutating func addHeader(named name: HTTPField.Name, value: String) throws(HeaderTableError) -> Int {
+    mutating func addHeader(named name: HTTPField.Name, value: String) throws(HeaderTableError) -> Int {
         try self.storage.add(
             name: name,
             value: value,
@@ -215,7 +215,7 @@ package struct DynamicHeaderTable: Sendable {
     }
 
     /// Increment `knownReceivedCount` (§ 2.1.4).
-    package mutating func insertCountIncrement(by: Int) throws(DynamicHeaderTableError) {
+    mutating func insertCountIncrement(by: Int) throws(DynamicHeaderTableError) {
         // RFC 9204 § 4.4.3 An encoder that receives an Increment field equal to zero, or one that increases the
         // Known Received Count beyond what the encoder has sent, MUST treat this as a connection error
         guard by > 0 else { throw DynamicHeaderTableError.incrementTooLow }
@@ -228,7 +228,7 @@ package struct DynamicHeaderTable: Sendable {
 
     /// When a section is acknowledged or a stream is closed, all the fields used in that stream are implicitly ack'd.
     /// See RFC 9204 § 2.1.4 for details.
-    package mutating func acknowledgeInsertCount(_ count: Int) throws(DynamicHeaderTableError) {
+    mutating func acknowledgeInsertCount(_ count: Int) throws(DynamicHeaderTableError) {
         guard count > 0 else {
             throw DynamicHeaderTableError.ackCountTooLow
         }
@@ -242,7 +242,7 @@ package struct DynamicHeaderTable: Sendable {
     /// the current maximum length signaled by the peer (RFC 9204 § 4.3.1).
     ///
     /// - Note: This value cannot exceed `self.maximumCapacity`.
-    package mutating func setCurrentCapacity(_ capacity: Int) throws {
+    mutating func setCurrentCapacity(_ capacity: Int) throws {
         guard capacity <= self.maximumCapacity else {
             // This means the remote sent us a "set dynamic table capacity" instruction with a value higher than the value we sent in the SETTINGS frame.
             throw DynamicHeaderTableError.capacityTooHigh
@@ -250,11 +250,11 @@ package struct DynamicHeaderTable: Sendable {
         try self.storage.setTableSize(to: capacity, maximumEvictableAbsoluteIndex: self.maximumEvictableAbsoluteIndex)
     }
 
-    package mutating func addReference(_ absoluteIndex: Int) {
+    mutating func addReference(_ absoluteIndex: Int) {
         self.storage.addReference(absoluteIndex: absoluteIndex)
     }
 
-    package mutating func removeReference(_ absoluteIndex: Int) {
+    mutating func removeReference(_ absoluteIndex: Int) {
         self.storage.removeReference(absoluteIndex: absoluteIndex)
     }
 }

--- a/Sources/QPACK/Headers/DynamicHeaderTable.swift
+++ b/Sources/QPACK/Headers/DynamicHeaderTable.swift
@@ -30,15 +30,15 @@ enum DynamicHeaderTableError: Error, Sendable, Hashable {
 
 struct DynamicTableLookupResult: Sendable, Hashable {
     /// Relative index of the entry in the table.
-    package var relativeIndex: Int
+    var relativeIndex: Int
     /// Absolute index of the entry in the table.
-    package var absoluteIndex: Int
+    var absoluteIndex: Int
     /// Does the entry match the value too. If false, only the name was matched.
-    package var containsValue: Bool
+    var containsValue: Bool
     /// True if this item is old and should be duplicated rather than referencing this existing index.
-    package var isNearingEviction: Bool
+    var isNearingEviction: Bool
     /// True if the entry is known to be received by the peer.
-    package var isKnownReceived: Bool
+    var isKnownReceived: Bool
 }
 
 /// Implements the dynamic part of the QPACK header table, as defined in

--- a/Sources/QPACK/Headers/HeaderTableStorage.swift
+++ b/Sources/QPACK/Headers/HeaderTableStorage.swift
@@ -13,20 +13,20 @@
 //===----------------------------------------------------------------------===//
 
 import DequeModule
-package import HTTPTypes
+import HTTPTypes
 
-package struct HeaderTableEntry: Sendable, Hashable {
+struct HeaderTableEntry: Sendable, Hashable {
     /// The actual field (name and value).
     private var field: HTTPField
     /// The absolute index, which is fixed for the lifetime of the entry as per RFC 9204 § 3.2.4.
-    package var absoluteIndex: Int
+    var absoluteIndex: Int
     /// The name of the field.
-    package var name: HTTPField.Name {
+    var name: HTTPField.Name {
         self.field.name
     }
 
     /// The value of the field.
-    package var value: String {
+    var value: String {
         self.field.value
     }
 
@@ -49,7 +49,7 @@ package struct HeaderTableEntry: Sendable, Hashable {
     }
 }
 
-package enum HeaderTableError: Error, Hashable, Sendable {
+enum HeaderTableError: Error, Hashable, Sendable {
     case insufficientStorage
     case cannotPurge
 }

--- a/Sources/QPACK/Headers/StaticHeaderTable.swift
+++ b/Sources/QPACK/Headers/StaticHeaderTable.swift
@@ -12,9 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import HTTPTypes
+import HTTPTypes
 
-package enum StaticHeaderTable {
+enum StaticHeaderTable {
     /// This array represents all the static header table entries as defined in RFC 9204 § 3.1.
     ///
     /// The absolute index is the position, which is the array index.
@@ -123,7 +123,7 @@ package enum StaticHeaderTable {
 
     /// A mapping of header name to the array of static table indices carrying that name.
     /// Arrays are guaranteed to be non-empty, and their values are in ascending index order.
-    private static let indicesByName: [HTTPField.Name: [Int]] = {
+    static let indicesByName: [HTTPField.Name: [Int]] = {
         var result = [HTTPField.Name: [Int]](minimumCapacity: Self.shared.count)
         for index in Self.shared.indices {
             result[Self.shared[index].0, default: []].append(index)
@@ -132,7 +132,7 @@ package enum StaticHeaderTable {
     }()
 
     /// Get the element of the static table at the specific index if it exists
-    package static func get(at index: Int) -> (HTTPField.Name, String)? {
+    static func get(at index: Int) -> (HTTPField.Name, String)? {
         if self.shared.indices.contains(index) {
             return self.shared[index]
         } else {

--- a/Sources/QPACK/HuffmanCoding.swift
+++ b/Sources/QPACK/HuffmanCoding.swift
@@ -29,7 +29,7 @@ extension ByteBuffer {
     }
 
     /// Returns the number of bytes required to encode a given string.
-    package static func huffmanEncodedByteLength(of bytes: some Collection<UInt8>) -> Int {
+    static func huffmanEncodedByteLength(of bytes: some Collection<UInt8>) -> Int {
         self.huffmanEncodedBitLength(of: bytes) / 8
     }
 
@@ -38,7 +38,7 @@ extension ByteBuffer {
     /// - Parameter stringBytes: The string data to encode.
     /// - Returns: The number of bytes used while encoding the string.
     @discardableResult
-    package mutating func setHuffmanEncoded(bytes stringBytes: some Collection<UInt8>) -> Int {
+    mutating func setHuffmanEncoded(bytes stringBytes: some Collection<UInt8>) -> Int {
         let clen = ByteBuffer.huffmanEncodedBitLength(of: stringBytes)
         self.ensureBitsAvailable(clen)
 
@@ -61,7 +61,7 @@ extension ByteBuffer {
     }
 
     @discardableResult
-    package mutating func writeHuffmanEncoded(bytes stringBytes: some Collection<UInt8>) -> Int {
+    mutating func writeHuffmanEncoded(bytes stringBytes: some Collection<UInt8>) -> Int {
         let written = self.setHuffmanEncoded(bytes: stringBytes)
         self.moveWriterIndex(forwardBy: written)
         return written
@@ -159,7 +159,7 @@ extension ByteBuffer {
     ///   - length: The number of huffman-encoded octets to read.
     /// - Returns: The decoded `String`, or nil if it can't be read.
     @discardableResult
-    package func getHuffmanEncodedString(at index: Int, length: Int) -> String? {
+    func getHuffmanEncodedString(at index: Int, length: Int) -> String? {
         if index + length > self.capacity {
             assertionFailure(
                 "Requested range out of bounds: \(index..<index + length) vs. \(self.capacity)"

--- a/Sources/QPACK/IntegerCoding.swift
+++ b/Sources/QPACK/IntegerCoding.swift
@@ -27,7 +27,7 @@ extension ByteBuffer {
     /// - Returns: Returns the number of bytes used to encode the integer.
     @discardableResult
     @inlinable
-    package mutating func writeQPACKPrefixedInteger<Integer: FixedWidthInteger>(
+    mutating func writeQPACKPrefixedInteger<Integer: FixedWidthInteger>(
         _ value: Integer,
         prefix: Int,
         prefixBits: UInt8 = 0
@@ -74,7 +74,7 @@ extension ByteBuffer {
     /// If no integer can be read, returns nil and leaves the index as it was.
     /// - Precondition: The prefix MUST be between 1 and 8 inclusive.
     /// - Throws: IntegerReadingError if the result doesn't fit in the requested type.
-    package mutating func readQPACKPrefixedInteger<Integer: FixedWidthInteger & Sendable>(
+    mutating func readQPACKPrefixedInteger<Integer: FixedWidthInteger & Sendable>(
         as: Integer.Type = Integer.self,
         withPrefix prefix: Int
     ) throws(IntegerReadingError) -> Integer? {

--- a/Sources/QPACK/QPACKConstants.swift
+++ b/Sources/QPACK/QPACKConstants.swift
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-package enum QPACKConstants {
+@_spi(PackageInternal)
+public enum QPACKConstants {
     /// Rough estimate of bytes per header for initial capacity calculation.
     /// Used in HeaderTableStorage initialization for performance optimization.
     static let estimatedBytesPerHeader: Int = 64
@@ -20,7 +21,8 @@ package enum QPACKConstants {
     /// Default target evictable fraction for dynamic header table.
     /// This fraction of the table is kept evictable to reduce blocking.
     /// Value should be between 0.0 and 1.0 (exclusive).
-    package static let defaultTargetEvictableFraction: Double = 0.1
+    @_spi(PackageInternal)
+    public static let defaultTargetEvictableFraction: Double = 0.1
 
     /// Default capacity for field lines array when reading field sections.
     /// Used for performance optimization to reduce array reallocations.

--- a/Sources/QPACK/QPACKDecoder.swift
+++ b/Sources/QPACK/QPACKDecoder.swift
@@ -12,17 +12,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import HTTPTypes
-package import NIOQUICHelpers
+public import HTTPTypes
+public import NIOQUICHelpers
 
-package enum QPACKDecoderError: Error, Sendable, Hashable {
+@_spi(PackageInternal)
+public enum QPACKDecoderError: Error, Sendable, Hashable {
     case invalidHeaderName
     case invalidReference
     case invalidFieldSection
 }
 
 /// The result of decoding a field section, plus the instruction which need to be sent back, if any.
-package enum QPACKFullDecodeResult: Sendable {
+@_spi(PackageInternal)
+public enum QPACKFullDecodeResult: Sendable {
     /// The section cannot not be decoded because we don't have the required insert count. You can try again later.
     case missingInsertCount
     /// The section has been decoded with the given result. Also, an instruction may need to be sent to the remote.
@@ -32,7 +34,7 @@ package enum QPACKFullDecodeResult: Sendable {
 }
 
 /// The result of decoding a field section.
-package enum QPACKDecodeResult: Sendable {
+enum QPACKDecodeResult: Sendable {
     /// The section cannot not be decoded because we don't have the required insert count. You can try again later.
     case missingInsertCount
     /// The section has been decoded with the given result.
@@ -41,7 +43,8 @@ package enum QPACKDecodeResult: Sendable {
     case error(any Error)
 }
 
-package struct QPACKDecoder {
+@_spi(PackageInternal)
+public struct QPACKDecoder {
     private var dynamicTable: DynamicHeaderTable
     /// Makes decisions on when and how to sync state with the encoder.
     private var stateSynchronizer: QPACKStateSynchronizer
@@ -53,7 +56,8 @@ package struct QPACKDecoder {
     }
 
     /// - Parameter dynamicTableMaxCapacity: The max the encoder can set the dynamic table capacity to (RFC 9204 § 3.2.3).
-    package init(dynamicTableMaxCapacity: Int) {
+    @_spi(PackageInternal)
+    public init(dynamicTableMaxCapacity: Int) {
         self.stateSynchronizer = QPACKStateSynchronizer()
         // RFC 9204 § 3.2.2 The initial capacity of the dynamic table is zero
         // Target evictable is irrelevant to the decoder
@@ -66,8 +70,10 @@ package struct QPACKDecoder {
     }
 
     /// Process an encoder instruction and (maybe) emit a decoder instruction to send back.
-    package mutating func processInstruction(_ instruction: QPACKEncoderInstruction) throws -> QPACKDecoderInstruction?
-    {
+    @_spi(PackageInternal)
+    public mutating func processInstruction(
+        _ instruction: QPACKEncoderInstruction
+    ) throws -> QPACKDecoderInstruction? {
         switch instruction {
         case .setDynamicTableCapacity(let capacity):
             try self.dynamicTable.setCurrentCapacity(capacity)
@@ -120,7 +126,8 @@ package struct QPACKDecoder {
         return nil
     }
 
-    package func cancelStream(streamID: QUICStreamID) -> QPACKDecoderInstruction? {
+    @_spi(PackageInternal)
+    public func cancelStream(streamID: QUICStreamID) -> QPACKDecoderInstruction? {
         if self.dynamicTable.maximumCapacity == 0 {
             // A decoder with a maximum dynamic table capacity equal to zero MAY omit sending Stream
             // Cancellations, because the encoder cannot have any dynamic table references.
@@ -132,7 +139,8 @@ package struct QPACKDecoder {
 
     /// Return a list of headers for a FieldSection, if the required insert count is met.
     /// Otherwise, return ``QPACKDecodeResult/missingInsertCount``.
-    package mutating func decodeFieldSection(
+    @_spi(PackageInternal)
+    public mutating func decodeFieldSection(
         prefix: FieldSectionPrefix,
         lines: [FieldLine],
         streamID: QUICStreamID

--- a/Sources/QPACK/QPACKDecoder.swift
+++ b/Sources/QPACK/QPACKDecoder.swift
@@ -51,7 +51,8 @@ public struct QPACKDecoder {
     /// The number of dynamic table inserts we have acknowledged. See RFC 9204 § 2.1.4.
     private var knownReceivedCount = 0
 
-    package var insertCount: Int {
+    @_spi(PackageInternal)
+    public var insertCount: Int {
         self.dynamicTable.insertCount
     }
 
@@ -228,7 +229,8 @@ public struct QPACKDecoder {
         }
     }
 
-    package func decodeFieldSectionPrefix(_ prefix: EncodedFieldSectionPrefix) -> FieldSectionPrefix? {
+    @_spi(PackageInternal)
+    public func decodeFieldSectionPrefix(_ prefix: EncodedFieldSectionPrefix) -> FieldSectionPrefix? {
         prefix.decode(totalInserts: self.insertCount, maxCapacity: self.dynamicTable.maximumCapacity)
     }
 }

--- a/Sources/QPACK/QPACKEncoder.swift
+++ b/Sources/QPACK/QPACKEncoder.swift
@@ -13,10 +13,10 @@
 //===----------------------------------------------------------------------===//
 
 import DequeModule
-package import HTTPTypes
-package import NIOQUICHelpers
+public import HTTPTypes
+public import NIOQUICHelpers
 
-package enum QPACKEncoderError: Error, Sendable, Hashable {
+enum QPACKEncoderError: Error, Sendable, Hashable {
     case unknownStream
     case unexpectedStreamAck
 }
@@ -197,7 +197,8 @@ private struct QPACKEncodeSingleResult {
 }
 
 /// A full QPACK encoder which may use the dynamic table and may emit instructions.
-package struct DynamicQPACKEncoder {
+@_spi(PackageInternal)
+public struct DynamicQPACKEncoder {
     /// The actual header table.
     private var table: DynamicHeaderTable
     /// The maximum number of streams we'll risk blocking. The peers decoder chooses this.
@@ -207,7 +208,8 @@ package struct DynamicQPACKEncoder {
     /// For when the dynamic table can't be used (e.g. it's full).
     private let staticEncoder: StaticQPACKEncoder
 
-    package static func create(
+    @_spi(PackageInternal)
+    public static func create(
         dynamicTableMaxCapacity: Int,
         dynamicTableInitialCapacity: Int,
         maxBlockedStreams: Int,
@@ -240,7 +242,8 @@ package struct DynamicQPACKEncoder {
         return (encoder, result)
     }
 
-    package mutating func encode(headers: [HTTPField], forStream streamID: QUICStreamID) -> QPACKEncodeResult {
+    @_spi(PackageInternal)
+    public mutating func encode(headers: [HTTPField], forStream streamID: QUICStreamID) -> QPACKEncodeResult {
         let base = self.table.insertCount
         var highestRequiredIndex: Int?
         var requiredIndices = [Int]()
@@ -457,7 +460,8 @@ package struct DynamicQPACKEncoder {
         }
     }
 
-    package mutating func processInstruction(
+    @_spi(PackageInternal)
+    public mutating func processInstruction(
         _ instruction: QPACKDecoderInstruction
     ) throws {
         switch instruction {
@@ -510,9 +514,13 @@ package struct DynamicQPACKEncoder {
 }
 
 /// Can encode field sections but only statically (can't use dynamic table and can't send instructions).
-package struct StaticQPACKEncoder {
-    package init() {}
-    package func encode(headers: [HTTPField]) -> FieldSection {
+@_spi(PackageInternal)
+public struct StaticQPACKEncoder {
+    @_spi(PackageInternal)
+    public init() {}
+    
+    @_spi(PackageInternal)
+    public func encode(headers: [HTTPField]) -> FieldSection {
         let base = 0  // base 0 is the cheapest way when no dynamic entries
         var lines = [FieldLine]()
         lines.reserveCapacity(headers.count)

--- a/Sources/QPACK/QPACKEncoder.swift
+++ b/Sources/QPACK/QPACKEncoder.swift
@@ -518,7 +518,7 @@ public struct DynamicQPACKEncoder {
 public struct StaticQPACKEncoder {
     @_spi(PackageInternal)
     public init() {}
-    
+
     @_spi(PackageInternal)
     public func encode(headers: [HTTPField]) -> FieldSection {
         let base = 0  // base 0 is the cheapest way when no dynamic entries

--- a/Sources/QPACK/QPACKEncoder.swift
+++ b/Sources/QPACK/QPACKEncoder.swift
@@ -105,11 +105,15 @@ struct StreamTracker {
     }
 }
 
-package struct QPACKEncodeResult: Sendable, Hashable {
-    package let fieldSection: FieldSection
-    package let instructions: [QPACKEncoderInstruction]
+@_spi(PackageInternal)
+public struct QPACKEncodeResult: Sendable, Hashable {
+    @_spi(PackageInternal)
+    public let fieldSection: FieldSection
+    @_spi(PackageInternal)
+    public let instructions: [QPACKEncoderInstruction]
 
-    package init(fieldSection: FieldSection, instructions: [QPACKEncoderInstruction]) {
+    @_spi(PackageInternal)
+    public init(fieldSection: FieldSection, instructions: [QPACKEncoderInstruction]) {
         self.fieldSection = fieldSection
         self.instructions = instructions
     }

--- a/Sources/QPACK/QPACKInstruction.swift
+++ b/Sources/QPACK/QPACKInstruction.swift
@@ -29,7 +29,8 @@ public enum QPACKReferenceTable: Sendable, Hashable {
 }
 
 /// Encoder instructions from RFC 9204 § 4.3.
-package enum QPACKEncoderInstruction: Sendable, Hashable {
+@_spi(PackageInternal)
+public enum QPACKEncoderInstruction: Sendable, Hashable {
     /// 4.3.1. Set Dynamic Table Capacity.
     case setDynamicTableCapacity(Int)
     /// 4.3.2. Insert with Name Reference.

--- a/Sources/QPACK/QPACKInstruction.swift
+++ b/Sources/QPACK/QPACKInstruction.swift
@@ -12,9 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import NIOQUICHelpers
+public import NIOQUICHelpers
 
-package enum QPACKReferenceTable: Sendable, Hashable {
+@_spi(PackageInternal)
+public enum QPACKReferenceTable: Sendable, Hashable {
     case staticTable
     case dynamicTable
 
@@ -40,7 +41,8 @@ package enum QPACKEncoderInstruction: Sendable, Hashable {
 }
 
 /// Decoder instructions from RFC 9204 § 4.4.
-package enum QPACKDecoderInstruction: Sendable, Hashable {
+@_spi(PackageInternal)
+public enum QPACKDecoderInstruction: Sendable, Hashable {
     /// 4.4.1. Section Acknowledgment.
     case sectionAcknowledgement(streamID: QUICStreamID)
     /// 4.4.2. Stream Cancellation.

--- a/Sources/QPACK/QPACKInstructionCoding.swift
+++ b/Sources/QPACK/QPACKInstructionCoding.swift
@@ -12,14 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import struct NIOCore.ByteBuffer
+public import struct NIOCore.ByteBuffer
 
 extension ByteBuffer {
     /// Read a single ``QPACKEncoderInstruction`` from this `ByteBuffer`.
     /// Moves the reader index to the end of the instruction.
     /// If a valid instruction can't be formed, returns nil and leaves the reader index as it was.
     /// - Returns: The instruction, or nil if it cannot be decoded.
-    package mutating func readQPACKEncoderInstruction() throws(IntegerReadingError) -> QPACKEncoderInstruction? {
+    mutating func readQPACKEncoderInstruction() throws(IntegerReadingError) -> QPACKEncoderInstruction? {
         guard let firstByte = self.peekInteger(as: UInt8.self) else {
             return nil
         }
@@ -74,7 +74,7 @@ extension ByteBuffer {
     /// - Parameters:
     ///   - instruction: The instruction to encode.
     ///   - preferHuffmanEncoding: Whether to use huffman coding for strings (where applicable and more efficient to do so).
-    package mutating func writeQPACKEncoderInstruction(
+    mutating func writeQPACKEncoderInstruction(
         _ instruction: QPACKEncoderInstruction,
         preferHuffmanEncoding: Bool
     ) {
@@ -110,7 +110,7 @@ extension ByteBuffer {
     /// Moves the reader index to the end of the instruction.
     /// If a valid instruction can't be formed, returns nil and leaves the reader index as it was.
     /// - Returns: The instruction, or nil if it cannot be decoded.
-    package mutating func readQPACKDecoderInstruction() throws(IntegerReadingError) -> QPACKDecoderInstruction? {
+    mutating func readQPACKDecoderInstruction() throws(IntegerReadingError) -> QPACKDecoderInstruction? {
         guard let firstByte = self.getInteger(at: self.readerIndex, as: UInt8.self) else {
             return nil
         }
@@ -142,7 +142,7 @@ extension ByteBuffer {
 
     /// Encode a single ``QPACKDecoderInstruction`` into this `ByteBuffer`.
     /// - Parameter instruction: The instruction to encode.
-    package mutating func writeQPACKDecoderInstruction(_ instruction: QPACKDecoderInstruction) {
+    mutating func writeQPACKDecoderInstruction(_ instruction: QPACKDecoderInstruction) {
         switch instruction {
         case .sectionAcknowledgement(let streamID):
             // Start with a 1, then a 7-bit prefix integer
@@ -158,27 +158,37 @@ extension ByteBuffer {
 }
 
 /// Encode qpack encoder instructions.
-package struct QPACKEncoderInstructionEncoder {
+@_spi(PackageInternal)
+public struct QPACKEncoderInstructionEncoder {
+    @_spi(PackageInternal)
+    public typealias OutboundIn = QPACKEncoderInstruction
+
     private let preferHuffmanEncoding: Bool
 
-    package init(preferHuffmanEncoding: Bool) {
+    @_spi(PackageInternal)
+    public init(preferHuffmanEncoding: Bool) {
         self.preferHuffmanEncoding = preferHuffmanEncoding
     }
 
-    package func encode(data: QPACKEncoderInstruction, out: inout ByteBuffer) {
+    @_spi(PackageInternal)
+    public func encode(data: QPACKEncoderInstruction, out: inout ByteBuffer) {
         out.writeQPACKEncoderInstruction(data, preferHuffmanEncoding: self.preferHuffmanEncoding)
     }
 }
 
 /// Decode qpack encoder instructions.
-package struct QPACKEncoderInstructionDecoder {
-    package init() {}
+@_spi(PackageInternal)
+public struct QPACKEncoderInstructionDecoder {
+    @_spi(PackageInternal)
+    public init() {}
 
-    package func decode(buffer: inout ByteBuffer) throws(IntegerReadingError) -> QPACKEncoderInstruction? {
+    @_spi(PackageInternal)
+    public func decode(buffer: inout ByteBuffer) throws(IntegerReadingError) -> QPACKEncoderInstruction? {
         try buffer.readQPACKEncoderInstruction()
     }
 
-    package func decodeLast(
+    @_spi(PackageInternal)
+    public func decodeLast(
         buffer: inout ByteBuffer,
         seenEOF: Bool
     ) throws(IntegerReadingError) -> QPACKEncoderInstruction? {
@@ -187,23 +197,33 @@ package struct QPACKEncoderInstructionDecoder {
 }
 
 /// Encode qpack decoder instructions.
-package struct QPACKDecoderInstructionEncoder {
-    package init() {}
+@_spi(PackageInternal)
+public struct QPACKDecoderInstructionEncoder {
+    @_spi(PackageInternal)
+    public typealias OutboundIn = QPACKDecoderInstruction
 
-    package func encode(data: QPACKDecoderInstruction, out: inout ByteBuffer) {
+    @_spi(PackageInternal)
+    public init() {}
+
+    @_spi(PackageInternal)
+    public func encode(data: QPACKDecoderInstruction, out: inout ByteBuffer) {
         out.writeQPACKDecoderInstruction(data)
     }
 }
 
 /// Decode qpack decoder instructions.
-package struct QPACKDecoderInstructionDecoder {
-    package init() {}
+@_spi(PackageInternal)
+public struct QPACKDecoderInstructionDecoder {
+    @_spi(PackageInternal)
+    public init() {}
 
-    package func decode(buffer: inout ByteBuffer) throws(IntegerReadingError) -> QPACKDecoderInstruction? {
+    @_spi(PackageInternal)
+    public func decode(buffer: inout ByteBuffer) throws(IntegerReadingError) -> QPACKDecoderInstruction? {
         try buffer.readQPACKDecoderInstruction()
     }
 
-    package func decodeLast(
+    @_spi(PackageInternal)
+    public func decodeLast(
         buffer: inout ByteBuffer,
         seenEOF: Bool
     ) throws(IntegerReadingError) -> QPACKDecoderInstruction? {

--- a/Sources/QPACK/QPACKStateSynchronizer.swift
+++ b/Sources/QPACK/QPACKStateSynchronizer.swift
@@ -14,14 +14,14 @@
 
 /// Decides when to send a section acknowledgment (RFC 9204 § 4.4.1).
 /// This allows us to conform to RFC 9204 § 2.2.2.
-package struct QPACKStateSynchronizer {
+struct QPACKStateSynchronizer {
     private var lastCountAcknowledged: Int = 0
 
-    package init() {}
+    init() {}
 
     /// Called when a field section has been processed.
     /// - Parameter insertCount: The required insert count of the processed section as per RFC 9204 § 4.5.1.
-    package mutating func sectionProcessed(withRequiredInsertCount insertCount: Int) {
+    mutating func sectionProcessed(withRequiredInsertCount insertCount: Int) {
         if self.lastCountAcknowledged < insertCount {
             self.lastCountAcknowledged = insertCount
         }
@@ -30,7 +30,7 @@ package struct QPACKStateSynchronizer {
     /// Called when a new header has been added to the dynamic table of the decoder.
     /// - Parameter insertCount: The total number of dynamic-table inserts that have been performed so far.
     /// - Returns: true if an `insert count increment decoder instruction` (RFC 9204 § 4.4.3) should be sent.
-    package mutating func dynamicTableEntryAdded(insertCount: Int) -> Bool {
+    mutating func dynamicTableEntryAdded(insertCount: Int) -> Bool {
         if self.lastCountAcknowledged < insertCount {
             self.lastCountAcknowledged = insertCount
             return true

--- a/Sources/QPACK/StringCoding.swift
+++ b/Sources/QPACK/StringCoding.swift
@@ -72,7 +72,7 @@ extension ByteBuffer {
     /// - prefix: The number of bits in the first byte leave before starting the string
     /// - prefixBits: The bits to use in the first byte before the string begins.
     @discardableResult
-    package mutating func writeQPACKEncodedString(
+    mutating func writeQPACKEncodedString(
         _ string: String,
         preferHuffmanEncoding: Bool,
         prefix: Int,

--- a/Sources/QPACK/StringCoding.swift
+++ b/Sources/QPACK/StringCoding.swift
@@ -18,7 +18,7 @@ extension ByteBuffer {
     /// Read one QPACK encoded string from this ByteBuffer.
     /// Will move the reader index to the end of the string.
     /// If a qpack encoded string cannot be read, nil will be returned and the index will be left where it was.
-    package mutating func readQPACKEncodedString(withPrefix prefix: Int) throws(IntegerReadingError) -> String? {
+    mutating func readQPACKEncodedString(withPrefix prefix: Int) throws(IntegerReadingError) -> String? {
         guard let result = try self.getQPACKEncodedString(at: self.readerIndex, withPrefix: prefix) else {
             return nil
         }
@@ -27,7 +27,7 @@ extension ByteBuffer {
     }
 
     /// Get one QPACK encoded string from this ByteBuffer without moving the reader index.
-    package func getQPACKEncodedString(
+    func getQPACKEncodedString(
         at: Int,
         withPrefix prefix: Int
     ) throws(IntegerReadingError) -> Decoded<String>? {

--- a/Tests/H3IntegrationTests/AsyncEndToEndTests.swift
+++ b/Tests/H3IntegrationTests/AsyncEndToEndTests.swift
@@ -16,7 +16,6 @@ import HTTP3
 import HTTPTypes
 import Logging
 import NIOCore
-@_spi(HTTP3AsyncInterface) @testable import NIOHTTP3
 import NIOHTTPTypes
 import NIOPosix
 import Testing
@@ -24,6 +23,8 @@ import X509
 
 import struct NIOQUIC.QUICConfiguration
 import struct NIOQUIC.QUICStreamCreator
+
+@_spi(HTTP3AsyncInterface) @testable import NIOHTTP3
 
 struct AsyncEndToEndTests {
     private let eventLoopGroup = MultiThreadedEventLoopGroup.singleton

--- a/Tests/H3IntegrationTests/AsyncEndToEndTests.swift
+++ b/Tests/H3IntegrationTests/AsyncEndToEndTests.swift
@@ -16,7 +16,7 @@ import HTTP3
 import HTTPTypes
 import Logging
 import NIOCore
-@_spi(HTTP3AsyncInterface) import NIOHTTP3
+@_spi(HTTP3AsyncInterface) @testable import NIOHTTP3
 import NIOHTTPTypes
 import NIOPosix
 import Testing

--- a/Tests/H3IntegrationTests/EndToEndTests.swift
+++ b/Tests/H3IntegrationTests/EndToEndTests.swift
@@ -12,19 +12,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(PackageInternal) @testable import HTTP3
 import HTTPTypes
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
-@_spi(HTTP3AsyncInterface) @testable import NIOHTTP3
 import NIOHTTPTypes
 import NIOPosix
 import NIOQUIC
 import NIOQUICHelpers
-@_spi(PackageInternal) @testable import QPACK
 import Testing
 import X509
+
+@_spi(PackageInternal) @testable import HTTP3
+@_spi(HTTP3AsyncInterface) @testable import NIOHTTP3
+@_spi(PackageInternal) @testable import QPACK
 
 /// Buffers incoming body data until end. Then echoes it all back with a 200 status header.
 final class EchoHTTPServerHandler: ChannelInboundHandler {

--- a/Tests/H3IntegrationTests/EndToEndTests.swift
+++ b/Tests/H3IntegrationTests/EndToEndTests.swift
@@ -22,7 +22,7 @@ import NIOHTTPTypes
 import NIOPosix
 import NIOQUIC
 import NIOQUICHelpers
-@_spi(PackageInternal) import QPACK
+@_spi(PackageInternal) @testable import QPACK
 import Testing
 import X509
 

--- a/Tests/H3IntegrationTests/EndToEndTests.swift
+++ b/Tests/H3IntegrationTests/EndToEndTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@_spi(PackageInternal) @testable import HTTP3
 import HTTPTypes
 import Logging
 import NIOConcurrencyHelpers
@@ -22,7 +22,7 @@ import NIOHTTPTypes
 import NIOPosix
 import NIOQUIC
 import NIOQUICHelpers
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 import X509
 

--- a/Tests/H3IntegrationTests/EndToEndTests.swift
+++ b/Tests/H3IntegrationTests/EndToEndTests.swift
@@ -17,7 +17,7 @@ import HTTPTypes
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
-@_spi(HTTP3AsyncInterface) import NIOHTTP3
+@_spi(HTTP3AsyncInterface) @testable import NIOHTTP3
 import NIOHTTPTypes
 import NIOPosix
 import NIOQUIC

--- a/Tests/H3IntegrationTests/HTTP3+NIOQUIC.swift
+++ b/Tests/H3IntegrationTests/HTTP3+NIOQUIC.swift
@@ -15,7 +15,7 @@
 @_spi(PackageInternal) import HTTP3
 import Logging
 import NIOCore
-@_spi(HTTP3AsyncInterface) import NIOHTTP3
+@_spi(HTTP3AsyncInterface) @testable import NIOHTTP3
 import NIOQUICHelpers
 
 import class NIOQUIC.AsyncVerifier

--- a/Tests/H3IntegrationTests/HTTP3+NIOQUIC.swift
+++ b/Tests/H3IntegrationTests/HTTP3+NIOQUIC.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@_spi(PackageInternal) import HTTP3
 import Logging
 import NIOCore
 @_spi(HTTP3AsyncInterface) import NIOHTTP3

--- a/Tests/H3IntegrationTests/HTTP3+NIOQUIC.swift
+++ b/Tests/H3IntegrationTests/HTTP3+NIOQUIC.swift
@@ -15,7 +15,6 @@
 @_spi(PackageInternal) import HTTP3
 import Logging
 import NIOCore
-@_spi(HTTP3AsyncInterface) @testable import NIOHTTP3
 import NIOQUICHelpers
 
 import class NIOQUIC.AsyncVerifier
@@ -23,6 +22,8 @@ import class NIOQUIC.Authenticator
 import struct NIOQUIC.QUICConfiguration
 import class NIOQUIC.QUICHandler
 import struct NIOQUIC.QUICStreamCreator
+
+@_spi(HTTP3AsyncInterface) @testable import NIOHTTP3
 
 typealias QUICHTTP3ConnectionHandler = HTTP3ConnectionHandler<QUICStreamCreator>
 

--- a/Tests/HTTP3Tests/FieldSectionQueueTests.swift
+++ b/Tests/HTTP3Tests/FieldSectionQueueTests.swift
@@ -12,9 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import HTTP3
+@_spi(PackageInternal) @testable import HTTP3
 import NIOQUICHelpers
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 
 struct FieldSectionQueueTests {

--- a/Tests/HTTP3Tests/FieldSectionQueueTests.swift
+++ b/Tests/HTTP3Tests/FieldSectionQueueTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@testable import HTTP3
 import NIOQUICHelpers
 import QPACK
 import Testing

--- a/Tests/HTTP3Tests/FieldSectionQueueTests.swift
+++ b/Tests/HTTP3Tests/FieldSectionQueueTests.swift
@@ -12,10 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(PackageInternal) @testable import HTTP3
 import NIOQUICHelpers
 @_spi(PackageInternal) import QPACK
 import Testing
+
+@_spi(PackageInternal) @testable import HTTP3
 
 struct FieldSectionQueueTests {
     private func makeTestEntry(streamID: QUICStreamID, requiredInsertCount: Int) -> FieldSectionQueue.Entry {

--- a/Tests/HTTP3Tests/HTTP3ConnectionQuiescingStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3ConnectionQuiescingStateMachineTests.swift
@@ -12,9 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(PackageInternal) @testable import HTTP3
 import NIOQUICHelpers
 import Testing
+
+@_spi(PackageInternal) @testable import HTTP3
 
 struct HTTP3ConnectionQuiescingStateMachineTests {
     // MARK: Receiving GOAWAY

--- a/Tests/HTTP3Tests/HTTP3ConnectionQuiescingStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3ConnectionQuiescingStateMachineTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@testable import HTTP3
 import NIOQUICHelpers
 import Testing
 

--- a/Tests/HTTP3Tests/HTTP3ConnectionQuiescingStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3ConnectionQuiescingStateMachineTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import HTTP3
+@_spi(PackageInternal) @testable import HTTP3
 import NIOQUICHelpers
 import Testing
 

--- a/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
@@ -12,9 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@_spi(PackageInternal) import HTTP3
 import NIOQUICHelpers
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 
 struct HTTP3ConnectionStateMachineTests {

--- a/Tests/HTTP3Tests/HTTP3ErrorTests.swift
+++ b/Tests/HTTP3Tests/HTTP3ErrorTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@_spi(PackageInternal) import HTTP3
 import Testing
 
 struct HTTP3ErrorTests {

--- a/Tests/HTTP3Tests/HTTP3FrameCodingTests.swift
+++ b/Tests/HTTP3Tests/HTTP3FrameCodingTests.swift
@@ -12,10 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@_spi(PackageInternal) @testable import HTTP3
 import HTTPTypes
 import NIOCore
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 
 struct HTTP3FrameCodingTests {

--- a/Tests/HTTP3Tests/HTTP3FrameCodingTests.swift
+++ b/Tests/HTTP3Tests/HTTP3FrameCodingTests.swift
@@ -12,11 +12,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(PackageInternal) @testable import HTTP3
 import HTTPTypes
 import NIOCore
 @_spi(PackageInternal) import QPACK
 import Testing
+
+@_spi(PackageInternal) @testable import HTTP3
 
 struct HTTP3FrameCodingTests {
     @Test

--- a/Tests/HTTP3Tests/HTTP3FrameDecoderStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3FrameDecoderStateMachineTests.swift
@@ -12,10 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable @_spi(PackageInternal) import HTTP3
 import NIOCore
 @_spi(PackageInternal) import QPACK
 import Testing
+
+@testable @_spi(PackageInternal) import HTTP3
 
 struct HTTP3FrameDecoderStateMachineTests {
     private let testDataFrameContent: [UInt8] = [1, 2, 3, 4]

--- a/Tests/HTTP3Tests/HTTP3FrameDecoderStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3FrameDecoderStateMachineTests.swift
@@ -12,9 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@testable @_spi(PackageInternal) import HTTP3
 import NIOCore
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 
 struct HTTP3FrameDecoderStateMachineTests {

--- a/Tests/HTTP3Tests/HTTP3FrameValidatorTests.swift
+++ b/Tests/HTTP3Tests/HTTP3FrameValidatorTests.swift
@@ -12,8 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(PackageInternal) @testable import HTTP3
 import Testing
+
+@_spi(PackageInternal) @testable import HTTP3
 
 struct HTTP3FrameValidatorTests {
     static func validRequestHeaders() -> HTTP3Frame {

--- a/Tests/HTTP3Tests/HTTP3FrameValidatorTests.swift
+++ b/Tests/HTTP3Tests/HTTP3FrameValidatorTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import HTTP3
+@_spi(PackageInternal) @testable import HTTP3
 import Testing
 
 struct HTTP3FrameValidatorTests {
@@ -575,7 +575,7 @@ extension HTTP3FrameValidator {
 }
 
 extension HTTP3FrameValidator.ProcessFrameAction: Equatable {
-    package static func == (lhs: Self, rhs: Self) -> Bool {
+    static func == (lhs: Self, rhs: Self) -> Bool {
         switch (lhs, rhs) {
         case (.forwardFrame(let l), .forwardFrame(let r)): return l == r
         case (.previousError, .previousError): return true
@@ -614,7 +614,7 @@ extension HTTP3FrameValidator.ProcessFrameAction: Equatable {
 }
 
 extension HTTP3FrameValidator.UnknownFrameAction: Equatable {
-    package static func == (lhs: Self, rhs: Self) -> Bool {
+    static func == (lhs: Self, rhs: Self) -> Bool {
         switch (lhs, rhs) {
         case (.dropFrame, .dropFrame): return true
         case (.previousError, .previousError): return true

--- a/Tests/HTTP3Tests/HTTP3GoAwayIDTests.swift
+++ b/Tests/HTTP3Tests/HTTP3GoAwayIDTests.swift
@@ -12,8 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import HTTP3
 import Testing
+
+@testable import HTTP3
 
 struct HTTP3GoawayIDTests {
     @Test

--- a/Tests/HTTP3Tests/HTTP3GoAwayIDTests.swift
+++ b/Tests/HTTP3Tests/HTTP3GoAwayIDTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@testable import HTTP3
 import Testing
 
 struct HTTP3GoawayIDTests {

--- a/Tests/HTTP3Tests/HTTP3SettingsTests.swift
+++ b/Tests/HTTP3Tests/HTTP3SettingsTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@testable import HTTP3
 import NIOCore
 import Testing
 

--- a/Tests/HTTP3Tests/HTTP3SettingsTests.swift
+++ b/Tests/HTTP3Tests/HTTP3SettingsTests.swift
@@ -12,9 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import HTTP3
 import NIOCore
 import Testing
+
+@testable import HTTP3
 
 struct HTTP3SettingsTests {
     @Test

--- a/Tests/HTTP3Tests/HTTP3StreamStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3StreamStateMachineTests.swift
@@ -12,12 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(PackageInternal) @testable import HTTP3
 import HTTPTypes
 import NIOCore
 import NIOQUICHelpers
 @_spi(PackageInternal) import QPACK
 import Testing
+
+@_spi(PackageInternal) @testable import HTTP3
 
 struct HTTP3StreamStateMachineTests {
     private let testDataFrame = HTTP3Frame.data(.init(bytes: [1, 2, 3, 4]))

--- a/Tests/HTTP3Tests/HTTP3StreamStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3StreamStateMachineTests.swift
@@ -12,11 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@_spi(PackageInternal) @testable import HTTP3
 import HTTPTypes
 import NIOCore
 import NIOQUICHelpers
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 
 struct HTTP3StreamStateMachineTests {

--- a/Tests/HTTP3Tests/QPACKStateMachineTests.swift
+++ b/Tests/HTTP3Tests/QPACKStateMachineTests.swift
@@ -12,10 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(PackageInternal) @testable import HTTP3
 import NIOQUICHelpers
 @_spi(PackageInternal) import QPACK
 import Testing
+
+@_spi(PackageInternal) @testable import HTTP3
 
 struct QPACKStateMachineTests {
     @Test

--- a/Tests/HTTP3Tests/QPACKStateMachineTests.swift
+++ b/Tests/HTTP3Tests/QPACKStateMachineTests.swift
@@ -12,9 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import HTTP3
+@_spi(PackageInternal) @testable import HTTP3
 import NIOQUICHelpers
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 
 struct QPACKStateMachineTests {

--- a/Tests/HTTP3Tests/QPACKStateMachineTests.swift
+++ b/Tests/HTTP3Tests/QPACKStateMachineTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@testable import HTTP3
 import NIOQUICHelpers
 import QPACK
 import Testing

--- a/Tests/HTTP3Tests/StreamIDTrackerTests.swift
+++ b/Tests/HTTP3Tests/StreamIDTrackerTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@testable import HTTP3
 import Testing
 
 struct StreamIDTrackerTests {

--- a/Tests/HTTP3Tests/StreamIDTrackerTests.swift
+++ b/Tests/HTTP3Tests/StreamIDTrackerTests.swift
@@ -12,8 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import HTTP3
 import Testing
+
+@testable import HTTP3
 
 struct StreamIDTrackerTests {
     @Test

--- a/Tests/HTTP3Tests/TestUtil.swift
+++ b/Tests/HTTP3Tests/TestUtil.swift
@@ -14,6 +14,7 @@
 
 public import HTTP3
 import NIOCore
+
 @testable import QPACK
 
 extension String {

--- a/Tests/HTTP3Tests/TestUtil.swift
+++ b/Tests/HTTP3Tests/TestUtil.swift
@@ -14,7 +14,7 @@
 
 public import HTTP3
 import NIOCore
-import QPACK
+@testable import QPACK
 
 extension String {
     var huffmanEncodedBytes: [UInt8] {

--- a/Tests/NIOHTTP3Tests/HTTP3GracefulShutdownTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3GracefulShutdownTests.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
@@ -20,6 +19,7 @@ import NIOEmbedded
 import NIOQUICHelpers
 import Testing
 
+@_spi(PackageInternal) @testable import HTTP3
 @testable import NIOHTTP3
 
 struct HTTP3GracefulShutdownTests {

--- a/Tests/NIOHTTP3Tests/HTTP3OutboundControlStreamHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3OutboundControlStreamHandlerTests.swift
@@ -12,9 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@_spi(PackageInternal) import HTTP3
 import NIOEmbedded
-import NIOHTTP3
+@testable import NIOHTTP3
 import Testing
 
 struct HTTP3OutboundControlStreamHandlerTests {

--- a/Tests/NIOHTTP3Tests/HTTP3OutboundControlStreamHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3OutboundControlStreamHandlerTests.swift
@@ -14,8 +14,9 @@
 
 @_spi(PackageInternal) import HTTP3
 import NIOEmbedded
-@testable import NIOHTTP3
 import Testing
+
+@testable import NIOHTTP3
 
 struct HTTP3OutboundControlStreamHandlerTests {
     let testSettings = HTTP3Settings(qpackMaximumTableCapacity: 100)

--- a/Tests/NIOHTTP3Tests/HTTP3OutboundControlStreamStateMachineTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3OutboundControlStreamStateMachineTests.swift
@@ -13,8 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(PackageInternal) import HTTP3
-@testable import NIOHTTP3
 import Testing
+
+@testable import NIOHTTP3
 
 struct HTTP3OutboundControlStreamStateMachineTests {
     @Test

--- a/Tests/NIOHTTP3Tests/HTTP3OutboundControlStreamStateMachineTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3OutboundControlStreamStateMachineTests.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
-import NIOHTTP3
+@_spi(PackageInternal) import HTTP3
+@testable import NIOHTTP3
 import Testing
 
 struct HTTP3OutboundControlStreamStateMachineTests {

--- a/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import DequeModule
-import HTTP3
+@_spi(PackageInternal) @testable import HTTP3
 import HTTPTypes
 import Logging
 import NIOConcurrencyHelpers

--- a/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
@@ -22,7 +22,7 @@ import NIOEmbedded
 import NIOExtras
 @testable import NIOHTTP3
 import NIOQUICHelpers
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 
 struct NIOHTTP3StreamHandlerTests {

--- a/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
@@ -20,7 +20,7 @@ import NIOConcurrencyHelpers
 import NIOCore
 import NIOEmbedded
 import NIOExtras
-import NIOHTTP3
+@testable import NIOHTTP3
 import NIOQUICHelpers
 import QPACK
 import Testing

--- a/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
@@ -13,17 +13,18 @@
 //===----------------------------------------------------------------------===//
 
 import DequeModule
-@_spi(PackageInternal) @testable import HTTP3
 import HTTPTypes
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOEmbedded
 import NIOExtras
-@testable import NIOHTTP3
 import NIOQUICHelpers
 @_spi(PackageInternal) import QPACK
 import Testing
+
+@_spi(PackageInternal) @testable import HTTP3
+@testable import NIOHTTP3
 
 struct NIOHTTP3StreamHandlerTests {
     private var testRequestHeaderFields: [HTTPField] = [

--- a/Tests/NIOHTTP3Tests/HTTP3ToHTTPCodecTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3ToHTTPCodecTests.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(PackageInternal) @testable import HTTP3
 import HTTPTypes
 import NIOConcurrencyHelpers
 import NIOCore
@@ -21,6 +20,8 @@ import NIOExtras
 import NIOHTTP3
 import NIOHTTPTypes
 import Testing
+
+@_spi(PackageInternal) @testable import HTTP3
 
 struct HTTP3ToHTTPCodecTests {
     private let validRequestHead: HTTP3Frame = .headers([

--- a/Tests/NIOHTTP3Tests/HTTP3ToHTTPCodecTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3ToHTTPCodecTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@_spi(PackageInternal) @testable import HTTP3
 import HTTPTypes
 import NIOConcurrencyHelpers
 import NIOCore

--- a/Tests/NIOHTTP3Tests/HTTP3ToHTTPCodecTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3ToHTTPCodecTests.swift
@@ -49,8 +49,8 @@ struct HTTP3ToHTTPCodecTests {
         try channel.writeOutbound(
             HTTPRequestPart.head(.init(method: .get, scheme: "https", authority: "test", path: "/"))
         )
-        try channel.writeOutbound(HTTPRequestPart.body(buffer: .init(bytes: [1, 2, 3])))
-        try channel.writeOutbound(HTTPRequestPart.body(buffer: .init(bytes: [4, 5, 6])))
+        try channel.writeOutbound(HTTPRequestPart.body(.init(bytes: [1, 2, 3])))
+        try channel.writeOutbound(HTTPRequestPart.body(.init(bytes: [4, 5, 6])))
         try channel.writeOutbound(HTTPRequestPart.end([.cookie: "test"]))
 
         let events = try framesPromise.futureResult.wait()
@@ -114,8 +114,8 @@ struct HTTP3ToHTTPCodecTests {
         let channel = EmbeddedChannel(handlers: [recorder, handler], loop: eventLoop)
 
         try channel.writeOutbound(HTTPResponsePart.head(.init(status: .ok)))
-        try channel.writeOutbound(HTTPResponsePart.body(buffer: .init(bytes: [1, 2, 3])))
-        try channel.writeOutbound(HTTPResponsePart.body(buffer: .init(bytes: [4, 5, 6])))
+        try channel.writeOutbound(HTTPResponsePart.body(.init(bytes: [1, 2, 3])))
+        try channel.writeOutbound(HTTPResponsePart.body(.init(bytes: [4, 5, 6])))
         try channel.writeOutbound(HTTPResponsePart.end([.cookie: "test"]))
 
         var events = [WriteOrClose<HTTP3Frame>]()

--- a/Tests/NIOHTTP3Tests/HTTP3UnidirectionalStreamTypeDecoderHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3UnidirectionalStreamTypeDecoderHandlerTests.swift
@@ -16,7 +16,7 @@
 import Logging
 import NIOCore
 import NIOEmbedded
-import NIOHTTP3
+@testable import NIOHTTP3
 import NIOTestUtils
 import Testing
 

--- a/Tests/NIOHTTP3Tests/HTTP3UnidirectionalStreamTypeDecoderHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3UnidirectionalStreamTypeDecoderHandlerTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@_spi(PackageInternal) import HTTP3
 import Logging
 import NIOCore
 import NIOEmbedded

--- a/Tests/NIOHTTP3Tests/HTTP3UnidirectionalStreamTypeDecoderHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3UnidirectionalStreamTypeDecoderHandlerTests.swift
@@ -16,12 +16,13 @@
 import Logging
 import NIOCore
 import NIOEmbedded
-@testable import NIOHTTP3
 import NIOTestUtils
 import Testing
 
 import struct NIOQUICHelpers.QUICApplicationErrorCode
 import struct NIOQUICHelpers.QUICStopSendingEvent
+
+@testable import NIOHTTP3
 
 /// - Warning: Only access on eventloop!
 private final class RecorderHandler: ChannelInboundHandler {

--- a/Tests/NIOHTTP3Tests/HTTP3UnidirectionalStreamTypeDecoderStateMachineTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3UnidirectionalStreamTypeDecoderStateMachineTests.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
-import NIOHTTP3
+@_spi(PackageInternal) import HTTP3
+@testable import NIOHTTP3
 import Testing
 
 import struct NIOCore.ByteBuffer

--- a/Tests/NIOHTTP3Tests/HTTP3UnidirectionalStreamTypeDecoderStateMachineTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3UnidirectionalStreamTypeDecoderStateMachineTests.swift
@@ -13,10 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(PackageInternal) import HTTP3
-@testable import NIOHTTP3
 import Testing
 
 import struct NIOCore.ByteBuffer
+
+@testable import NIOHTTP3
 
 struct HTTP3UnidirectionalStreamTypeDecoderStateMachineTests {
     @Test

--- a/Tests/NIOHTTP3Tests/HTTPMessageParsingTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTPMessageParsingTests.swift
@@ -12,13 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(PackageInternal) @testable import HTTP3
 import HTTPTypes
 import NIOCore
 import NIOEmbedded
-@testable import NIOHTTP3
 import NIOHTTPTypes
 import Testing
+
+@_spi(PackageInternal) @testable import HTTP3
+@testable import NIOHTTP3
 
 struct HTTPMessageParsingTests {
     let validRequestHead: HTTP3Frame = .headers([

--- a/Tests/NIOHTTP3Tests/HTTPMessageParsingTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTPMessageParsingTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HTTP3
+@_spi(PackageInternal) @testable import HTTP3
 import HTTPTypes
 import NIOCore
 import NIOEmbedded

--- a/Tests/NIOHTTP3Tests/HTTPMessageParsingTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTPMessageParsingTests.swift
@@ -16,7 +16,7 @@ import HTTP3
 import HTTPTypes
 import NIOCore
 import NIOEmbedded
-import NIOHTTP3
+@testable import NIOHTTP3
 import NIOHTTPTypes
 import Testing
 

--- a/Tests/NIOHTTP3Tests/QPACKOutboundDecoderStreamHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/QPACKOutboundDecoderStreamHandlerTests.swift
@@ -13,9 +13,10 @@
 //===----------------------------------------------------------------------===//
 
 import NIOEmbedded
-@testable import NIOHTTP3
 @_spi(PackageInternal) import QPACK
 import Testing
+
+@testable import NIOHTTP3
 
 struct QPACKOutboundDecoderStreamHandlerTests {
     @Test

--- a/Tests/NIOHTTP3Tests/QPACKOutboundDecoderStreamHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/QPACKOutboundDecoderStreamHandlerTests.swift
@@ -13,8 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import NIOEmbedded
-import NIOHTTP3
-import QPACK
+@testable import NIOHTTP3
+@_spi(PackageInternal) import QPACK
 import Testing
 
 struct QPACKOutboundDecoderStreamHandlerTests {

--- a/Tests/NIOHTTP3Tests/QPACKOutboundEncoderStreamHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/QPACKOutboundEncoderStreamHandlerTests.swift
@@ -13,8 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import NIOEmbedded
-import NIOHTTP3
-import QPACK
+@testable import NIOHTTP3
+@_spi(PackageInternal) import QPACK
 import Testing
 
 struct QPACKOutboundEncoderStreamHandlerTests {

--- a/Tests/NIOHTTP3Tests/QPACKOutboundEncoderStreamHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/QPACKOutboundEncoderStreamHandlerTests.swift
@@ -13,9 +13,10 @@
 //===----------------------------------------------------------------------===//
 
 import NIOEmbedded
-@testable import NIOHTTP3
 @_spi(PackageInternal) import QPACK
 import Testing
+
+@testable import NIOHTTP3
 
 struct QPACKOutboundEncoderStreamHandlerTests {
     @Test

--- a/Tests/NIOHTTP3Tests/StreamClosedHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/StreamClosedHandlerTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIOHTTP3
+@testable import NIOHTTP3
 import Testing
 
 struct StreamClosedHandlerTests {

--- a/Tests/NIOHTTP3Tests/StreamClosedHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/StreamClosedHandlerTests.swift
@@ -12,8 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import NIOHTTP3
 import Testing
+
+@testable import NIOHTTP3
 
 struct StreamClosedHandlerTests {
     @Test

--- a/Tests/QPACKTests/DecoderInstructionCoderTests.swift
+++ b/Tests/QPACKTests/DecoderInstructionCoderTests.swift
@@ -14,7 +14,7 @@
 
 import HTTPTypes
 import NIOCore
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 
 /// Tests for encoding and decoding the `decoder instructions`.

--- a/Tests/QPACKTests/DecoderInstructionCoderTests.swift
+++ b/Tests/QPACKTests/DecoderInstructionCoderTests.swift
@@ -14,7 +14,7 @@
 
 import HTTPTypes
 import NIOCore
-@_spi(PackageInternal) import QPACK
+@_spi(PackageInternal) @testable import QPACK
 import Testing
 
 /// Tests for encoding and decoding the `decoder instructions`.

--- a/Tests/QPACKTests/DecoderInstructionCoderTests.swift
+++ b/Tests/QPACKTests/DecoderInstructionCoderTests.swift
@@ -14,8 +14,9 @@
 
 import HTTPTypes
 import NIOCore
-@_spi(PackageInternal) @testable import QPACK
 import Testing
+
+@_spi(PackageInternal) @testable import QPACK
 
 /// Tests for encoding and decoding the `decoder instructions`.
 struct DecoderInstructionCoderTests {

--- a/Tests/QPACKTests/DecoderTests.swift
+++ b/Tests/QPACKTests/DecoderTests.swift
@@ -15,7 +15,7 @@
 import HTTPTypes
 import NIOCore
 import NIOQUICHelpers
-@_spi(PackageInternal) import QPACK
+@_spi(PackageInternal) @testable import QPACK
 import Testing
 
 struct DecoderTests {

--- a/Tests/QPACKTests/DecoderTests.swift
+++ b/Tests/QPACKTests/DecoderTests.swift
@@ -15,8 +15,9 @@
 import HTTPTypes
 import NIOCore
 import NIOQUICHelpers
-@_spi(PackageInternal) @testable import QPACK
 import Testing
+
+@_spi(PackageInternal) @testable import QPACK
 
 struct DecoderTests {
     @Test

--- a/Tests/QPACKTests/DecoderTests.swift
+++ b/Tests/QPACKTests/DecoderTests.swift
@@ -15,7 +15,7 @@
 import HTTPTypes
 import NIOCore
 import NIOQUICHelpers
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 
 struct DecoderTests {

--- a/Tests/QPACKTests/DynamicHeaderTableTests.swift
+++ b/Tests/QPACKTests/DynamicHeaderTableTests.swift
@@ -14,7 +14,7 @@
 
 import HTTPTypes
 import NIOCore
-import QPACK
+@testable import QPACK
 import Testing
 
 struct DynamicHeaderTableTests {

--- a/Tests/QPACKTests/DynamicHeaderTableTests.swift
+++ b/Tests/QPACKTests/DynamicHeaderTableTests.swift
@@ -14,8 +14,9 @@
 
 import HTTPTypes
 import NIOCore
-@testable import QPACK
 import Testing
+
+@testable import QPACK
 
 struct DynamicHeaderTableTests {
     @Test

--- a/Tests/QPACKTests/EncodeDecodeTests.swift
+++ b/Tests/QPACKTests/EncodeDecodeTests.swift
@@ -14,7 +14,7 @@
 
 import HTTPTypes
 import NIOQUICHelpers
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 
 struct EncodeDecodeTests {

--- a/Tests/QPACKTests/EncoderInstructionCoderTests.swift
+++ b/Tests/QPACKTests/EncoderInstructionCoderTests.swift
@@ -14,7 +14,7 @@
 
 import HTTPTypes
 import NIOCore
-@_spi(PackageInternal) import QPACK
+@_spi(PackageInternal) @testable import QPACK
 import Testing
 
 /// Tests for encoding and decoding the `encoder instructions`.

--- a/Tests/QPACKTests/EncoderInstructionCoderTests.swift
+++ b/Tests/QPACKTests/EncoderInstructionCoderTests.swift
@@ -14,7 +14,7 @@
 
 import HTTPTypes
 import NIOCore
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 
 /// Tests for encoding and decoding the `encoder instructions`.

--- a/Tests/QPACKTests/EncoderInstructionCoderTests.swift
+++ b/Tests/QPACKTests/EncoderInstructionCoderTests.swift
@@ -14,8 +14,9 @@
 
 import HTTPTypes
 import NIOCore
-@_spi(PackageInternal) @testable import QPACK
 import Testing
+
+@_spi(PackageInternal) @testable import QPACK
 
 /// Tests for encoding and decoding the `encoder instructions`.
 struct EncoderInstructionCoderTests {

--- a/Tests/QPACKTests/EncoderTests.swift
+++ b/Tests/QPACKTests/EncoderTests.swift
@@ -13,8 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import HTTPTypes
-@_spi(PackageInternal) @testable import QPACK
 import Testing
+
+@_spi(PackageInternal) @testable import QPACK
 
 struct EncoderTests {
     /// Dynamic table is disabled, literal should be sent as a literal.

--- a/Tests/QPACKTests/EncoderTests.swift
+++ b/Tests/QPACKTests/EncoderTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import HTTPTypes
-@_spi(PackageInternal) import QPACK
+@_spi(PackageInternal) @testable import QPACK
 import Testing
 
 struct EncoderTests {

--- a/Tests/QPACKTests/EncoderTests.swift
+++ b/Tests/QPACKTests/EncoderTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import HTTPTypes
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 
 struct EncoderTests {

--- a/Tests/QPACKTests/EndToEndTests.swift
+++ b/Tests/QPACKTests/EndToEndTests.swift
@@ -15,7 +15,7 @@
 import HTTPTypes
 import NIOCore
 import NIOQUICHelpers
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 
 struct EndToEndTests {

--- a/Tests/QPACKTests/EndToEndTests.swift
+++ b/Tests/QPACKTests/EndToEndTests.swift
@@ -15,8 +15,9 @@
 import HTTPTypes
 import NIOCore
 import NIOQUICHelpers
-@_spi(PackageInternal) @testable import QPACK
 import Testing
+
+@_spi(PackageInternal) @testable import QPACK
 
 struct EndToEndTests {
     @Test

--- a/Tests/QPACKTests/EndToEndTests.swift
+++ b/Tests/QPACKTests/EndToEndTests.swift
@@ -15,7 +15,7 @@
 import HTTPTypes
 import NIOCore
 import NIOQUICHelpers
-@_spi(PackageInternal) import QPACK
+@_spi(PackageInternal) @testable import QPACK
 import Testing
 
 struct EndToEndTests {

--- a/Tests/QPACKTests/FieldLineCodingTests.swift
+++ b/Tests/QPACKTests/FieldLineCodingTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-import QPACK
+@_spi(PackageInternal) @testable import QPACK
 import Testing
 
 struct FieldLineCodingTests {

--- a/Tests/QPACKTests/FieldLineCodingTests.swift
+++ b/Tests/QPACKTests/FieldLineCodingTests.swift
@@ -13,8 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-@_spi(PackageInternal) @testable import QPACK
 import Testing
+
+@_spi(PackageInternal) @testable import QPACK
 
 struct FieldLineCodingTests {
     @Test

--- a/Tests/QPACKTests/HuffmanCodingTests.swift
+++ b/Tests/QPACKTests/HuffmanCodingTests.swift
@@ -14,8 +14,9 @@
 
 import Foundation
 import NIOCore
-@testable import QPACK
 import Testing
+
+@testable import QPACK
 
 struct HuffmanCodingTests {
     var scratchBuffer: ByteBuffer = ByteBufferAllocator().buffer(capacity: 4096)

--- a/Tests/QPACKTests/HuffmanCodingTests.swift
+++ b/Tests/QPACKTests/HuffmanCodingTests.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import NIOCore
-import QPACK
+@testable import QPACK
 import Testing
 
 struct HuffmanCodingTests {

--- a/Tests/QPACKTests/InstructionCodingTests.swift
+++ b/Tests/QPACKTests/InstructionCodingTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-@_spi(PackageInternal) import QPACK
+@_spi(PackageInternal) @testable import QPACK
 import Testing
 
 struct InstructionCodingTests {

--- a/Tests/QPACKTests/InstructionCodingTests.swift
+++ b/Tests/QPACKTests/InstructionCodingTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 
 struct InstructionCodingTests {

--- a/Tests/QPACKTests/InstructionCodingTests.swift
+++ b/Tests/QPACKTests/InstructionCodingTests.swift
@@ -13,8 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-@_spi(PackageInternal) @testable import QPACK
 import Testing
+
+@_spi(PackageInternal) @testable import QPACK
 
 struct InstructionCodingTests {
     @Test

--- a/Tests/QPACKTests/IntegerCodingTests.swift
+++ b/Tests/QPACKTests/IntegerCodingTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 
 struct IntegerCodingTests {

--- a/Tests/QPACKTests/IntegerCodingTests.swift
+++ b/Tests/QPACKTests/IntegerCodingTests.swift
@@ -13,8 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-@_spi(PackageInternal) @testable import QPACK
 import Testing
+
+@_spi(PackageInternal) @testable import QPACK
 
 struct IntegerCodingTests {
     private var scratchBuffer = ByteBufferAllocator().buffer(capacity: 11)

--- a/Tests/QPACKTests/IntegerCodingTests.swift
+++ b/Tests/QPACKTests/IntegerCodingTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-@_spi(PackageInternal) import QPACK
+@_spi(PackageInternal) @testable import QPACK
 import Testing
 
 struct IntegerCodingTests {

--- a/Tests/QPACKTests/StaticHeaderTableTests.swift
+++ b/Tests/QPACKTests/StaticHeaderTableTests.swift
@@ -13,8 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-@testable import QPACK
 import Testing
+
+@testable import QPACK
 
 struct StaticHeaderTableTests {
     @Test

--- a/Tests/QPACKTests/StaticHeaderTableTests.swift
+++ b/Tests/QPACKTests/StaticHeaderTableTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-import QPACK
+@testable import QPACK
 import Testing
 
 struct StaticHeaderTableTests {

--- a/Tests/QPACKTests/StringCodingTests.swift
+++ b/Tests/QPACKTests/StringCodingTests.swift
@@ -13,8 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-@_spi(PackageInternal) @testable import QPACK
 import Testing
+
+@_spi(PackageInternal) @testable import QPACK
 
 struct StringCodingTests {
     private var scratchBuffer = ByteBufferAllocator().buffer(capacity: 11)

--- a/Tests/QPACKTests/StringCodingTests.swift
+++ b/Tests/QPACKTests/StringCodingTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-import QPACK
+@_spi(PackageInternal) import QPACK
 import Testing
 
 struct StringCodingTests {

--- a/Tests/QPACKTests/StringCodingTests.swift
+++ b/Tests/QPACKTests/StringCodingTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-@_spi(PackageInternal) import QPACK
+@_spi(PackageInternal) @testable import QPACK
 import Testing
 
 struct StringCodingTests {


### PR DESCRIPTION
This is a mechanical change.

### Motivation

CMO does not work for objects that use the package access modifier.

### Modifications

- Remove all `package` access modifiers
- Mark objects `internal` and import as `@testable` in tests that only need to be accessed from tests
- Mark objects `@_spi(PackageInternal)` that need to be accessed from other modules.
