### PR TITLE
[Performance] HTTP3StreamHandler: Generics are faster than closures

### DIFF
--- a/Sources/HTTP3/HTTP3FrameDecoder.swift
+++ b/Sources/HTTP3/HTTP3FrameDecoder.swift
@@ -116,7 +116,7 @@ struct HTTP3FrameDecoder: ~Copyable {
                 // We know length must fit in an Int now.
                 self.nextStep = .skipBytes(length: Int(length))
                 return .returnFrame(.unknown)
-            default:
+            case .cancelPush, .goaway, .headers, .maxPushID, .pushPromise, .settings:
                 self.nextStep = .decodePayload(type: type, length: length)
             }
             return .continueDecodeLoop

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -34,7 +34,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
     private let preferHuffmanEncoding: Bool
     private let logger: Logger
     /// Instances of stream handlers which need to be pinged whenever a dynamic table entry is added.
-    private var streamHandlers = [QUICStreamID: HTTP3StreamHandler]()
+    private var streamHandlers = [QUICStreamID: HTTP3StreamHandler<HTTP3ConnectionCoordinator<QUICStreamCreator>>]()
 
     init(
         eventLoop: any EventLoop,
@@ -547,12 +547,13 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
             ),
             streamID: streamID,
             streamType: streamType,
-            qpackEncoder: self.encodeHeaders,
-            qpackDecoder: self.decodeHeaders,
-            onStreamClosed: { seenEOF, streamID, streamType in
-                self.onStreamClosed(streamID: streamID, seenEOF: seenEOF, streamType: .init(streamType))
-            },
-            onConnectionError: self.emitConnectionErrorFromStream,
+            delegate: self,
+//            qpackEncoder: self.encodeHeaders,
+//            qpackDecoder: self.decodeHeaders,
+//            onStreamClosed: { seenEOF, streamID, streamType in
+//                self.onStreamClosed(streamID: streamID, seenEOF: seenEOF, streamType: .init(streamType))
+//            },
+//            onConnectionError: self.emitConnectionErrorFromStream,
             logger: logger
         )
         try streamChannel.pipeline.syncOperations.addHandler(streamHandler)
@@ -561,14 +562,14 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
 
     // MARK: Actions
 
-    private func encodeHeaders(_ headers: [HTTPField], forStream streamID: QUICStreamID) -> HTTP3PartialFrame.Headers {
+    func encodeHeaders(_ headers: [HTTPField], forStream streamID: QUICStreamID) -> HTTP3PartialFrame.Headers {
         self.eventLoop.assertInEventLoop()
         let result = self.connectionStateMachine.encodeHeaders(headers, forStream: streamID)
         self.outboundQPACKEncoderHandler.sendInstructions(result.instructions)
         return HTTP3PartialFrame.Headers(fieldSection: result.fieldSection)
     }
 
-    private func decodeHeaders(_ headers: HTTP3PartialFrame.Headers, forStream streamID: QUICStreamID) {
+    func decodeHeaders(_ headers: HTTP3PartialFrame.Headers, forStream streamID: QUICStreamID) {
         self.eventLoop.assertInEventLoop()
         let action = self.connectionStateMachine.decodeHeaders(headers, forStream: streamID)
         switch action {
@@ -793,4 +794,15 @@ extension Channel {
         buffer.writeEncodedInteger(streamType.rawValue, strategy: .quic)
         self.writeAndFlush(buffer, promise: nil)
     }
+}
+
+extension HTTP3ConnectionCoordinator: HTTP3StreamDelegate {
+    func onStreamClosed(_ sawEOF: Bool, streamID: NIOQUICHelpers.QUICStreamID, streamType: HTTP3.HTTP3StreamType.Framed) {
+        self.onStreamClosed(streamID: streamID, seenEOF: sawEOF, streamType: .init(streamType))
+    }
+    
+    func onConnectionError(_ error: HTTP3.HTTP3Error) {
+        self.emitConnectionErrorFromStream(error)
+    }
+
 }

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -791,10 +791,11 @@ extension Channel {
 }
 
 extension HTTP3ConnectionCoordinator: HTTP3StreamDelegate {
-    func onStreamClosed(_ sawEOF: Bool, streamID: NIOQUICHelpers.QUICStreamID, streamType: HTTP3.HTTP3StreamType.Framed) {
+    func onStreamClosed(_ sawEOF: Bool, streamID: NIOQUICHelpers.QUICStreamID, streamType: HTTP3.HTTP3StreamType.Framed)
+    {
         self.onStreamClosed(streamID: streamID, seenEOF: sawEOF, streamType: .init(streamType))
     }
-    
+
     func onConnectionError(_ error: HTTP3.HTTP3Error) {
         self.emitConnectionErrorFromStream(error)
     }

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -548,12 +548,6 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
             streamID: streamID,
             streamType: streamType,
             delegate: self,
-//            qpackEncoder: self.encodeHeaders,
-//            qpackDecoder: self.decodeHeaders,
-//            onStreamClosed: { seenEOF, streamID, streamType in
-//                self.onStreamClosed(streamID: streamID, seenEOF: seenEOF, streamType: .init(streamType))
-//            },
-//            onConnectionError: self.emitConnectionErrorFromStream,
             logger: logger
         )
         try streamChannel.pipeline.syncOperations.addHandler(streamHandler)

--- a/Sources/NIOHTTP3/HTTP3StreamHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3StreamHandler.swift
@@ -18,10 +18,28 @@ import Logging
 import NIOCore
 import NIOQUICHelpers
 
+/// This is an internal protocol that shall only be implemented by HTTP3ConnectionCoordinator
+/// It exists to enable testing of `HTTP3StreamHandler` in isolation.
+protocol HTTP3StreamDelegate {
+    /// Ask the connection coordinator to encode some fields into a partial header.
+    /// It will handle sending any necessary instructions to the remote, on the dedicated QPACK stream.
+    func encodeHeaders(_: [HTTPField], forStream streamID: QUICStreamID) -> HTTP3PartialFrame.Headers
+
+    /// Tell the connection coordinator that we want to decode a header. It will handle queueing and call back into us when it has a result.
+    func decodeHeaders(_: HTTP3PartialFrame.Headers, forStream streamID: QUICStreamID)
+
+    /// Tell the connection state when this stream becomes inactive.
+    /// - Parameter sawEOF: `true` if we read an EOF before closure. That means no incoming frames were dropped.
+    func onStreamClosed(_ sawEOF: Bool, streamID: QUICStreamID, streamType: HTTP3StreamType.Framed)
+
+    /// Ask the connection coordinator to send connection-level error to the remote peer.
+    func onConnectionError(_ error: HTTP3Error)
+}
+
 /// This handler should be added to every incoming and outgoing HTTP/3 stream which carries HTTP frames.
 /// It handles encoding and decoding of these frames.
 /// It will only pass through valid frames, and handles things such as QPACK header decoding.
-final class HTTP3StreamHandler: ChannelDuplexHandler {
+final class HTTP3StreamHandler<Delegate: HTTP3StreamDelegate>: ChannelDuplexHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = HTTP3Frame
 
@@ -31,16 +49,7 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
     private let streamID: QUICStreamID
     private let streamType: HTTP3StreamType.Framed
 
-    /// Ask the connection coordinator to encode some fields into a partial header.
-    /// It will handle sending any necessary instructions to the remote, on the dedicated QPACK stream.
-    private let qpackEncoder: ([HTTPField], QUICStreamID) -> HTTP3PartialFrame.Headers
-    /// Tell the connection coordinator that we want to decode a header. It will handle queueing and call back into us when it has a result.
-    private let qpackDecoder: (HTTP3PartialFrame.Headers, QUICStreamID) -> Void
-    /// Tell the connection state when this stream becomes inactive.
-    /// - Parameter sawEOF: `true` if we read an EOF before closure. That means no incoming frames were dropped.
-    private let onStreamClosed: (_ sawEOF: Bool, QUICStreamID, HTTP3StreamType.Framed) -> Void
-    /// Ask the connection coordinator to send connection-level error to the remote peer.
-    private let onConnectionError: (HTTP3Error) -> Void
+    private let delegate: Delegate
 
     /// The channel context. This handler can only be in one channel at a time.
     private var context: ChannelHandlerContext?
@@ -60,19 +69,13 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
         stateMachine: consuming HTTP3StreamStateMachine,
         streamID: QUICStreamID,
         streamType: HTTP3StreamType.Framed,
-        qpackEncoder: @escaping ([HTTPField], QUICStreamID) -> HTTP3PartialFrame.Headers,
-        qpackDecoder: @escaping (HTTP3PartialFrame.Headers, QUICStreamID) -> Void,
-        onStreamClosed: @escaping (Bool, QUICStreamID, HTTP3StreamType.Framed) -> Void,
-        onConnectionError: @escaping (HTTP3Error) -> Void,
+        delegate: Delegate,
         logger: Logger
     ) {
         self.streamID = streamID
         self.streamType = streamType
         self.stateMachine = stateMachine
-        self.qpackEncoder = qpackEncoder
-        self.qpackDecoder = qpackDecoder
-        self.onStreamClosed = onStreamClosed
-        self.onConnectionError = onConnectionError
+        self.delegate = delegate
         self.logger = logger
     }
 
@@ -142,7 +145,7 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
                     // ignore that now
                     break
                 case .emitConnectionError(let error):
-                    self.onConnectionError(error)
+                    self.delegate.onConnectionError(error)
                 case .alreadyClosed, .needMoreBytes, .previousError, .callAgain:
                     fatalError("Action shouldn't have been buffered")
                 }
@@ -150,7 +153,7 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
             if didFireChannelRead {
                 context.fireChannelReadComplete()
             }
-            self.onStreamClosed(seenEOF, self.streamID, self.streamType)
+            self.delegate.onStreamClosed(seenEOF, streamID: self.streamID, streamType: self.streamType)
         }
         // Cleanup reference to avoid leaks.
         self.context = nil
@@ -210,7 +213,7 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
                 didFireChannelRead = true
             case .decodeHeader(let partialHeader):
                 self.logger.trace("HTTP3StreamHandler waiting for QPACK decode")
-                self.qpackDecoder(partialHeader, self.streamID)
+                self.delegate.decodeHeaders(partialHeader, forStream: self.streamID)
             case .emitStreamError(let error):
                 context.triggerUserOutboundEvent(
                     QUICStopSendingEvent(code: QUICApplicationErrorCode(error.h3ErrorCode ?? .noError)),
@@ -218,7 +221,7 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
                 )
                 context.fireErrorCaught(error)
             case .emitConnectionError(let error):
-                self.onConnectionError(error)
+                self.delegate.onConnectionError(error)
             }
         }
         // If we didn't read anything in this loop then we should also not fire the read complete
@@ -261,7 +264,7 @@ final class HTTP3StreamHandler: ChannelDuplexHandler {
             context.fireErrorCaught(error)
             promise?.fail(error)
         case .encodeHeaders(let fields):
-            let encoded = self.qpackEncoder(fields, self.streamID)
+            let encoded = self.delegate.encodeHeaders(fields, forStream: self.streamID)
             let action = self.stateMachine.gotHeaderEncodeResult(encoded, from: fields, into: &self.pendingBytes!)
 
             switch action {

--- a/Sources/NIOHTTP3/HTTP3StreamHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3StreamHandler.swift
@@ -29,7 +29,9 @@ protocol HTTP3StreamDelegate {
     func decodeHeaders(_: HTTP3PartialFrame.Headers, forStream streamID: QUICStreamID)
 
     /// Tell the connection state when this stream becomes inactive.
-    /// - Parameter sawEOF: `true` if we read an EOF before closure. That means no incoming frames were dropped.
+    ///
+    /// - Parameters:
+    ///     - sawEOF: `true` if we read an EOF before closure. That means no incoming frames were dropped.
     func onStreamClosed(_ sawEOF: Bool, streamID: QUICStreamID, streamType: HTTP3StreamType.Framed)
 
     /// Ask the connection coordinator to send connection-level error to the remote peer.

--- a/Sources/NIOHTTP3/HTTP3StreamHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3StreamHandler.swift
@@ -32,6 +32,8 @@ protocol HTTP3StreamDelegate {
     ///
     /// - Parameters:
     ///     - sawEOF: `true` if we read an EOF before closure. That means no incoming frames were dropped.
+    ///     - streamID: The closed stream's ID
+    ///     - streamType: The closed stream's type
     func onStreamClosed(_ sawEOF: Bool, streamID: QUICStreamID, streamType: HTTP3StreamType.Framed)
 
     /// Ask the connection coordinator to send connection-level error to the remote peer.

--- a/Tests/H3IntegrationTests/EndToEndTests.swift
+++ b/Tests/H3IntegrationTests/EndToEndTests.swift
@@ -669,7 +669,7 @@ struct EndToEndTests {
         // Write a settings frame, which is illegal on the request stream
         // Our outbound handlers will prevent writing an invalid frame, so we need to skip past the stream handler
         _ = requestStreamChannel.eventLoop.submit {
-            let streamHandler = try requestStreamChannel.pipeline.syncOperations.handler(type: HTTP3StreamHandler.self)
+            let streamHandler = try requestStreamChannel.pipeline.syncOperations.handler(type: HTTP3StreamHandler<HTTP3ConnectionCoordinator<NIOQUIC.QUICStreamCreator>>.self)
             let streamHandlerContext = try requestStreamChannel.pipeline.syncOperations.context(handler: streamHandler)
             var buffer = ByteBuffer()
             buffer.writeHTTP3PartialFrame(.settings(HTTP3Settings()), preferHuffmanEncoding: false)
@@ -900,7 +900,7 @@ struct EndToEndTests {
         // Write a malformed header, which can't decode.
         // Our outbound handlers will prevent writing an invalid frame, so we need to skip past the stream handler.
         _ = requestStreamChannel.eventLoop.submit {
-            let streamHandler = try requestStreamChannel.pipeline.syncOperations.handler(type: HTTP3StreamHandler.self)
+            let streamHandler = try requestStreamChannel.pipeline.syncOperations.handler(type: HTTP3StreamHandler<HTTP3ConnectionCoordinator<NIOQUIC.QUICStreamCreator>>.self)
             let streamHandlerContext = try requestStreamChannel.pipeline.syncOperations.context(handler: streamHandler)
             var buffer = ByteBuffer()
             buffer.writeHTTP3PartialFrame(

--- a/Tests/H3IntegrationTests/EndToEndTests.swift
+++ b/Tests/H3IntegrationTests/EndToEndTests.swift
@@ -669,7 +669,9 @@ struct EndToEndTests {
         // Write a settings frame, which is illegal on the request stream
         // Our outbound handlers will prevent writing an invalid frame, so we need to skip past the stream handler
         _ = requestStreamChannel.eventLoop.submit {
-            let streamHandler = try requestStreamChannel.pipeline.syncOperations.handler(type: HTTP3StreamHandler<HTTP3ConnectionCoordinator<NIOQUIC.QUICStreamCreator>>.self)
+            let streamHandler = try requestStreamChannel.pipeline.syncOperations.handler(
+                type: HTTP3StreamHandler<HTTP3ConnectionCoordinator<NIOQUIC.QUICStreamCreator>>.self
+            )
             let streamHandlerContext = try requestStreamChannel.pipeline.syncOperations.context(handler: streamHandler)
             var buffer = ByteBuffer()
             buffer.writeHTTP3PartialFrame(.settings(HTTP3Settings()), preferHuffmanEncoding: false)
@@ -900,7 +902,9 @@ struct EndToEndTests {
         // Write a malformed header, which can't decode.
         // Our outbound handlers will prevent writing an invalid frame, so we need to skip past the stream handler.
         _ = requestStreamChannel.eventLoop.submit {
-            let streamHandler = try requestStreamChannel.pipeline.syncOperations.handler(type: HTTP3StreamHandler<HTTP3ConnectionCoordinator<NIOQUIC.QUICStreamCreator>>.self)
+            let streamHandler = try requestStreamChannel.pipeline.syncOperations.handler(
+                type: HTTP3StreamHandler<HTTP3ConnectionCoordinator<NIOQUIC.QUICStreamCreator>>.self
+            )
             let streamHandlerContext = try requestStreamChannel.pipeline.syncOperations.context(handler: streamHandler)
             var buffer = ByteBuffer()
             buffer.writeHTTP3PartialFrame(

--- a/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
@@ -26,6 +26,61 @@ import Testing
 @_spi(PackageInternal) @testable import HTTP3
 @testable import NIOHTTP3
 
+final class TestDelegate: HTTP3StreamDelegate {
+
+    static func makeStaticEncoder() -> ([HTTPField], QUICStreamID) -> HTTP3PartialFrame.Headers {
+        { fields, _ in
+            let fieldSection = StaticQPACKEncoder().encode(headers: fields)
+            return HTTP3PartialFrame.Headers(fieldSection: fieldSection)
+        }
+    }
+
+    static func makeUnexpectedStreamClose() -> (Bool, QUICStreamID, HTTP3StreamType.Framed) -> Void {
+        { eof, _, _ in
+            Issue.record("Unexpected closure of stream. Saw EOF: \(eof)")
+        }
+    }
+
+    static func makeUnexpectedConnectionError() -> (any Error) -> Void {
+        { error in
+            Issue.record("Unexpected error \(error)")
+        }
+    }
+
+    let _encodeHeaders: ([HTTPField], QUICStreamID) -> HTTP3PartialFrame.Headers
+    let _decodeHeaders: (HTTP3PartialFrame.Headers, QUICStreamID) -> Void
+    let _onStreamClosed: (Bool, QUICStreamID, HTTP3StreamType.Framed) -> Void
+    let _onConnectionError: (HTTP3Error) -> Void
+
+    init(
+        encodeHeaders: @escaping ([HTTPField], QUICStreamID) -> HTTP3PartialFrame.Headers = TestDelegate.makeStaticEncoder(),
+        decodeHeaders: @escaping (HTTP3PartialFrame.Headers, QUICStreamID) -> Void,
+        onStreamClosed: @escaping (Bool, QUICStreamID, HTTP3StreamType.Framed) -> Void = TestDelegate.makeUnexpectedStreamClose(),
+        onConnectionError: @escaping (HTTP3Error) -> Void = TestDelegate.makeUnexpectedConnectionError()
+    ) {
+        self._encodeHeaders = encodeHeaders
+        self._decodeHeaders = decodeHeaders
+        self._onStreamClosed = onStreamClosed
+        self._onConnectionError = onConnectionError
+    }
+
+    func encodeHeaders(_ fields: [HTTPField], forStream streamID: QUICStreamID) -> HTTP3PartialFrame.Headers {
+        self._encodeHeaders(fields, streamID)
+    }
+
+    func decodeHeaders(_ fields: HTTP3PartialFrame.Headers, forStream streamID: QUICStreamID) {
+        self._decodeHeaders(fields, streamID)
+    }
+
+    func onStreamClosed(_ sawEOF: Bool, streamID: QUICStreamID, streamType: HTTP3StreamType.Framed) {
+        self._onStreamClosed(sawEOF, streamID, streamType)
+    }
+
+    func onConnectionError(_ error: HTTP3Error) {
+        self._onConnectionError(error)
+    }
+}
+
 struct NIOHTTP3StreamHandlerTests {
     private var testRequestHeaderFields: [HTTPField] = [
         .init(name: .method, value: "GET"),
@@ -62,10 +117,11 @@ struct NIOHTTP3StreamHandlerTests {
             stateMachine: .init(streamType: .request, incoming: true, preferHuffmanEncoding: false),
             streamID: 5,
             streamType: .request,
-            qpackEncoder: testEncoderClosure,
-            qpackDecoder: { field, _ in headerToDecode = field },
-            onStreamClosed: { eof, _, _ in Issue.record("Unexpected closure of stream. Saw EOF: \(eof)") },
-            onConnectionError: { Issue.record("Unexpected error \($0)") },
+            delegate: TestDelegate(
+                decodeHeaders: { field, _ in
+                    headerToDecode = field
+                }
+            ),
             logger: self.logger
         )
         let eventLoop = EmbeddedEventLoop()
@@ -103,10 +159,11 @@ struct NIOHTTP3StreamHandlerTests {
             stateMachine: .init(streamType: .request, incoming: true, preferHuffmanEncoding: false),
             streamID: 5,
             streamType: .request,
-            qpackEncoder: testEncoderClosure,
-            qpackDecoder: { field, _ in headerToDecode = field },
-            onStreamClosed: { eof, _, _ in Issue.record("Unexpected closure of stream. Saw EOF: \(eof)") },
-            onConnectionError: { Issue.record("Unexpected error \($0)") },
+            delegate: TestDelegate(
+                decodeHeaders: { field, _ in
+                    headerToDecode = field
+                }
+            ),
             logger: self.logger
         )
         let eventLoop = EmbeddedEventLoop()
@@ -149,10 +206,11 @@ struct NIOHTTP3StreamHandlerTests {
             stateMachine: .init(streamType: .request, incoming: true, preferHuffmanEncoding: false),
             streamID: 5,
             streamType: .request,
-            qpackEncoder: testEncoderClosure,
-            qpackDecoder: { field, _ in headerToDecode = field },
-            onStreamClosed: { eof, _, _ in Issue.record("Unexpected closure of stream. Saw EOF: \(eof)") },
-            onConnectionError: { Issue.record("Unexpected error \($0)") },
+            delegate: TestDelegate(
+                decodeHeaders: { field, _ in
+                    headerToDecode = field
+                }
+            ),
             logger: self.logger
         )
         let eventLoop = EmbeddedEventLoop()
@@ -197,10 +255,11 @@ struct NIOHTTP3StreamHandlerTests {
             stateMachine: .init(streamType: .control, incoming: false, preferHuffmanEncoding: false),
             streamID: 5,
             streamType: .request,
-            qpackEncoder: testEncoderClosure,
-            qpackDecoder: { field, _ in Issue.record("Unexpected header decode \(field)") },
-            onStreamClosed: { eof, _, _ in Issue.record("Unexpected closure of stream. Saw EOF: \(eof)") },
-            onConnectionError: { Issue.record("Unexpected error \($0)") },
+            delegate: TestDelegate(
+                decodeHeaders: { field, _ in
+                    Issue.record("Unexpected header decode \(field)")
+                }
+            ),
             logger: self.logger
         )
         let eventLoop = EmbeddedEventLoop()
@@ -222,10 +281,11 @@ struct NIOHTTP3StreamHandlerTests {
             stateMachine: .init(streamType: .request, incoming: true, preferHuffmanEncoding: false),
             streamID: 5,
             streamType: .request,
-            qpackEncoder: testEncoderClosure,
-            qpackDecoder: { field, _ in Issue.record("Unexpected header decode \(field)") },
-            onStreamClosed: { eof, _, _ in Issue.record("Unexpected closure of stream. Saw EOF: \(eof)") },
-            onConnectionError: { Issue.record("Unexpected error \($0)") },
+            delegate: TestDelegate(
+                decodeHeaders: { field, _ in
+                    Issue.record("Unexpected header decode \(field)")
+                }
+            ),
             logger: self.logger
         )
         let eventLoop = EmbeddedEventLoop()
@@ -251,10 +311,11 @@ struct NIOHTTP3StreamHandlerTests {
             stateMachine: .init(streamType: .request, incoming: false, preferHuffmanEncoding: false),
             streamID: 5,
             streamType: .request,
-            qpackEncoder: testEncoderClosure,
-            qpackDecoder: { field, _ in Issue.record("Unexpected header decode \(field)") },
-            onStreamClosed: { eof, _, _ in Issue.record("Unexpected closure of stream. Saw EOF: \(eof)") },
-            onConnectionError: { Issue.record("Unexpected error \($0)") },
+            delegate: TestDelegate(
+                decodeHeaders: { field, _ in
+                    Issue.record("Unexpected header decode \(field)")
+                }
+            ),
             logger: self.logger
         )
         let eventLoop = EmbeddedEventLoop()
@@ -282,10 +343,12 @@ struct NIOHTTP3StreamHandlerTests {
             stateMachine: .init(streamType: .request, incoming: false, preferHuffmanEncoding: false),
             streamID: 5,
             streamType: .request,
-            qpackEncoder: testEncoderClosure,
-            qpackDecoder: { field, _ in Issue.record("Unexpected header decode \(field)") },
-            onStreamClosed: { eof, _, _ in sawEOF.succeed(eof) },
-            onConnectionError: { Issue.record("Unexpected error \($0)") },
+            delegate: TestDelegate(
+                decodeHeaders: { field, _ in
+                    Issue.record("Unexpected header decode \(field)")
+                },
+                onStreamClosed: { eof, _, _ in sawEOF.succeed(eof) }
+            ),
             logger: self.logger
         )
         let errorPromise = eventLoop.makePromise(of: (any Error).self)
@@ -312,10 +375,12 @@ struct NIOHTTP3StreamHandlerTests {
             stateMachine: .init(streamType: .control, incoming: false, preferHuffmanEncoding: false),
             streamID: 5,
             streamType: .control,
-            qpackEncoder: testEncoderClosure,
-            qpackDecoder: { field, _ in Issue.record("Unexpected header decode \(field)") },
-            onStreamClosed: { eof, _, _ in Issue.record("Unexpected closure of stream. Saw EOF: \(eof)") },
-            onConnectionError: { connectionErrorPromise.succeed($0) },
+            delegate: TestDelegate(
+                decodeHeaders: { field, _ in
+                    Issue.record("Unexpected header decode \(field)")
+                },
+                onConnectionError: { connectionErrorPromise.succeed($0) }
+            ),
             logger: self.logger
         )
         let channel = EmbeddedChannel(handlers: [handler], loop: eventLoop)
@@ -343,10 +408,12 @@ struct NIOHTTP3StreamHandlerTests {
             stateMachine: .init(streamType: .control, incoming: false, preferHuffmanEncoding: false),
             streamID: 5,
             streamType: .control,
-            qpackEncoder: testEncoderClosure,
-            qpackDecoder: { field, _ in Issue.record("Unexpected header decode \(field)") },
-            onStreamClosed: { eof, _, _ in streamClosedPromise.succeed(eof) },
-            onConnectionError: { Issue.record("Unexpected connection error \($0)") },
+            delegate: TestDelegate(
+                decodeHeaders: { field, _ in
+                    Issue.record("Unexpected header decode \(field)")
+                },
+                onStreamClosed: { eof, _, _ in streamClosedPromise.succeed(eof) },
+            ),
             logger: self.logger
         )
         let channel = EmbeddedChannel(handlers: [handler], loop: eventLoop)
@@ -364,10 +431,12 @@ struct NIOHTTP3StreamHandlerTests {
             stateMachine: .init(streamType: .control, incoming: false, preferHuffmanEncoding: false),
             streamID: 5,
             streamType: .control,
-            qpackEncoder: testEncoderClosure,
-            qpackDecoder: { field, _ in Issue.record("Unexpected header decode \(field)") },
-            onStreamClosed: { eof, _, _ in streamClosedPromise.succeed(eof) },
-            onConnectionError: { Issue.record("Unexpected connection error \($0)") },
+            delegate: TestDelegate(
+                decodeHeaders: { field, _ in
+                    Issue.record("Unexpected header decode \(field)")
+                },
+                onStreamClosed: { eof, _, _ in streamClosedPromise.succeed(eof) },
+            ),
             logger: self.logger
         )
         let channel = EmbeddedChannel(handlers: [handler], loop: eventLoop)
@@ -387,10 +456,10 @@ struct NIOHTTP3StreamHandlerTests {
             stateMachine: .init(streamType: .request, incoming: true, preferHuffmanEncoding: false),
             streamID: 5,
             streamType: .request,
-            qpackEncoder: testEncoderClosure,
-            qpackDecoder: { _, _ in },
-            onStreamClosed: { eof, _, _ in streamClosedPromise.succeed(eof) },
-            onConnectionError: { Issue.record("Unexpected connection error \($0)") },
+            delegate: TestDelegate(
+                decodeHeaders: { _, _ in },
+                onStreamClosed: { eof, _, _ in streamClosedPromise.succeed(eof) },
+            ),
             logger: self.logger
         )
         let channel = EmbeddedChannel(handlers: [handler], loop: eventLoop)
@@ -438,10 +507,10 @@ struct NIOHTTP3StreamHandlerTests {
             stateMachine: .init(streamType: .request, incoming: true, preferHuffmanEncoding: false),
             streamID: 5,
             streamType: .request,
-            qpackEncoder: testEncoderClosure,
-            qpackDecoder: { _, _ in },
-            onStreamClosed: { eof, _, _ in streamClosedPromise.succeed(eof) },
-            onConnectionError: { Issue.record("Unexpected connection error \($0)") },
+            delegate: TestDelegate(
+                decodeHeaders: { _, _ in },
+                onStreamClosed: { eof, _, _ in streamClosedPromise.succeed(eof) },
+            ),
             logger: self.logger
         )
         // Record events into a Deque so we can pop them as we expect them and assert nothing left at the end.
@@ -503,10 +572,10 @@ struct NIOHTTP3StreamHandlerTests {
             stateMachine: .init(streamType: .request, incoming: true, preferHuffmanEncoding: false),
             streamID: 5,
             streamType: .request,
-            qpackEncoder: testEncoderClosure,
-            qpackDecoder: { _, _ in },
-            onStreamClosed: { _, _, _ in },
-            onConnectionError: { Issue.record("Unexpected connection error \($0)") },
+            delegate: TestDelegate(
+                decodeHeaders: { _, _ in },
+                onStreamClosed: { _, _, _ in },
+            ),
             logger: self.logger
         )
         let recorderPromise = eventLoop.makePromise(of: [HTTP3Frame].self)
@@ -537,10 +606,10 @@ struct NIOHTTP3StreamHandlerTests {
             stateMachine: .init(streamType: .request, incoming: true, preferHuffmanEncoding: false),
             streamID: 5,
             streamType: .request,
-            qpackEncoder: self.testEncoderClosure,
-            qpackDecoder: { _, _ in },
-            onStreamClosed: { _, _, _ in },
-            onConnectionError: { Issue.record("Unexpected connection error \($0)") },
+            delegate: TestDelegate(
+                decodeHeaders: { _, _ in },
+                onStreamClosed: { _, _, _ in },
+            ),
             logger: self.logger
         )
 
@@ -587,10 +656,10 @@ struct NIOHTTP3StreamHandlerTests {
             stateMachine: .init(streamType: .request, incoming: false, preferHuffmanEncoding: false),
             streamID: 5,
             streamType: .request,
-            qpackEncoder: self.testEncoderClosure,
-            qpackDecoder: { _, _ in },
-            onStreamClosed: { _, _, _ in },
-            onConnectionError: { Issue.record("Unexpected connection error \($0)") },
+            delegate: TestDelegate(
+                decodeHeaders: { _, _ in },
+                onStreamClosed: { _, _, _ in },
+            ),
             logger: self.logger
         )
 

--- a/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
@@ -53,9 +53,11 @@ final class TestDelegate: HTTP3StreamDelegate {
     let _onConnectionError: (HTTP3Error) -> Void
 
     init(
-        encodeHeaders: @escaping ([HTTPField], QUICStreamID) -> HTTP3PartialFrame.Headers = TestDelegate.makeStaticEncoder(),
+        encodeHeaders: @escaping ([HTTPField], QUICStreamID) -> HTTP3PartialFrame.Headers =
+            TestDelegate.makeStaticEncoder(),
         decodeHeaders: @escaping (HTTP3PartialFrame.Headers, QUICStreamID) -> Void,
-        onStreamClosed: @escaping (Bool, QUICStreamID, HTTP3StreamType.Framed) -> Void = TestDelegate.makeUnexpectedStreamClose(),
+        onStreamClosed: @escaping (Bool, QUICStreamID, HTTP3StreamType.Framed) -> Void =
+            TestDelegate.makeUnexpectedStreamClose(),
         onConnectionError: @escaping (HTTP3Error) -> Void = TestDelegate.makeUnexpectedConnectionError()
     ) {
         self._encodeHeaders = encodeHeaders


### PR DESCRIPTION
### Motivation

With generics we can help the compiler to make smarter (faster) decisions.

### Change

- Change four callbacks to a single Delegate pattern

### Result

Easier code for the compiler. Hopefully less ARC and fewer mallocs
