### PR TITLE
Wire up datagrams

### DIFF
--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -93,6 +93,8 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             let encoderMaxTableSize: Int
             var streamIDTracker = StreamIDTracker()
             var quiescingState: HTTP3ConnectionQuiescingStateMachine
+            var remoteAllowsDatagrams = false
+            let localAllowsDatagrams: Bool
 
             init(notStarted: consuming NotStarted) {
                 self.inboundControlStream = .init()
@@ -101,6 +103,7 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
                 self.qpackState = notStarted.qpackState
                 self.type = notStarted.type
                 self.encoderMaxTableSize = Int(clamping: notStarted.localSettings.qpackMaximumTableCapacity)
+                self.localAllowsDatagrams = notStarted.localSettings.h3Datagram
                 self.quiescingState = .init(type: notStarted.type)
             }
         }
@@ -152,6 +155,123 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         case .finished:
             self = .init(state: .finished)
             return .none
+        }
+    }
+
+    // MARK: Datagrams
+
+    @_spi(PackageInternal)
+    public enum ReceivedDatagramAction {
+        case buffer
+        case forward
+        case discard
+    }
+
+    @_spi(PackageInternal)
+    public func receivedDatagram(streamID: QUICStreamID) -> ReceivedDatagramAction {
+        switch self.state {
+        case .notStarted(let notStarted):
+            // Buffer if the local peer is willing to receive datagrams.
+            return notStarted.localSettings.h3Datagram ? .buffer : .discard
+
+        case .initialized(let initialized):
+            // Didn't advertise 'SETTINGS_H3_DATAGRAM', discard it.
+            guard initialized.localAllowsDatagrams else { return .discard }
+
+            // If the connection is quiescing then the datagram may never be allowed on some streams.
+            if initialized.type == .server {
+                if !initialized.quiescingState.inboundRequestStreamAllowed(incomingStreamID: streamID) {
+                    return .discard
+                }
+            }
+
+            switch initialized.streamIDTracker.opennessOfStream(withID: streamID) {
+            case .notYetOpen:
+                return .buffer
+            case .open:
+                return .forward
+            case .closed:
+                return .discard
+            }
+
+        case .finished:
+            return .discard
+        }
+    }
+
+    @_spi(PackageInternal)
+    public enum SendDatagramAction {
+        /// Send the datagram on the connection.
+        case send
+        /// Drop the datagram and fail any write promise with the given error.
+        case drop(HTTP3Error)
+
+        @inline(never)
+        static func drop(
+            code: HTTP3Error.Code,
+            message: String,
+            location: HTTP3Error.SourceLocation
+        ) -> Self {
+            let error = HTTP3Error(code: code, message: message, cause: nil, errorCode: nil, location: location)
+            return .drop(error)
+        }
+    }
+
+    /// Whether a datagram associated with the given stream may be sent to the remote.
+    @_spi(PackageInternal)
+    public func sendDatagram(streamID: QUICStreamID) -> SendDatagramAction {
+        switch self.state {
+        case .notStarted:
+            return .drop(
+                code: .datagramsNotNegotiated,
+                message: "Datagrams can't be sent before the connection has been initialized",
+                location: .here()
+            )
+
+        case .initialized(let initialized):
+            // Datagrams can only be sent once the remote peer has advertised they'll accept them.
+            // See: RFC 9297 § 2.1.1.
+            guard initialized.remoteAllowsDatagrams else {
+                return .drop(
+                    code: .datagramsNotNegotiated,
+                    message: "The remote has not advertised support for HTTP datagrams",
+                    location: .here()
+                )
+            }
+
+            // Datagrams can only be sent on client initiated bidirectional streams.
+            // See: RFC 9297 § 2.1.
+            guard streamID.type == .clientInitiatedBidirectional else {
+                return .drop(
+                    code: .invalidStream,
+                    message: "Datagrams can only be sent on client-initiated bidirectional streams",
+                    location: .here()
+                )
+            }
+
+            switch initialized.streamIDTracker.opennessOfStream(withID: streamID) {
+            case .open:
+                return .send
+            case .notYetOpen:
+                return .drop(
+                    code: .invalidStream,
+                    message: "Stream \(streamID) hasn't been opened",
+                    location: .here()
+                )
+            case .closed:
+                return .drop(
+                    code: .invalidStream,
+                    message: "Stream \(streamID) is closed",
+                    location: .here()
+                )
+            }
+
+        case .finished:
+            return .drop(
+                code: .connectionClosed,
+                message: "Datagrams can't be sent once the connection has been closed",
+                location: .here()
+            )
         }
     }
 
@@ -557,6 +677,7 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
                         Int(clamping: settings.qpackMaximumTableCapacity)
                     )
                 )
+                initializedState.remoteAllowsDatagrams = settings.h3Datagram
                 self = .init(state: .initialized(initializedState))
                 switch action {
                 case .makeEncoderInstructionStream:
@@ -861,8 +982,15 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
 
     @_spi(PackageInternal)
     public enum CloseAction {
-        /// Send a GOAWAY frame containing ``id`` and close any existing streams with an id in ``idsToCancel``
-        case sendGoaway(id: HTTP3GoawayID, idsToCancel: [QUICStreamID])
+        /// Send a GOAWAY frame containing ``id`` and close any existing streams with an id in ``idsToCancel``.
+        ///
+        /// Streams with an ID greater than or equal to ``firstRejectedStreamID`` will be rejected and can therefore
+        /// never be created. This is `nil` for clients, whose GOAWAY carries a push ID rather than a stream ID.
+        case sendGoaway(
+            id: HTTP3GoawayID,
+            idsToCancel: [QUICStreamID],
+            firstRejectedStreamID: QUICStreamID?
+        )
         /// Throw an error: the caller of this function has made a mistake and gave us an invalid id.
         case throwError(any Error)
         /// Close the connection immediately.
@@ -882,10 +1010,12 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             let action = initializedState.quiescingState.sendGoaway(goawayID: newLocalMaxID)
 
             let idsToCancel: [QUICStreamID]
+            let firstRejectedStreamID: QUICStreamID?
             switch initializedState.type {
             case .client:
                 // TODO: Once we implement server push, explicitly cancel pushes above the max ID here
                 idsToCancel = []
+                firstRejectedStreamID = nil
             case .server:
                 // RFC 9114 § 5.2: Upon sending a GOAWAY frame, the endpoint SHOULD explicitly cancel (see Sections 4.1.1 and 7.2.3) any requests or
                 // pushes that have identifiers greater than or equal to the one indicated, in order to clean up transport state for the affected streams
@@ -893,13 +1023,14 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
                 idsToCancel = initializedState.streamIDTracker.getOpenStreamIDs {
                     $0 >= sentID && $0.isBidirectional && $0.isClientInitiated
                 }
+                firstRejectedStreamID = sentID
             }
             self = .init(state: .initialized(initializedState))
             switch action {
             case .throwError(let error):
                 return .throwError(error)
             case .sendGoaway(let id):
-                return .sendGoaway(id: id, idsToCancel: idsToCancel)
+                return .sendGoaway(id: id, idsToCancel: idsToCancel, firstRejectedStreamID: firstRejectedStreamID)
             }
         }
     }

--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -168,14 +168,10 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         case connectionError(HTTP3Error)
 
         @inline(never)
-        static func connectionError(
-            code: HTTP3Error.Code,
-            message: String,
-            location: HTTP3Error.SourceLocation
-        ) -> Self {
+        static func datagramsNotNegotiated(location: HTTP3Error.SourceLocation) -> Self {
             let error = HTTP3Error(
-                code: code,
-                message: message,
+                code: .datagramsNotNegotiated,
+                message: "Received an HTTP datagram without having advertised 'SETTINGS_H3_DATAGRAM'",
                 cause: nil,
                 errorCode: .generalProtocolError,
                 location: location
@@ -188,17 +184,16 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
     public func receivedDatagram(streamID: QUICStreamID) -> ReceivedDatagramAction {
         switch self.state {
         case .notStarted(let notStarted):
-            // Buffer if the local peer is willing to receive datagrams.
-            return notStarted.localSettings.h3Datagram ? .buffer : .discard
+            if notStarted.localSettings.h3Datagram {
+                return .buffer
+            } else {
+                return .datagramsNotNegotiated(location: .here())
+            }
 
         case .initialized(let initialized):
-            // Didn't advertise 'SETTINGS_H3_DATAGRAM', discard it.
+            // Didn't advertise 'SETTINGS_H3_DATAGRAM': emit an error.
             guard initialized.localAllowsDatagrams else {
-                return .connectionError(
-                    code: .datagramsNotNegotiated,
-                    message: "Received an HTTP datagram without having advertised 'SETTINGS_H3_DATAGRAM'",
-                    location: .here()
-                )
+                return .datagramsNotNegotiated(location: .here())
             }
 
             // If the connection is quiescing then the datagram may never be allowed on some streams.
@@ -1219,7 +1214,10 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
 
     /// Call this when a stream wants to emit a connection-level error.
     @_spi(PackageInternal)
-    public mutating func emitConnectionErrorFromStream(error: HTTP3Error) -> EmitConnectionErrorAction {
+    public mutating func emitConnectionErrorFromStream(
+        error: HTTP3Error,
+        allowNotStarted: Bool = false
+    ) -> EmitConnectionErrorAction {
         switch consume self.state {
         case .finished:
             // We already finished, so emitting a connection error is now pointless.
@@ -1229,7 +1227,12 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             self = .init(state: .finished)
             return .emitConnectionError(error)
         case .notStarted:
-            fatalError("Stream emitted connection error before started")
+            if allowNotStarted {
+                self = .init(state: .finished)
+                return .emitConnectionError(error)
+            } else {
+                fatalError("Stream emitted connection error before started")
+            }
         }
     }
 

--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -171,7 +171,7 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         static func datagramsNotNegotiated(location: HTTP3Error.SourceLocation) -> Self {
             let error = HTTP3Error(
                 code: .datagramsNotNegotiated,
-                message: "Received an HTTP datagram without having advertised 'SETTINGS_H3_DATAGRAM'",
+                message: "Received an HTTP datagram but datagrams weren't negotiated by both peers",
                 cause: nil,
                 errorCode: .generalProtocolError,
                 location: location
@@ -191,8 +191,8 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             }
 
         case .initialized(let initialized):
-            // Didn't advertise 'SETTINGS_H3_DATAGRAM': emit an error.
-            guard initialized.localAllowsDatagrams else {
+            // Datagrams can only be sent once both peers have advertised support.
+            guard initialized.localAllowsDatagrams, initialized.remoteAllowsDatagrams else {
                 return .datagramsNotNegotiated(location: .here())
             }
 
@@ -247,12 +247,11 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             )
 
         case .initialized(let initialized):
-            // Datagrams can only be sent once the remote peer has advertised they'll accept them.
-            // See: RFC 9297 § 2.1.1.
-            guard initialized.remoteAllowsDatagrams else {
+            // Datagrams can only be sent once both peers have advertised support.
+            guard initialized.remoteAllowsDatagrams, initialized.localAllowsDatagrams else {
                 return .drop(
                     code: .datagramsNotNegotiated,
-                    message: "The remote has not advertised support for HTTP datagrams",
+                    message: "Datagrams have not been negotiated by both peers",
                     location: .here()
                 )
             }

--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -293,6 +293,28 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         }
     }
 
+    // Only used for an assertion.
+    @_spi(PackageInternal)
+    package func isStreamOpen(_ id: QUICStreamID) -> Bool {
+        let isOpen: Bool
+
+        switch self.state {
+        case .notStarted:
+            isOpen = false
+        case .initialized(let state):
+            switch state.streamIDTracker.opennessOfStream(withID: id) {
+            case .open:
+                isOpen = true
+            case .notYetOpen, .closed:
+                isOpen = false
+            }
+        case .finished:
+            isOpen = false
+        }
+
+        return isOpen
+    }
+
     // MARK: Inbound streams
 
     @_spi(PackageInternal)

--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -1023,12 +1023,12 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
     public enum CloseAction {
         /// Send a GOAWAY frame containing ``id`` and close any existing streams with an id in ``idsToCancel``.
         ///
-        /// Streams with an ID greater than or equal to ``firstRejectedStreamID`` will be rejected and can therefore
+        /// Streams with an ID greater than or equal to ``lowestRejectedStreamID`` will be rejected and can therefore
         /// never be created. This is `nil` for clients, whose GOAWAY carries a push ID rather than a stream ID.
         case sendGoaway(
             id: HTTP3GoawayID,
             idsToCancel: [QUICStreamID],
-            firstRejectedStreamID: QUICStreamID?
+            lowestRejectedStreamID: QUICStreamID?
         )
         /// Throw an error: the caller of this function has made a mistake and gave us an invalid id.
         case throwError(any Error)
@@ -1049,12 +1049,12 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             let action = initializedState.quiescingState.sendGoaway(goawayID: newLocalMaxID)
 
             let idsToCancel: [QUICStreamID]
-            let firstRejectedStreamID: QUICStreamID?
+            let lowestRejectedStreamID: QUICStreamID?
             switch initializedState.type {
             case .client:
                 // TODO: Once we implement server push, explicitly cancel pushes above the max ID here
                 idsToCancel = []
-                firstRejectedStreamID = nil
+                lowestRejectedStreamID = nil
             case .server:
                 // RFC 9114 § 5.2: Upon sending a GOAWAY frame, the endpoint SHOULD explicitly cancel (see Sections 4.1.1 and 7.2.3) any requests or
                 // pushes that have identifiers greater than or equal to the one indicated, in order to clean up transport state for the affected streams
@@ -1062,14 +1062,14 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
                 idsToCancel = initializedState.streamIDTracker.getOpenStreamIDs {
                     $0 >= sentID && $0.isBidirectional && $0.isClientInitiated
                 }
-                firstRejectedStreamID = sentID
+                lowestRejectedStreamID = sentID
             }
             self = .init(state: .initialized(initializedState))
             switch action {
             case .throwError(let error):
                 return .throwError(error)
             case .sendGoaway(let id):
-                return .sendGoaway(id: id, idsToCancel: idsToCancel, firstRejectedStreamID: firstRejectedStreamID)
+                return .sendGoaway(id: id, idsToCancel: idsToCancel, lowestRejectedStreamID: lowestRejectedStreamID)
             }
         }
     }

--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -165,6 +165,23 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         case buffer
         case forward
         case discard
+        case connectionError(HTTP3Error)
+
+        @inline(never)
+        static func connectionError(
+            code: HTTP3Error.Code,
+            message: String,
+            location: HTTP3Error.SourceLocation
+        ) -> Self {
+            let error = HTTP3Error(
+                code: code,
+                message: message,
+                cause: nil,
+                errorCode: .generalProtocolError,
+                location: location
+            )
+            return .connectionError(error)
+        }
     }
 
     @_spi(PackageInternal)
@@ -176,7 +193,13 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
 
         case .initialized(let initialized):
             // Didn't advertise 'SETTINGS_H3_DATAGRAM', discard it.
-            guard initialized.localAllowsDatagrams else { return .discard }
+            guard initialized.localAllowsDatagrams else {
+                return .connectionError(
+                    code: .datagramsNotNegotiated,
+                    message: "Received an HTTP datagram without having advertised 'SETTINGS_H3_DATAGRAM'",
+                    location: .here()
+                )
+            }
 
             // If the connection is quiescing then the datagram may never be allowed on some streams.
             if initialized.type == .server {

--- a/Sources/HTTP3/HTTP3Error.swift
+++ b/Sources/HTTP3/HTTP3Error.swift
@@ -264,8 +264,8 @@ extension HTTP3Error {
             Self(.peerTerminatedInboundStream)
         }
 
-        // Attempted to send a datagram but the remote peer hasn't advertised that it's willing
-        /// to receive datagrams.
+        /// A datagram was sent or received on a connection where the endpoint receiving it hasn't
+        /// advertised that it's willing to receive datagrams.
         public static var datagramsNotNegotiated: Self {
             Self(.datagramsNotNegotiated)
         }

--- a/Sources/HTTP3/QUICStreamID+Extensions.swift
+++ b/Sources/HTTP3/QUICStreamID+Extensions.swift
@@ -41,4 +41,9 @@ extension QUICStreamID {
     var isServerInitiated: Bool {
         !self.isClientInitiated
     }
+
+    /// The last two bits of the ID, which determine the type of the stream.
+    var typeBits: Int {
+        Int(self.rawValue & 0b11)
+    }
 }

--- a/Sources/HTTP3/StreamIDTracker.swift
+++ b/Sources/HTTP3/StreamIDTracker.swift
@@ -39,7 +39,7 @@ struct StreamIDTracker {
             self.openBidirectionalStreamCount += 1
         }
 
-        let streamType = Int(id.rawValue & 0b11)  // The last 2 bits determine the type of a QUIC stream.
+        let streamType = id.typeBits  // The last 2 bits determine the type of a QUIC stream.
 
         let previousHighestSeenID = self.highestIDSeenByType[streamType]
         if previousHighestSeenID == nil || id > previousHighestSeenID! {
@@ -85,7 +85,7 @@ struct StreamIDTracker {
     /// - Returns: `true` if the next id of the same type as the provided one would be equal to or greater than the provided one.
     func hasExhaustedSameTypeStreams(withIDsLessThan givenID: QUICStreamID) -> Bool {
         /// The stream type for the id we were given. This is determined by the last 2 bits. See RFC 9000 § 2.1
-        let givenIDType = Int(givenID.rawValue & 0b11)
+        let givenIDType = givenID.typeBits
         /// The highest ID that we have seen so far for streams of this type
         let highestSeenIDOfSameType = self.highestIDSeenByType[givenIDType]
         /// The next ID for a stream of this type
@@ -98,5 +98,26 @@ struct StreamIDTracker {
             }
         // Would the next ID be more than or equal to the max?
         return nextIDOfSameType >= givenID.rawValue
+    }
+
+    enum Openness {
+        /// The stream hasn't been opened yet.
+        case notYetOpen
+        /// The stream is open.
+        case open
+        /// The stream is closed.
+        case closed
+    }
+
+    func opennessOfStream(withID streamID: QUICStreamID) -> Openness {
+        if self.openStreams.contains(streamID) {
+            return .open
+        }
+
+        if let highest = self.highestIDSeenByType[streamID.typeBits] {
+            return streamID > highest ? .notYetOpen : .closed
+        } else {
+            return .notYetOpen
+        }
     }
 }

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -83,25 +83,33 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
 
     // MARK: Datagram
 
-    /// Returns whether the connection should forward the given datagram.
+    enum ReceivedDatagramAction {
+        /// Deliver the datagram to the connection channel.
+        case deliver
+        /// Don't deliver the datagram: it was either buffered or dropped.
+        case drop
+        /// Close the connection with the given error.
+        case closeConnection(HTTP3Error)
+    }
+
+    /// Returns what the connection should do with the given datagram.
     ///
     /// Datagrams may be buffered if the stream isn't open yet or dropped if the connection
     /// isn't in a state to receive datagrams.
-    func receivedDatagram(_ datagram: HTTP3Datagram) -> Bool {
+    func receivedDatagram(_ datagram: HTTP3Datagram) -> ReceivedDatagramAction {
         self.eventLoop.assertInEventLoop()
-        let forward: Bool
 
         switch self.connectionStateMachine.receivedDatagram(streamID: datagram.streamID) {
         case .forward:
-            forward = true
+            return .deliver
         case .buffer:
             self.datagramBuffer.append(datagram)
-            forward = false
+            return .drop
         case .discard:
-            forward = false
+            return .drop
+        case .connectionError(let error):
+            return .closeConnection(error)
         }
-
-        return forward
     }
 
     /// Whether a datagram associated with the given stream may be sent to the remote.
@@ -835,7 +843,8 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
         }
     }
 
-    /// Call this when the remote sends a datagram which can't be parsed.
+    /// Call this when the remote sends a datagram which can't be accepted, i.e. it can't be parsed
+    /// or wasn't negotiated.
     func receivedInvalidDatagram(_ error: HTTP3Error) {
         self.eventLoop.assertInEventLoop()
         self.logger.debug("Emitting connection error", metadata: [LoggingKeys.error: "\(error)"])

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -801,13 +801,13 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
             // We will only reach here if the connection state machine is in the `.notStarted` case; the state machine
             // can only be in the `.notStarted` case if `channelActive` has not been called.
             self.shutdownConnectionImmediately()
-        case .sendGoaway(let id, let streamsToCancel, let firstRejectedStreamID):
+        case .sendGoaway(let id, let streamsToCancel, let lowestRejectedStreamID):
             self.logger.trace("Sending goaway", metadata: [LoggingKeys.goawayID: "\(id)"])
             self.outboundControlStreamHandler.sendGoaway(id: id)
             self.cancelStreamsDueToSendingGoaway(streamsToCancel)
-            if let firstRejectedStreamID {
+            if let lowestRejectedStreamID {
                 // These streams will never be opened: drop any datagrams for them.
-                self.datagramBuffer.discardDatagrams(forStreamsAtOrAbove: firstRejectedStreamID)
+                self.datagramBuffer.discardDatagrams(forStreamsAtOrAbove: lowestRejectedStreamID)
             }
         case .throwError(let error):
             throw error

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -848,7 +848,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
     func receivedInvalidDatagram(_ error: HTTP3Error) {
         self.eventLoop.assertInEventLoop()
         self.logger.debug("Emitting connection error", metadata: [LoggingKeys.error: "\(error)"])
-        switch self.connectionStateMachine.emitConnectionErrorFromStream(error: error) {
+        switch self.connectionStateMachine.emitConnectionErrorFromStream(error: error, allowNotStarted: true) {
         case .emitConnectionError(let error):
             self.connection?.emitConnectionError(error)
         case .none:

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -123,6 +123,8 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
     /// buffering datagrams for it, otherwise datagrams can be delivered out of order.
     private func emitBufferedDatagrams(forStream streamID: QUICStreamID) {
         self.eventLoop.assertInEventLoop()
+        assert(self.connectionStateMachine.isStreamOpen(streamID))
+        assert(self.connection != nil)
         if let datagrams = self.datagramBuffer.unbufferDatagrams(forStream: streamID) {
             self.connection?.emitDatagrams(datagrams)
         }

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import DequeModule
 @_spi(PackageInternal) import HTTP3
 import HTTPTypes
 import Logging
@@ -28,13 +29,16 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
     private let outboundQPACKDecoderHandler: QPACKOutboundDecoderStreamHandler
     private let outboundControlStreamHandler: HTTP3OutboundControlStreamHandler
     private let streamCreator: QUICStreamCreator
-    /// Send the connection error out to the peer. We should only call this if the connection state machine says so.
-    /// If we want to send a connection error, it needs to go through the connection state machine first.
-    var emitConnectionError: (HTTP3Error) -> Void
+    /// The connection handler.
+    ///
+    /// Setting this creates a strong retain cycle which is broken by the connection handler when
+    /// it's removed from the channel pipeline.
+    private var connection: HTTP3ConnectionHandler<QUICStreamCreator>?
     private let preferHuffmanEncoding: Bool
     private let logger: Logger
     /// Instances of stream handlers which need to be pinged whenever a dynamic table entry is added.
     private var streamHandlers = [QUICStreamID: HTTP3StreamHandler]()
+    private var datagramBuffer: HTTP3DatagramBuffer
 
     init(
         eventLoop: any EventLoop,
@@ -42,8 +46,10 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
         streamCreator: QUICStreamCreator,
         type: HTTP3ConnectionType,
         preferHuffmanEncoding: Bool,
-        logger: Logger
+        maxBufferedDatagramBytes: Int,
+        logger: Logger,
     ) {
+        precondition(maxBufferedDatagramBytes >= 0)
         self.eventLoop = eventLoop
         self.outboundQPACKDecoderHandler = .init()
         self.outboundQPACKEncoderHandler = .init()
@@ -52,7 +58,12 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
         self.streamCreator = streamCreator
         self.logger = logger
         self.preferHuffmanEncoding = preferHuffmanEncoding
-        self.emitConnectionError = { _ in fatalError() }
+        self.datagramBuffer = HTTP3DatagramBuffer(maxAllowedSize: maxBufferedDatagramBytes)
+    }
+
+    func setConnectionHandler(_ handler: HTTP3ConnectionHandler<QUICStreamCreator>?) {
+        self.eventLoop.preconditionInEventLoop()
+        self.connection = handler
     }
 
     func initialize() {
@@ -67,6 +78,46 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
             self.createControlStream()
         case .none:
             break
+        }
+    }
+
+    // MARK: Datagram
+
+    /// Returns whether the connection should forward the given datagram.
+    ///
+    /// Datagrams may be buffered if the stream isn't open yet or dropped if the connection
+    /// isn't in a state to receive datagrams.
+    func receivedDatagram(_ datagram: HTTP3Datagram) -> Bool {
+        self.eventLoop.assertInEventLoop()
+        let forward: Bool
+
+        switch self.connectionStateMachine.receivedDatagram(streamID: datagram.streamID) {
+        case .forward:
+            forward = true
+        case .buffer:
+            self.datagramBuffer.append(datagram)
+            forward = false
+        case .discard:
+            forward = false
+        }
+
+        return forward
+    }
+
+    /// Whether a datagram associated with the given stream may be sent to the remote.
+    func sendDatagram(streamID: QUICStreamID) -> HTTP3ConnectionStateMachine.SendDatagramAction {
+        self.eventLoop.assertInEventLoop()
+        return self.connectionStateMachine.sendDatagram(streamID: streamID)
+    }
+
+    /// Delivers any datagrams which were buffered for the given stream.
+    ///
+    /// Must only be called once the state machine knows the stream is open, i.e. once it will stop
+    /// buffering datagrams for it, otherwise datagrams can be delivered out of order.
+    private func emitBufferedDatagrams(forStream streamID: QUICStreamID) {
+        self.eventLoop.assertInEventLoop()
+        if let datagrams = self.datagramBuffer.unbufferDatagrams(forStream: streamID) {
+            self.connection?.emitDatagrams(datagrams)
         }
     }
 
@@ -225,6 +276,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
                     if addTypeHandlers {
                         try streamChannel.pipeline.syncOperations.addHandler(HTTP3ToHTTPClientCodec())
                     }
+                    self.emitBufferedDatagrams(forStream: streamID)
                     return HTTP3StreamInitializerParameters(params)
                 }.assumeIsolated().flatMap {
                     streamInitializer($0)
@@ -267,21 +319,26 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
                     if addTypeHandlers {
                         try streamChannel.pipeline.syncOperations.addHandler(HTTP3ToHTTPServerCodec())
                     }
+                    // State machine now considers the stream to be open: deliver the datagrams now.
+                    self.emitBufferedDatagrams(forStream: streamID)
                     return userInboundStreamInitializer(parameters).map(onUserStream)
                 } catch {
+                    self.datagramBuffer.discardDatagrams(forStream: streamID)
                     return streamChannel.eventLoop.makeFailedFuture(error)
                 }
             case .emitConnectionError(let error):
+                self.datagramBuffer.discardDatagrams(forStream: streamID)
                 return streamChannel.eventLoop.makeCompletedFuture {
                     try self.addStreamClosedHandler(
                         streamChannel: streamChannel,
                         streamID: streamID,
                         streamType: .request
                     )
-                    self.emitConnectionError(error)
+                    self.connection?.emitConnectionError(error)
                 }
             case .emitStreamError:
                 self.logger.trace("Rejecting inbound stream", metadata: [LoggingKeys.quicStreamID: "\(streamID)"])
+                self.datagramBuffer.discardDatagrams(forStream: streamID)
                 return streamChannel.eventLoop.makeCompletedFuture {
                     try self.addStreamClosedHandler(
                         streamChannel: streamChannel,
@@ -316,7 +373,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
                                 streamID: streamID,
                                 streamType: .unidirectional(.push)
                             )
-                            self.emitConnectionError(error)
+                            self.connection?.emitConnectionError(error)
                         case .emitStreamError(let error):
                             try self.addStreamClosedHandler(
                                 streamChannel: streamChannel,
@@ -363,7 +420,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
                                 streamID: streamID,
                                 streamType: .unidirectional(.control)
                             )
-                            self.emitConnectionError(error)
+                            self.connection?.emitConnectionError(error)
                         case .emitStreamError(let error):
                             try self.addStreamClosedHandler(
                                 streamChannel: streamChannel,
@@ -382,7 +439,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
                                 let action = self.connectionStateMachine.receivedIncomingEncoderInstruction(instruction)
                                 switch action {
                                 case .emitConnectionError(let error):
-                                    self.emitConnectionError(error)
+                                    self.connection?.emitConnectionError(error)
                                 case .sendDecoderInstruction(let instruction):
                                     self.outboundQPACKDecoderHandler.sendInstruction(instruction)
                                     self.checkForNewDecodes()
@@ -413,7 +470,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
                                 streamID: streamID,
                                 streamType: .unidirectional(.qpackEncoder)
                             )
-                            self.emitConnectionError(error)
+                            self.connection?.emitConnectionError(error)
                         case .emitStreamError(let error):
                             try self.addStreamClosedHandler(
                                 streamChannel: streamChannel,
@@ -432,7 +489,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
                                 let action = self.connectionStateMachine.receivedIncomingDecoderInstruction($0)
                                 switch action {
                                 case .emitConnectionError(let error):
-                                    self.emitConnectionError(error)
+                                    self.connection?.emitConnectionError(error)
                                 case .none:
                                     break
                                 }
@@ -460,7 +517,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
                                 streamID: streamID,
                                 streamType: .unidirectional(.qpackDecoder)
                             )
-                            self.emitConnectionError(error)
+                            self.connection?.emitConnectionError(error)
                         case .emitStreamError(let error):
                             try self.addStreamClosedHandler(
                                 streamChannel: streamChannel,
@@ -498,7 +555,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
         case .none:
             break
         case .emitConnectionError(let error):
-            self.emitConnectionError(error)
+            self.connection?.emitConnectionError(error)
         case .makeEncoderInstructionStream:
             self.createQPACKEncoderInstructionStream()
         case .cancelStreams(let ids):
@@ -583,7 +640,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
         case .informDecodeResult(let payload):
             self.processQPACKDecodeResult(payload)
         case .emitConnectionError(let error):
-            self.emitConnectionError(error)
+            self.connection?.emitConnectionError(error)
         case .none:
             break
         }
@@ -599,6 +656,8 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
         self.logger.trace("Stream has closed", metadata: [LoggingKeys.quicStreamID: "\(streamID)"])
         // It's safe to remove this now. When we tell the state machine about the closure, it'll remove any queued QPACK decodes.
         self.streamHandlers[streamID] = nil
+        // Anything buffered will never be delivered, drop them.
+        self.datagramBuffer.discardDatagrams(forStream: streamID)
         let action = self.connectionStateMachine.streamClosed(
             streamID: streamID,
             seenEOF: seenEOF,
@@ -619,7 +678,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
             )
             self.shutdownConnectionImmediately()
         case .emitConnectionError(let error):
-            self.emitConnectionError(error)
+            self.connection?.emitConnectionError(error)
         case .none:
             break
         }
@@ -632,7 +691,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
         let action = self.connectionStateMachine.shutdownConnectionImmediately()
         switch action {
         case .shutdown:
-            self.emitConnectionError(
+            self.connection?.emitConnectionError(
                 .init(
                     code: .none,
                     message: "",
@@ -660,7 +719,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
             case .informDecodeResult(let payload):
                 self.processQPACKDecodeResult(payload)
             case .emitConnectionError(let error):
-                self.emitConnectionError(error)
+                self.connection?.emitConnectionError(error)
             }
         }
     }
@@ -738,10 +797,14 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
             // We will only reach here if the connection state machine is in the `.notStarted` case; the state machine
             // can only be in the `.notStarted` case if `channelActive` has not been called.
             self.shutdownConnectionImmediately()
-        case .sendGoaway(let id, let streamsToCancel):
+        case .sendGoaway(let id, let streamsToCancel, let firstRejectedStreamID):
             self.logger.trace("Sending goaway", metadata: [LoggingKeys.goawayID: "\(id)"])
             self.outboundControlStreamHandler.sendGoaway(id: id)
             self.cancelStreamsDueToSendingGoaway(streamsToCancel)
+            if let firstRejectedStreamID {
+                // These streams will never be opened: drop any datagrams for them.
+                self.datagramBuffer.discardDatagrams(forStreamsAtOrAbove: firstRejectedStreamID)
+            }
         case .throwError(let error):
             throw error
         case .none:
@@ -766,9 +829,21 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
         let action = self.connectionStateMachine.emitConnectionErrorFromStream(error: error)
         switch action {
         case .emitConnectionError(let error):
-            self.emitConnectionError(error)
+            self.connection?.emitConnectionError(error)
         case .none:
             assertionFailure("Tried to emit stream error when already finished.")
+        }
+    }
+
+    /// Call this when the remote sends a datagram which can't be parsed.
+    func receivedInvalidDatagram(_ error: HTTP3Error) {
+        self.eventLoop.assertInEventLoop()
+        self.logger.debug("Emitting connection error", metadata: [LoggingKeys.error: "\(error)"])
+        switch self.connectionStateMachine.emitConnectionErrorFromStream(error: error) {
+        case .emitConnectionError(let error):
+            self.connection?.emitConnectionError(error)
+        case .none:
+            ()  // Already closed, nothing to do.
         }
     }
 

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import DequeModule
 @_spi(PackageInternal) import HTTP3
 import HTTPTypes
 import Logging

--- a/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
@@ -345,10 +345,14 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
             return
         }
 
-        let forward = self.coordinator.receivedDatagram(datagram)
-
-        if forward {
+        switch self.coordinator.receivedDatagram(datagram) {
+        case .deliver:
             context.fireChannelRead(self.wrapInboundOut(datagram))
+        case .drop:
+            ()  // Buffered or dropped by the coordinator.
+        case .closeConnection(let error):
+            self.coordinator.receivedInvalidDatagram(error)
+            context.fireErrorCaught(error)
         }
     }
 

--- a/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+internal import DequeModule
 @_spi(PackageInternal) public import HTTP3
 public import Logging
 public import NIOCore
@@ -34,8 +35,10 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
     ChannelInboundHandler,
     ChannelOutboundHandler
 {
-    public typealias InboundIn = Any
-    public typealias OutboundIn = Any
+    public typealias InboundIn = ByteBuffer
+    public typealias InboundOut = HTTP3Datagram
+    public typealias OutboundIn = HTTP3Datagram
+    public typealias OutboundOut = ByteBuffer
 
     private let addTypeHandlers: Bool
     private let coordinator: HTTP3ConnectionCoordinator<StreamCreator>
@@ -64,6 +67,7 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
         streamCreator: StreamCreator,
         type: HTTP3ConnectionType,
         preferHuffmanEncoding: Bool,
+        maxBufferedDatagramBytes: Int,
         logger: Logger,
         inboundStreamInitializer: H3InboundStreamInitializer,
         internalInboundStreamInitializer: (
@@ -87,6 +91,7 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
             streamCreator: streamCreator,
             type: type,
             preferHuffmanEncoding: preferHuffmanEncoding,
+            maxBufferedDatagramBytes: maxBufferedDatagramBytes,
             logger: logger
         )
         self.type = type
@@ -94,22 +99,6 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
         self.gracefulShutdownRTTMultiplier = gracefulShutdownRTTMultiplier
         self.inboundStreamInitializer = inboundStreamInitializer
         self.internalInboundStreamInitializer = internalInboundStreamInitializer
-
-        self.coordinator.emitConnectionError = { error in
-            self.logger.debug(
-                "Closing connection",
-                metadata: [
-                    LoggingKeys.error: "\(error.h3ErrorCode ?? .noError)", LoggingKeys.reason: "\(error.message)",
-                ]
-            )
-            self.context?.triggerUserOutboundEvent(
-                QUICCloseConnectionEvent(
-                    code: QUICApplicationErrorCode(error.h3ErrorCode ?? .noError),
-                    reasonPhrase: error.message
-                ),
-                promise: nil
-            )
-        }
     }
 
     /// Create a ``HTTP3ConnectionHandler`` for use in a server.
@@ -223,6 +212,7 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
             streamCreator: streamCreator,
             type: .server,
             preferHuffmanEncoding: configuration.preferHuffmanEncoding,
+            maxBufferedDatagramBytes: configuration.maxBufferedDatagramBytes,
             logger: logger,
             inboundStreamInitializer: inboundRequestStreamInitializer,
             internalInboundStreamInitializer: internalInboundStreamInitializer,
@@ -255,6 +245,7 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
             streamCreator: streamCreator,
             type: .client,
             preferHuffmanEncoding: configuration.preferHuffmanEncoding,
+            maxBufferedDatagramBytes: configuration.maxBufferedDatagramBytes,
             logger: logger,
             inboundStreamInitializer: .closure(inboundPushStreamInitializer),
             internalInboundStreamInitializer: nil,
@@ -293,6 +284,7 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
             streamCreator: streamCreator,
             type: .client,
             preferHuffmanEncoding: configuration.preferHuffmanEncoding,
+            maxBufferedDatagramBytes: configuration.maxBufferedDatagramBytes,
             logger: logger,
             inboundStreamInitializer: .closure(inboundPushStreamInitializer),
             internalInboundStreamInitializer: internalInboundStreamInitializer,
@@ -308,12 +300,13 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
             fatalError("HTTP3ConnectionHandler must only be added to one Channel")
         }
         self.context = context
+        self.coordinator.setConnectionHandler(self)
     }
 
     public func handlerRemoved(context: ChannelHandlerContext) {
         self.context = nil
         // Break the reference cycle
-        self.coordinator.emitConnectionError = { _ in }
+        self.coordinator.setConnectionHandler(nil)
     }
 
     public func channelActive(context: ChannelHandlerContext) {
@@ -336,6 +329,41 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
         // or in the way the channels notify the state machine when they open/close.
         self.coordinator.assertNoOpenStreams()
         context.fireChannelInactive()
+    }
+
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        var buffer = self.unwrapInboundIn(data)
+
+        let datagram: HTTP3Datagram
+
+        do {
+            datagram = try buffer.parseDatagram()
+        } catch {
+            // RFC 9297 § 2.1: an unparsable datagram is a connection error.
+            self.coordinator.receivedInvalidDatagram(error)
+            context.fireErrorCaught(error)
+            return
+        }
+
+        let forward = self.coordinator.receivedDatagram(datagram)
+
+        if forward {
+            context.fireChannelRead(self.wrapInboundOut(datagram))
+        }
+    }
+
+    public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let datagram = self.unwrapOutboundIn(data)
+
+        switch self.coordinator.sendDatagram(streamID: datagram.streamID) {
+        case .send:
+            var buffer = context.channel.allocator.buffer(capacity: 8 + datagram.payload.readableBytes)
+            buffer.writeDatagram(datagram)
+            context.write(self.wrapOutboundOut(buffer), promise: promise)
+
+        case .drop(let error):
+            promise?.fail(error)
+        }
     }
 
     /// Ask the handler to initialize a new incoming stream. This must be called for every incoming QUIC stream _before_ that stream channel is activated.
@@ -597,6 +625,34 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
     }
 }
 
+extension HTTP3ConnectionHandler {
+    func emitDatagrams(_ datagrams: Deque<HTTP3Datagram>) {
+        guard let context = self.context else { return }
+        if datagrams.isEmpty { return }
+
+        for datagram in datagrams {
+            context.fireChannelRead(self.wrapInboundOut(datagram))
+        }
+        context.fireChannelReadComplete()
+    }
+
+    func emitConnectionError(_ error: HTTP3Error) {
+        self.logger.debug(
+            "Closing connection",
+            metadata: [
+                LoggingKeys.error: "\(error.h3ErrorCode ?? .noError)", LoggingKeys.reason: "\(error.message)",
+            ]
+        )
+        self.context?.triggerUserOutboundEvent(
+            QUICCloseConnectionEvent(
+                code: QUICApplicationErrorCode(error.h3ErrorCode ?? .noError),
+                reasonPhrase: error.message
+            ),
+            promise: nil
+        )
+    }
+}
+
 @available(*, unavailable)
 extension HTTP3ConnectionHandler: Sendable {}
 
@@ -620,6 +676,10 @@ public struct HTTP3ServerConfiguration: Sendable {
     /// GOAWAY frame during graceful shutdown. Defaults to 1.
     public var gracefulShutdownRTTMultiplier: Int = 1
 
+    /// The maximum number of bytes from HTTP/3 datagrams that can be buffered at one time per
+    /// connection.
+    public var maxBufferedDatagramBytes: Int = 64 * 1024
+
     private init(rttProvider: @escaping (@Sendable () -> TimeAmount)) {
         self.rttProvider = rttProvider
     }
@@ -639,6 +699,10 @@ public struct HTTP3ClientConfiguration: Sendable {
     /// If true, Huffman encoding will be used where applicable, e.g. for header field sections.
     /// - Note: Huffman encoding will not be used if it would result in a larger payload than not using it, even if this property is true.
     public var preferHuffmanEncoding = true
+
+    /// The maximum number of bytes from HTTP/3 datagrams that can be buffered at one time per
+    /// connection.
+    public var maxBufferedDatagramBytes: Int = 64 * 1024
 
     private init() {}
 

--- a/Sources/NIOHTTP3/HTTP3DatagramBuffer.swift
+++ b/Sources/NIOHTTP3/HTTP3DatagramBuffer.swift
@@ -71,7 +71,7 @@ struct HTTP3DatagramBuffer {
     private var runs: Deque<StreamIDRun>
 
     #if DEBUG
-    /// A set of stream IDs for which datagrams have already been discarded.
+    /// A set of stream IDs for which datagrams have already been unbuffered.
     private var unbuffered: Set<QUICStreamID> = []
 
     private mutating func markUnbuffered(_ streamID: QUICStreamID) {
@@ -81,7 +81,7 @@ struct HTTP3DatagramBuffer {
     private func checkNotUnbuffered(_ streamID: QUICStreamID) {
         if self.unbuffered.contains(streamID) {
             fatalError(
-                "\(streamID) has been discarded: you can't buffer data for a stream after it has been unbuffered"
+                "\(streamID) has been unbuffered: you can't buffer data for a stream after it has been unbuffered"
             )
         }
     }
@@ -143,11 +143,10 @@ struct HTTP3DatagramBuffer {
     }
 
     /// Removes all datagrams for the given stream ID, if they exist.
+    ///
+    /// Unlike ``unbufferDatagrams(forStream:)`` this doesn't stop the stream from buffering datagrams
+    /// again: discarding is a cleanup, so it doesn't change the order datagrams are delivered in.
     mutating func discardDatagrams(forStream id: QUICStreamID) {
-        #if DEBUG
-        self.markUnbuffered(id)
-        #endif
-
         if let batch = self.storage.removeValue(forKey: id) {
             self.totalSize -= batch.totalSize
         }
@@ -162,12 +161,6 @@ struct HTTP3DatagramBuffer {
 
     /// Removes all buffered datagrams.
     mutating func discardAllDatagrams() {
-        #if DEBUG
-        for id in self.storage.keys {
-            self.markUnbuffered(id)
-        }
-        #endif
-
         self.storage.removeAll()
         self.runs.removeAll()
         self.totalSize = 0
@@ -219,9 +212,9 @@ extension [QUICStreamID: HTTP3DatagramBuffer.DatagramBatch] {
         var bytes: Int
         var datagrams: Int
 
-        mutating func record(bytes: Int) {
+        mutating func record(bytes: Int, datagrams: Int = 1) {
             self.bytes += bytes
-            self.datagrams += 1
+            self.datagrams += datagrams
         }
     }
 
@@ -238,8 +231,7 @@ extension [QUICStreamID: HTTP3DatagramBuffer.DatagramBatch] {
 
             // Fast-path: drop a whole batch.
             if maxDatagramsToDrop >= batch!.datagrams.count, bytesToDrop >= batch!.totalSize {
-                dropped.datagrams = batch!.datagrams.count
-                dropped.record(bytes: batch!.totalSize)
+                dropped.record(bytes: batch!.totalSize, datagrams: batch!.datagrams.count)
                 batch = nil
             } else {
                 while dropped.datagrams < maxDatagramsToDrop, dropped.bytes < bytesToDrop,

--- a/Tests/H3IntegrationTests/EndToEndTests.swift
+++ b/Tests/H3IntegrationTests/EndToEndTests.swift
@@ -1475,6 +1475,203 @@ struct EndToEndTests {
         try await serverChannel.close()
     }
 
+    // MARK: - Datagrams
+
+    /// Sets up a client and server which both advertise datagram support, waits until each has
+    /// received the other's SETTINGS frame, then calls `execute` with the two connection channels and
+    /// the ID of a request stream which the client has opened and the server has accepted.
+    @available(anyAppleOS 26, *)
+    private func withDatagramConnection(
+        authenticationConfiguration: AuthenticationConfiguration,
+        serverSettings: HTTP3Settings = HTTP3Settings(h3Datagram: true),
+        serverDatagrams: (promise: EventLoopPromise<[HTTP3Datagram]>, count: Int)? = nil,
+        clientDatagrams: (promise: EventLoopPromise<[HTTP3Datagram]>, count: Int)? = nil,
+        execute: (
+            _ clientConnection: any Channel,
+            _ serverConnection: any Channel,
+            _ streamID: QUICStreamID
+        ) async throws -> Void
+    ) async throws {
+        let host = "127.0.0.1"
+        let clientLogger = Logger(label: "Client")
+        let serverLogger = Logger(label: "Server")
+
+        let credentials = try TestCertificates.makeCredentials(for: authenticationConfiguration)
+
+        // The first frame on the inbound control stream is always SETTINGS, so recording one frame
+        // tells us the peer's datagram support is known.
+        let serverGotSettings = self.eventLoopGroup.any().makePromise(of: [HTTP3Frame].self)
+        let clientGotSettings = self.eventLoopGroup.any().makePromise(of: [HTTP3Frame].self)
+        let serverConnection = self.eventLoopGroup.any().makePromise(of: (any Channel).self)
+        let serverStreamID = self.eventLoopGroup.any().makePromise(of: QUICStreamID.self)
+
+        defer {
+            serverGotSettings.fail(NeverFulfilled())
+            clientGotSettings.fail(NeverFulfilled())
+            serverConnection.fail(NeverFulfilled())
+            serverStreamID.fail(NeverFulfilled())
+            serverDatagrams?.promise.fail(NeverFulfilled())
+            clientDatagrams?.promise.fail(NeverFulfilled())
+        }
+
+        let serverChannel = try await self.makeServer(
+            credentials: credentials,
+            host: host,
+            settings: serverSettings,
+            logger: serverLogger,
+            inboundConnectionInitializer: { connection in
+                connection.eventLoop.makeCompletedFuture {
+                    if let serverDatagrams {
+                        try connection.pipeline.syncOperations.addHandler(
+                            InboundDataRecorder<HTTP3Datagram>(
+                                promise: serverDatagrams.promise,
+                                targetCount: serverDatagrams.count
+                            )
+                        )
+                    }
+                    serverConnection.succeed(connection)
+                }
+            },
+            inboundStreamInitializer: { params in
+                serverStreamID.succeed(params.streamID)
+                return params.channel.eventLoop.makeSucceededVoidFuture()
+            },
+            internalInboundStreamInitializer: { channel, _, streamType in
+                channel.eventLoop.makeCompletedFuture {
+                    switch streamType {
+                    case .control:
+                        try channel.pipeline.syncOperations.addHandler(
+                            InboundDataRecorder<HTTP3Frame>(promise: serverGotSettings, targetCount: 1)
+                        )
+                    case .push, .qpackEncoder, .qpackDecoder, .unknown:
+                        ()  // Not interesting for datagrams.
+                    }
+                }
+            }
+        )
+
+        let clientConnection = try await self.makeClient(
+            credentials: credentials,
+            host: host,
+            port: serverChannel.localAddress!.port!,
+            settings: HTTP3Settings(h3Datagram: true),
+            logger: clientLogger,
+            internalInboundStreamInitializer: { channel, _, streamType in
+                channel.eventLoop.makeCompletedFuture {
+                    switch streamType {
+                    case .control:
+                        try channel.pipeline.syncOperations.addHandler(
+                            InboundDataRecorder<HTTP3Frame>(promise: clientGotSettings, targetCount: 1)
+                        )
+                    case .push, .qpackEncoder, .qpackDecoder, .unknown:
+                        ()  // Not interesting for datagrams.
+                    }
+                }
+            },
+            connectionInitializer: { connection in
+                connection.eventLoop.makeCompletedFuture {
+                    if let clientDatagrams {
+                        try connection.pipeline.syncOperations.addHandler(
+                            InboundDataRecorder<HTTP3Datagram>(
+                                promise: clientDatagrams.promise,
+                                targetCount: clientDatagrams.count
+                            )
+                        )
+                    }
+                }
+            }
+        )
+
+        _ = try await clientGotSettings.futureResult.get()
+        _ = try await serverGotSettings.futureResult.get()
+
+        let requestStream = try await clientConnection.makeHTTP3RequestChannel().get()
+        let streamID = QUICStreamID(rawValue: try await requestStream.getOption(.quicStreamID).get())
+
+        // Opening a QUIC stream sends nothing, so the server won't see it until something is written
+        // on it. The server can't be given datagrams for a stream it doesn't know about, so send the
+        // request headers and wait for the server to accept the stream. The stream is deliberately
+        // left open: datagrams can't be sent for a closed stream.
+        try await requestStream.writeAndFlush(
+            HTTP3Frame.headers([
+                .init(name: .method, value: "GET"),
+                .init(name: .path, value: "/"),
+                .init(name: .scheme, value: "https"),
+                .init(name: .authority, value: "test"),
+            ])
+        )
+        #expect(try await serverStreamID.futureResult.get() == streamID)
+
+        try await execute(clientConnection, try await serverConnection.futureResult.get(), streamID)
+
+        try await clientConnection.close()
+        try await serverChannel.close()
+    }
+
+    @Test(arguments: Self.standardAuthenticationConfigurations)
+    @available(anyAppleOS 26, *)
+    func testClientSendsDatagramToServer(authenticationConfiguration: AuthenticationConfiguration) async throws {
+        let serverDatagrams = self.eventLoopGroup.any().makePromise(of: [HTTP3Datagram].self)
+
+        try await self.withDatagramConnection(
+            authenticationConfiguration: authenticationConfiguration,
+            serverDatagrams: (serverDatagrams, 2)
+        ) { clientConnection, _, streamID in
+            try await clientConnection.writeAndFlush(
+                HTTP3Datagram(streamID: streamID, payload: ByteBuffer(string: "hello"))
+            )
+            try await clientConnection.writeAndFlush(
+                HTTP3Datagram(streamID: streamID, payload: ByteBuffer(string: "again"))
+            )
+
+            let received = try await serverDatagrams.futureResult.get()
+            #expect(received.map { $0.streamID } == [streamID, streamID])
+            #expect(received.map { String(buffer: $0.payload) } == ["hello", "again"])
+        }
+    }
+
+    @Test(arguments: Self.standardAuthenticationConfigurations)
+    @available(anyAppleOS 26, *)
+    func testServerSendsDatagramToClient(authenticationConfiguration: AuthenticationConfiguration) async throws {
+        let clientDatagrams = self.eventLoopGroup.any().makePromise(of: [HTTP3Datagram].self)
+
+        try await self.withDatagramConnection(
+            authenticationConfiguration: authenticationConfiguration,
+            clientDatagrams: (clientDatagrams, 1)
+        ) { _, serverConnection, streamID in
+            try await serverConnection.writeAndFlush(
+                HTTP3Datagram(streamID: streamID, payload: ByteBuffer(string: "from the server"))
+            )
+
+            let received = try await clientDatagrams.futureResult.get()
+            #expect(received.map { $0.streamID } == [streamID])
+            #expect(received.map { String(buffer: $0.payload) } == ["from the server"])
+        }
+    }
+
+    // The remote hasn't advertised 'SETTINGS_H3_DATAGRAM', so we must not send it datagrams.
+    @Test(arguments: Self.standardAuthenticationConfigurations)
+    @available(anyAppleOS 26, *)
+    func testSendingDatagramWithoutRemoteSupportFails(
+        authenticationConfiguration: AuthenticationConfiguration
+    ) async throws {
+        try await self.withDatagramConnection(
+            authenticationConfiguration: authenticationConfiguration,
+            serverSettings: HTTP3Settings(h3Datagram: false)
+        ) { clientConnection, _, streamID in
+            let error = await #expect(throws: HTTP3Error.self) {
+                try await clientConnection.writeAndFlush(
+                    HTTP3Datagram(streamID: streamID, payload: ByteBuffer(string: "nope"))
+                )
+            }
+            expectH3ErrorEqual(
+                error: error,
+                expectedCode: .datagramsNotNegotiated,
+                expectedH3ErrorCode: nil
+            )
+        }
+    }
+
     // MARK: - Helper Functions
 
     @available(anyAppleOS 26, *)

--- a/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
@@ -872,7 +872,8 @@ struct HTTP3ConnectionStateMachineTests {
         var stateMachine = HTTP3ConnectionStateMachine.makeInitialized(
             type: .server,
             idGenerator: &idGenerator,
-            localSettings: HTTP3Settings(h3Datagram: true)
+            localSettings: HTTP3Settings(h3Datagram: true),
+            remoteSettings: HTTP3Settings(h3Datagram: true)
         )
 
         #expect(stateMachine.receivedDatagram(streamID: 0).isBuffer)
@@ -891,7 +892,8 @@ struct HTTP3ConnectionStateMachineTests {
         var stateMachine = HTTP3ConnectionStateMachine.makeInitialized(
             type: .server,
             idGenerator: &idGenerator,
-            localSettings: HTTP3Settings(h3Datagram: true)
+            localSettings: HTTP3Settings(h3Datagram: true),
+            remoteSettings: HTTP3Settings(h3Datagram: true)
         )
 
         // Streams at or above ID 4 are rejected from here on.
@@ -915,7 +917,8 @@ struct HTTP3ConnectionStateMachineTests {
         var stateMachine = HTTP3ConnectionStateMachine.makeInitialized(
             type: .client,
             idGenerator: &idGenerator,
-            localSettings: HTTP3Settings(h3Datagram: true)
+            localSettings: HTTP3Settings(h3Datagram: true),
+            remoteSettings: HTTP3Settings(h3Datagram: true)
         )
 
         // A client's GOAWAY carries a push ID, so it says nothing about which request streams the
@@ -945,6 +948,21 @@ struct HTTP3ConnectionStateMachineTests {
     func testReceivedDatagramBeforeStartedWithoutLocalSupport() {
         let stateMachine = HTTP3ConnectionStateMachine(settings: .init(), type: .server)
         stateMachine.expectReceivingDatagramIsConnectionError(streamID: 0, code: .datagramsNotNegotiated)
+    }
+
+    @Test
+    func testReceivedDatagramWithoutRemoteSupport() {
+        var idGenerator = IDGenerator(type: .server)
+        var stateMachine = HTTP3ConnectionStateMachine.makeInitialized(
+            type: .server,
+            idGenerator: &idGenerator,
+            localSettings: HTTP3Settings(h3Datagram: true)
+        )
+
+        // The remote didn't advertise support so it must not send datagrams.
+        let streamID = idGenerator.inboundBidi()
+        #expect(stateMachine.inboundRequestStreamReceived(streamID: streamID).isAddHandlers)
+        stateMachine.expectReceivingDatagramIsConnectionError(streamID: streamID, code: .datagramsNotNegotiated)
     }
 
     @Test
@@ -985,6 +1003,7 @@ struct HTTP3ConnectionStateMachineTests {
         var stateMachine = HTTP3ConnectionStateMachine.makeInitialized(
             type: .server,
             idGenerator: &idGenerator,
+            localSettings: HTTP3Settings(h3Datagram: true),
             remoteSettings: HTTP3Settings(h3Datagram: true)
         )
 
@@ -1002,7 +1021,25 @@ struct HTTP3ConnectionStateMachineTests {
     @Test
     func testSendDatagramWithoutRemoteSupport() {
         var idGenerator = IDGenerator(type: .server)
-        var stateMachine = HTTP3ConnectionStateMachine.makeInitialized(type: .server, idGenerator: &idGenerator)
+        var stateMachine = HTTP3ConnectionStateMachine.makeInitialized(
+            type: .server,
+            idGenerator: &idGenerator,
+            localSettings: HTTP3Settings(h3Datagram: true)
+        )
+
+        let streamID = idGenerator.inboundBidi()
+        #expect(stateMachine.inboundRequestStreamReceived(streamID: streamID).isAddHandlers)
+        stateMachine.expectSendingDatagramIsDropped(streamID: streamID, code: .datagramsNotNegotiated)
+    }
+
+    @Test
+    func testSendDatagramWithoutLocalSupport() {
+        var idGenerator = IDGenerator(type: .server)
+        var stateMachine = HTTP3ConnectionStateMachine.makeInitialized(
+            type: .server,
+            idGenerator: &idGenerator,
+            remoteSettings: HTTP3Settings(h3Datagram: true)
+        )
 
         let streamID = idGenerator.inboundBidi()
         #expect(stateMachine.inboundRequestStreamReceived(streamID: streamID).isAddHandlers)
@@ -1016,6 +1053,7 @@ struct HTTP3ConnectionStateMachineTests {
         let stateMachine = HTTP3ConnectionStateMachine.makeInitialized(
             type: .server,
             idGenerator: &idGenerator,
+            localSettings: HTTP3Settings(h3Datagram: true),
             remoteSettings: HTTP3Settings(h3Datagram: true)
         )
         stateMachine.expectSendingDatagramIsDropped(streamID: streamID, code: .invalidStream)

--- a/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
@@ -12,10 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(PackageInternal) import HTTP3
 import NIOQUICHelpers
 @_spi(PackageInternal) import QPACK
 import Testing
+
+@_spi(PackageInternal) @testable import HTTP3
 
 struct HTTP3ConnectionStateMachineTests {
     // MARK: Initialization
@@ -511,12 +512,14 @@ struct HTTP3ConnectionStateMachineTests {
 
         // And then send a goaway with id 4. It should cancel the streams >= that id
         let action2 = stateMachine.sendGoaway(goawayID: 4)
-        guard case .sendGoaway(let idToSend, let idsToCancel) = action2 else {
+        guard case .sendGoaway(let idToSend, let idsToCancel, let firstRejectedStreamID) = action2 else {
             Issue.record("Unexpected action \(String(describing: action2))")
             return
         }
         #expect(idToSend == 4)
         #expect(idsToCancel.sorted() == [4, 8])
+        // Servers reject streams at or above the ID they send.
+        #expect(firstRejectedStreamID == 4)
 
         // Those streams got cancelled successfuly
         let action3 = stateMachine.streamClosed(streamID: 8, seenEOF: true, streamType: .request)
@@ -860,6 +863,136 @@ struct HTTP3ConnectionStateMachineTests {
             expectedMessage: "The server-initiated control stream was closed"
         )
     }
+
+    // MARK: Datagrams
+
+    @Test
+    func testReceivedDatagram() {
+        var idGenerator = IDGenerator(type: .server)
+        var stateMachine = HTTP3ConnectionStateMachine.makeInitialized(
+            type: .server,
+            idGenerator: &idGenerator,
+            localSettings: HTTP3Settings(h3Datagram: true)
+        )
+
+        #expect(stateMachine.receivedDatagram(streamID: 0) == .buffer)
+
+        let streamID = idGenerator.inboundBidi()
+        #expect(stateMachine.inboundRequestStreamReceived(streamID: streamID).isAddHandlers)
+        #expect(stateMachine.receivedDatagram(streamID: streamID) == .forward)
+
+        _ = stateMachine.streamClosed(streamID: streamID, seenEOF: true, streamType: .request)
+        #expect(stateMachine.receivedDatagram(streamID: streamID) == .discard)
+    }
+
+    @Test
+    func testReceivedDatagramForStreamRejectedByGoaway() {
+        var idGenerator = IDGenerator(type: .server)
+        var stateMachine = HTTP3ConnectionStateMachine.makeInitialized(
+            type: .server,
+            idGenerator: &idGenerator,
+            localSettings: HTTP3Settings(h3Datagram: true)
+        )
+
+        // Streams at or above ID 4 are rejected from here on.
+        #expect(stateMachine.sendGoaway(goawayID: 4)?.isSendGoaway == true)
+
+        // Stream 0 is below the GOAWAY ID so it can still open.
+        #expect(stateMachine.receivedDatagram(streamID: 0) == .buffer)
+
+        // Stream 4 will never open, so there's no point buffering its datagrams.
+        #expect(stateMachine.receivedDatagram(streamID: 4) == .discard)
+
+        // A rejected stream is tracked as open until its stream channel closes, so openness alone
+        // isn't enough to tell that its datagrams can't be delivered.
+        #expect(stateMachine.inboundRequestStreamReceived(streamID: 4).isEmitStreamError)
+        #expect(stateMachine.receivedDatagram(streamID: 4) == .discard)
+    }
+
+    @Test
+    func testClientGoawayDoesNotDiscardDatagrams() {
+        var idGenerator = IDGenerator(type: .client)
+        var stateMachine = HTTP3ConnectionStateMachine.makeInitialized(
+            type: .client,
+            idGenerator: &idGenerator,
+            localSettings: HTTP3Settings(h3Datagram: true)
+        )
+
+        // A client's GOAWAY carries a push ID, so it says nothing about which request streams the
+        // server may send datagrams for.
+        #expect(stateMachine.sendGoaway(goawayID: 0)?.isSendGoaway == true)
+
+        let streamID = idGenerator.outboundBidi()
+        stateMachine.outboundRequestStreamReady(streamID: streamID)
+        #expect(stateMachine.receivedDatagram(streamID: streamID) == .forward)
+    }
+
+    @Test
+    func testReceivedDatagramWithoutLocalSupport() {
+        var idGenerator = IDGenerator(type: .server)
+        var stateMachine = HTTP3ConnectionStateMachine.makeInitialized(type: .server, idGenerator: &idGenerator)
+
+        let streamID = idGenerator.inboundBidi()
+        #expect(stateMachine.inboundRequestStreamReceived(streamID: streamID).isAddHandlers)
+        #expect(stateMachine.receivedDatagram(streamID: streamID) == .discard)
+        #expect(stateMachine.receivedDatagram(streamID: 0) == .discard)
+    }
+
+    @Test
+    func testReceiveDatagramBeforeSettings() {
+        var idGenerator = IDGenerator(type: .server)
+        var stateMachine = HTTP3ConnectionStateMachine(settings: .init(), type: .server)
+        stateMachine.expectSendingDatagramIsDropped(streamID: 0, code: .datagramsNotNegotiated)
+
+        _ = stateMachine.initialize()
+        let streamID = idGenerator.inboundBidi()
+        #expect(stateMachine.inboundRequestStreamReceived(streamID: streamID).isAddHandlers)
+
+        // The stream is open but no SETTINGS frame has been received to advertise support.
+        stateMachine.expectSendingDatagramIsDropped(streamID: streamID, code: .datagramsNotNegotiated)
+    }
+
+    @Test
+    func testSendDatagram() {
+        var idGenerator = IDGenerator(type: .server)
+        var stateMachine = HTTP3ConnectionStateMachine.makeInitialized(
+            type: .server,
+            idGenerator: &idGenerator,
+            remoteSettings: HTTP3Settings(h3Datagram: true)
+        )
+
+        let streamID = idGenerator.inboundBidi()
+        #expect(stateMachine.inboundRequestStreamReceived(streamID: streamID).isAddHandlers)
+        #expect(stateMachine.sendDatagram(streamID: streamID).isSend)
+
+        _ = stateMachine.streamClosed(streamID: streamID, seenEOF: true, streamType: .request)
+        stateMachine.expectSendingDatagramIsDropped(streamID: streamID, code: .invalidStream)
+
+        #expect(stateMachine.shutdownConnectionImmediately() == .shutdown)
+        stateMachine.expectSendingDatagramIsDropped(streamID: streamID, code: .connectionClosed)
+    }
+
+    @Test
+    func testSendDatagramWithoutRemoteSupport() {
+        var idGenerator = IDGenerator(type: .server)
+        var stateMachine = HTTP3ConnectionStateMachine.makeInitialized(type: .server, idGenerator: &idGenerator)
+
+        let streamID = idGenerator.inboundBidi()
+        #expect(stateMachine.inboundRequestStreamReceived(streamID: streamID).isAddHandlers)
+        stateMachine.expectSendingDatagramIsDropped(streamID: streamID, code: .datagramsNotNegotiated)
+    }
+
+    // 1 = server-init bidi, 2 = client-init uni, 3 = server-init uni
+    @Test(arguments: [1, 2, 3])
+    func testSendDatagramOnInvalidStream(streamID: QUICStreamID) {
+        var idGenerator = IDGenerator(type: .server)
+        let stateMachine = HTTP3ConnectionStateMachine.makeInitialized(
+            type: .server,
+            idGenerator: &idGenerator,
+            remoteSettings: HTTP3Settings(h3Datagram: true)
+        )
+        stateMachine.expectSendingDatagramIsDropped(streamID: streamID, code: .invalidStream)
+    }
 }
 
 // MARK: Test utils
@@ -869,6 +1002,40 @@ extension HTTP3ConnectionStateMachine.IncomingEncoderInstructionAction {
         switch self {
         case .sendDecoderInstruction(let decoderInstruction): return decoderInstruction
         case .emitConnectionError: return nil
+        }
+    }
+}
+
+extension HTTP3ConnectionStateMachine.InboundRequestStreamReceivedAction {
+    fileprivate var isAddHandlers: Bool {
+        switch self {
+        case .addHandlers: return true
+        case .emitStreamError, .emitConnectionError: return false
+        }
+    }
+
+    fileprivate var isEmitStreamError: Bool {
+        switch self {
+        case .emitStreamError: return true
+        case .addHandlers, .emitConnectionError: return false
+        }
+    }
+}
+
+extension HTTP3ConnectionStateMachine.SendDatagramAction {
+    fileprivate var isSend: Bool {
+        switch self {
+        case .send: return true
+        case .drop: return false
+        }
+    }
+}
+
+extension HTTP3ConnectionStateMachine.CloseAction {
+    fileprivate var isSendGoaway: Bool {
+        switch self {
+        case .sendGoaway: return true
+        case .throwError, .closeImmediately: return false
         }
     }
 }
@@ -942,6 +1109,19 @@ struct IDGenerator {
 }
 
 extension HTTP3ConnectionStateMachine {
+    func expectSendingDatagramIsDropped(
+        streamID: QUICStreamID,
+        code: HTTP3Error.Code,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        switch self.sendDatagram(streamID: streamID) {
+        case .send:
+            Issue.record("Datagram for stream \(streamID) was not rejected", sourceLocation: sourceLocation)
+        case .drop(let error):
+            error.expect(code: code, h3ErrorCode: nil, sourceLocation: sourceLocation)
+        }
+    }
+
     /// Returns a state machine which has already exchanged settings with the 'remote' and created the required streams.
     /// The settings are configured to allow qpack in both directions.
     static func makeInitializedWithQPACK(

--- a/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
@@ -875,14 +875,14 @@ struct HTTP3ConnectionStateMachineTests {
             localSettings: HTTP3Settings(h3Datagram: true)
         )
 
-        #expect(stateMachine.receivedDatagram(streamID: 0) == .buffer)
+        #expect(stateMachine.receivedDatagram(streamID: 0).isBuffer)
 
         let streamID = idGenerator.inboundBidi()
         #expect(stateMachine.inboundRequestStreamReceived(streamID: streamID).isAddHandlers)
-        #expect(stateMachine.receivedDatagram(streamID: streamID) == .forward)
+        #expect(stateMachine.receivedDatagram(streamID: streamID).isForward)
 
         _ = stateMachine.streamClosed(streamID: streamID, seenEOF: true, streamType: .request)
-        #expect(stateMachine.receivedDatagram(streamID: streamID) == .discard)
+        #expect(stateMachine.receivedDatagram(streamID: streamID).isDiscard)
     }
 
     @Test
@@ -898,15 +898,15 @@ struct HTTP3ConnectionStateMachineTests {
         #expect(stateMachine.sendGoaway(goawayID: 4)?.isSendGoaway == true)
 
         // Stream 0 is below the GOAWAY ID so it can still open.
-        #expect(stateMachine.receivedDatagram(streamID: 0) == .buffer)
+        #expect(stateMachine.receivedDatagram(streamID: 0).isBuffer)
 
         // Stream 4 will never open, so there's no point buffering its datagrams.
-        #expect(stateMachine.receivedDatagram(streamID: 4) == .discard)
+        #expect(stateMachine.receivedDatagram(streamID: 4).isDiscard)
 
         // A rejected stream is tracked as open until its stream channel closes, so openness alone
         // isn't enough to tell that its datagrams can't be delivered.
         #expect(stateMachine.inboundRequestStreamReceived(streamID: 4).isEmitStreamError)
-        #expect(stateMachine.receivedDatagram(streamID: 4) == .discard)
+        #expect(stateMachine.receivedDatagram(streamID: 4).isDiscard)
     }
 
     @Test
@@ -924,7 +924,7 @@ struct HTTP3ConnectionStateMachineTests {
 
         let streamID = idGenerator.outboundBidi()
         stateMachine.outboundRequestStreamReady(streamID: streamID)
-        #expect(stateMachine.receivedDatagram(streamID: streamID) == .forward)
+        #expect(stateMachine.receivedDatagram(streamID: streamID).isForward)
     }
 
     @Test
@@ -934,8 +934,17 @@ struct HTTP3ConnectionStateMachineTests {
 
         let streamID = idGenerator.inboundBidi()
         #expect(stateMachine.inboundRequestStreamReceived(streamID: streamID).isAddHandlers)
-        #expect(stateMachine.receivedDatagram(streamID: streamID) == .discard)
-        #expect(stateMachine.receivedDatagram(streamID: 0) == .discard)
+        stateMachine.expectReceivingDatagramIsConnectionError(
+            streamID: streamID,
+            code: .datagramsNotNegotiated
+        )
+        stateMachine.expectReceivingDatagramIsConnectionError(streamID: 0, code: .datagramsNotNegotiated)
+    }
+
+    @Test
+    func testReceivedDatagramBeforeStartedWithoutLocalSupport() {
+        let stateMachine = HTTP3ConnectionStateMachine(settings: .init(), type: .server)
+        #expect(stateMachine.receivedDatagram(streamID: 0).isDiscard)
     }
 
     @Test
@@ -1018,6 +1027,29 @@ extension HTTP3ConnectionStateMachine.InboundRequestStreamReceivedAction {
         switch self {
         case .emitStreamError: return true
         case .addHandlers, .emitConnectionError: return false
+        }
+    }
+}
+
+extension HTTP3ConnectionStateMachine.ReceivedDatagramAction {
+    fileprivate var isBuffer: Bool {
+        switch self {
+        case .buffer: return true
+        case .forward, .discard, .connectionError: return false
+        }
+    }
+
+    fileprivate var isForward: Bool {
+        switch self {
+        case .forward: return true
+        case .buffer, .discard, .connectionError: return false
+        }
+    }
+
+    fileprivate var isDiscard: Bool {
+        switch self {
+        case .discard: return true
+        case .buffer, .forward, .connectionError: return false
         }
     }
 }
@@ -1119,6 +1151,22 @@ extension HTTP3ConnectionStateMachine {
             Issue.record("Datagram for stream \(streamID) was not rejected", sourceLocation: sourceLocation)
         case .drop(let error):
             error.expect(code: code, h3ErrorCode: nil, sourceLocation: sourceLocation)
+        }
+    }
+
+    func expectReceivingDatagramIsConnectionError(
+        streamID: QUICStreamID,
+        code: HTTP3Error.Code,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        switch self.receivedDatagram(streamID: streamID) {
+        case .buffer, .forward, .discard:
+            Issue.record(
+                "Datagram for stream \(streamID) didn't close the connection",
+                sourceLocation: sourceLocation
+            )
+        case .connectionError(let error):
+            error.expect(code: code, h3ErrorCode: .generalProtocolError, sourceLocation: sourceLocation)
         }
     }
 

--- a/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
@@ -944,7 +944,25 @@ struct HTTP3ConnectionStateMachineTests {
     @Test
     func testReceivedDatagramBeforeStartedWithoutLocalSupport() {
         let stateMachine = HTTP3ConnectionStateMachine(settings: .init(), type: .server)
-        #expect(stateMachine.receivedDatagram(streamID: 0).isDiscard)
+        stateMachine.expectReceivingDatagramIsConnectionError(streamID: 0, code: .datagramsNotNegotiated)
+    }
+
+    @Test
+    func testEmitConnectionErrorBeforeStarted() {
+        var stateMachine = HTTP3ConnectionStateMachine(settings: .init(), type: .server)
+        let testError = HTTP3Error(
+            code: .datagramsNotNegotiated,
+            message: "test",
+            cause: nil,
+            errorCode: .generalProtocolError,
+            location: .here()
+        )
+
+        let action = stateMachine.emitConnectionErrorFromStream(error: testError, allowNotStarted: true)
+        guard case .emitConnectionError = action else {
+            Issue.record("Unexpected action \(action)")
+            return
+        }
     }
 
     @Test


### PR DESCRIPTION
Motivation:

We need support for HTTP3 datagrams.

Modifications:

- Change the {in,out}bound types of the HTTPHandler from Any to ByteBuffer and HTTP3Datagram
- When reading, consult the state machine to check whether the stream is open yet or whether it will ever be opened
- When writing check whether the stream is still open

Result:

Datagrams!