### PR TITLE
Make constants static var over static let

### DIFF
--- a/Sources/HTTP3/HTTP3ErrorCode.swift
+++ b/Sources/HTTP3/HTTP3ErrorCode.swift
@@ -25,58 +25,80 @@ public struct HTTP3ErrorCode: Hashable, Sendable {
     public var rawValue: UInt64
 
     /// Create an ``HTTP3ErrorCode`` from its raw value.
+    @inlinable
     public init(rawValue: UInt64) {
         self.rawValue = rawValue
     }
 
     /// No error. This is used when the connection or stream needs to be closed, but there is no error to signal.
-    public static let noError = HTTP3ErrorCode(rawValue: 0x0100)
+    @inlinable
+    public static var noError: HTTP3ErrorCode { Self(rawValue: 0x0100) }
     /// Peer violated protocol requirements in a way that does not match a more specific error code or endpoint declines to use the more specific error code.
-    public static let generalProtocolError = HTTP3ErrorCode(rawValue: 0x0101)
+    @inlinable
+    public static var generalProtocolError: HTTP3ErrorCode { Self(rawValue: 0x0101) }
     /// An internal error has occurred in the HTTP stack.
-    public static let internalError = HTTP3ErrorCode(rawValue: 0x0102)
+    @inlinable
+    public static var internalError: HTTP3ErrorCode { Self(rawValue: 0x0102) }
     /// The endpoint detected that its peer created a stream that it will not accept.
-    public static let streamCreationError = HTTP3ErrorCode(rawValue: 0x0103)
+    @inlinable
+    public static var streamCreationError: HTTP3ErrorCode { Self(rawValue: 0x0103) }
     /// A stream required by the HTTP/3 connection was closed or reset.
-    public static let closedCriticalStream = HTTP3ErrorCode(rawValue: 0x0104)
+    @inlinable
+    public static var closedCriticalStream: HTTP3ErrorCode { Self(rawValue: 0x0104) }
     /// A frame was received that was not permitted in the current state or on the current stream.
-    public static let frameUnexpected = HTTP3ErrorCode(rawValue: 0x0105)
+    @inlinable
+    public static var frameUnexpected: HTTP3ErrorCode { Self(rawValue: 0x0105) }
     /// A frame that fails to satisfy layout requirements or with an invalid size was received.
-    public static let frameError = HTTP3ErrorCode(rawValue: 0x0106)
+    @inlinable
+    public static var frameError: HTTP3ErrorCode { Self(rawValue: 0x0106) }
     /// The endpoint detected that its peer is exhibiting a behavior that might be generating excessive load.
-    public static let excessiveLoad = HTTP3ErrorCode(rawValue: 0x0107)
+    @inlinable
+    public static var excessiveLoad: HTTP3ErrorCode { Self(rawValue: 0x0107) }
     /// A stream ID or push ID was used incorrectly, such as exceeding a limit, reducing a limit, or being reused.
-    public static let idError = HTTP3ErrorCode(rawValue: 0x0108)
+    @inlinable
+    public static var idError: HTTP3ErrorCode { Self(rawValue: 0x0108) }
     /// An endpoint detected an error in the payload of a SETTINGS frame.
-    public static let settingsError = HTTP3ErrorCode(rawValue: 0x0109)
+    @inlinable
+    public static var settingsError: HTTP3ErrorCode { Self(rawValue: 0x0109) }
     /// No SETTINGS frame was received at the beginning of the control stream.
-    public static let missingSettings = HTTP3ErrorCode(rawValue: 0x010a)
+    @inlinable
+    public static var missingSettings: HTTP3ErrorCode { Self(rawValue: 0x010a) }
     /// A server rejected a request without performing any application processing.
-    public static let requestRejected = HTTP3ErrorCode(rawValue: 0x010b)
+    @inlinable
+    public static var requestRejected: HTTP3ErrorCode { Self(rawValue: 0x010b) }
     /// The request or its response (including pushed response) is cancelled.
-    public static let requestCancelled = HTTP3ErrorCode(rawValue: 0x010c)
+    @inlinable
+    public static var requestCancelled: HTTP3ErrorCode { Self(rawValue: 0x010c) }
     /// The client's stream terminated without containing a fully formed request.
-    public static let requestIncomplete = HTTP3ErrorCode(rawValue: 0x010d)
+    @inlinable
+    public static var requestIncomplete: HTTP3ErrorCode { Self(rawValue: 0x010d) }
     /// An HTTP message was malformed and cannot be processed.
-    public static let messageError = HTTP3ErrorCode(rawValue: 0x010e)
+    @inlinable
+    public static var messageError: HTTP3ErrorCode { Self(rawValue: 0x010e) }
     /// The TCP connection established in response to a CONNECT request was reset or abnormally closed.
-    public static let connectError = HTTP3ErrorCode(rawValue: 0x010f)
+    @inlinable
+    public static var connectError: HTTP3ErrorCode { Self(rawValue: 0x010f) }
     /// The requested operation cannot be served over HTTP/3. The peer should retry over HTTP/1.1.
-    public static let versionFallback = HTTP3ErrorCode(rawValue: 0x0110)
+    @inlinable
+    public static var versionFallback: HTTP3ErrorCode { Self(rawValue: 0x0110) }
 
     // MARK: QPACK (RFC 9204)
 
     /// The decoder failed to interpret an encoded field section and is not able to continue decoding that field section.
-    public static let qpackDecompressionFailed = HTTP3ErrorCode(rawValue: 0x0200)
+    @inlinable
+    public static var qpackDecompressionFailed: HTTP3ErrorCode { Self(rawValue: 0x0200) }
     /// The decoder failed to interpret an encoder instruction received on the encoder stream.
-    public static let qpackEncoderStreamError = HTTP3ErrorCode(rawValue: 0x0201)
+    @inlinable
+    public static var qpackEncoderStreamError: HTTP3ErrorCode { Self(rawValue: 0x0201) }
     /// The encoder failed to interpret a decoder instruction received on the decoder stream.
-    public static let qpackDecoderStreamError = HTTP3ErrorCode(rawValue: 0x0202)
+    @inlinable
+    public static var qpackDecoderStreamError: HTTP3ErrorCode { Self(rawValue: 0x0202) }
 
     // MARK: Datagrams and Capsule (RFC 9297)
 
     /// Datagram or Capsule protocol parse error.
-    public static let datagramError = HTTP3ErrorCode(rawValue: 0x33)
+    @inlinable
+    public static var datagramError: HTTP3ErrorCode { Self(rawValue: 0x33) }
 }
 
 extension HTTP3ErrorCode: CustomDebugStringConvertible {

--- a/Sources/HTTP3/HTTP3Setting.swift
+++ b/Sources/HTTP3/HTTP3Setting.swift
@@ -70,21 +70,24 @@ extension HTTP3Setting {
         /// The default value is zero. This is the equivalent of the `SETTINGS_HEADER_TABLE_SIZE` from HTTP/2.
         ///
         /// See [RFC 9204 § 5](https://datatracker.ietf.org/doc/html/rfc9204#name-configuration)
-        public static let qpackMaximumTableCapacity = Self(extensionSetting: 0x01)!
+        @inlinable
+        public static var qpackMaximumTableCapacity: HTTP3Setting.Identifier { Self(extensionSetting: 0x01)! }
 
         /// Corresponds to `HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE`.
         ///
         /// The default value is unlimited, there is no limit on the field section size..
         ///
         /// See [RFC 9114 § 7.2.4.1](https://www.rfc-editor.org/rfc/rfc9114.html#section-7.2.4.1)
-        public static let maximumFieldSectionSize = Self(extensionSetting: 0x06)!
+        @inlinable
+        public static var maximumFieldSectionSize: HTTP3Setting.Identifier { Self(extensionSetting: 0x06)! }
 
         /// Corresponds to `SETTINGS_QPACK_BLOCKED_STREAMS`.
         ///
         /// The default value is zero.
         ///
         /// See [RFC 9204 § 5](https://datatracker.ietf.org/doc/html/rfc9204#name-configuration)
-        public static let qpackBlockedStreams = Self(extensionSetting: 0x07)!
+        @inlinable
+        public static var qpackBlockedStreams: HTTP3Setting.Identifier { Self(extensionSetting: 0x07)! }
 
         /// Corresponds to `SETTINGS_H3_DATAGRAM`.
         ///
@@ -92,6 +95,7 @@ extension HTTP3Setting {
         /// that the sender is willing to receive HTTP datagrams.
         ///
         /// See [RFC 9297 § 2.1.1](https://www.rfc-editor.org/rfc/rfc9297.html#section-2.1.1)
-        public static let h3Datagram = Self(extensionSetting: 0x33)!
+        @inlinable
+        public static var h3Datagram: HTTP3Setting.Identifier { Self(extensionSetting: 0x33)! }
     }
 }

--- a/Sources/HTTP3/LoggingKeys.swift
+++ b/Sources/HTTP3/LoggingKeys.swift
@@ -13,12 +13,12 @@
 //===----------------------------------------------------------------------===//
 
 package enum LoggingKeys {
-    package static let h3StreamType = "h3.stream.type"
-    package static let h3Frame = "h3.frame"
-    package static let h3FrameType = "h3.frame.type"
-    package static let quicStreamID = "quic.stream.id"
-    package static let error = "error"
-    package static let bytes = "bytes"
-    package static let goawayID = "h3.goaway.id"
-    package static let reason = "reason"
+    package static var h3StreamType: String { "h3.stream.type" }
+    package static var h3Frame: String { "h3.frame" }
+    package static var h3FrameType: String { "h3.frame.type" }
+    package static var quicStreamID: String { "quic.stream.id" }
+    package static var error: String { "error" }
+    package static var bytes: String { "bytes" }
+    package static var goawayID: String { "h3.goaway.id" }
+    package static var reason: String { "reason" }
 }

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -543,7 +543,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
             stateMachine: .init(
                 streamType: streamType,
                 incoming: incoming,
-                preferHuffmanEncoding: preferHuffmanEncoding
+                preferHuffmanEncoding: self.preferHuffmanEncoding
             ),
             streamID: streamID,
             streamType: streamType,

--- a/Sources/QPACK/HuffmanTables.swift
+++ b/Sources/QPACK/HuffmanTables.swift
@@ -202,9 +202,9 @@ typealias HuffmanDecodeEntry = (state: UInt8, flags: HuffmanDecoderFlags, sym: U
 internal struct HuffmanDecoderFlags: OptionSet {
     var rawValue: UInt8
 
-    static let accepted = HuffmanDecoderFlags(rawValue: 0b001)
-    static let symbol = HuffmanDecoderFlags(rawValue: 0b010)
-    static let failure = HuffmanDecoderFlags(rawValue: 0b100)
+    static var accepted: HuffmanDecoderFlags { Self(rawValue: 0b001) }
+    static var symbol: HuffmanDecoderFlags { Self(rawValue: 0b010) }
+    static var failure: HuffmanDecoderFlags { Self(rawValue: 0b100) }
 }
 
 /// This was described nicely by `@Lukasa` in his Python implementation:

--- a/Sources/QPACK/QPACKConstants.swift
+++ b/Sources/QPACK/QPACKConstants.swift
@@ -15,18 +15,18 @@
 package enum QPACKConstants {
     /// Rough estimate of bytes per header for initial capacity calculation.
     /// Used in HeaderTableStorage initialization for performance optimization.
-    static let estimatedBytesPerHeader: Int = 64
+    static var estimatedBytesPerHeader: Int { 64 }
 
     /// Default target evictable fraction for dynamic header table.
     /// This fraction of the table is kept evictable to reduce blocking.
     /// Value should be between 0.0 and 1.0 (exclusive).
-    package static let defaultTargetEvictableFraction: Double = 0.1
+    package static var defaultTargetEvictableFraction: Double { 0.1 }
 
     /// Default capacity for field lines array when reading field sections.
     /// Used for performance optimization to reduce array reallocations.
-    static let defaultFieldLinesCapacity: Int = 16
+    static var defaultFieldLinesCapacity: Int { 16 }
 
     /// Maximum compression efficiency heuristic for Huffman decoding.
     /// Used to estimate buffer capacity needed for decoded strings.
-    static let huffmanMaxCompressionRatio: Int = 2
+    static var huffmanMaxCompressionRatio: Int { 2 }
 }


### PR DESCRIPTION
### Motivation

Lots of our constants are defined as `static let`s. Static lets are evaluated lazily, because of this a tiny synchronization overhead is added to each lookup. `@inlinable static var`s however can be inlined at compile time – therefore occurring zero lookup costs.

### Modifications

- Move to `static var`
- Add `@inlinable` to public ones

### Result

Easier code for the compiler to optimize.
