### PR TITLE
Emit a datagrams negotiated event

### DIFF
--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -96,6 +96,10 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             var remoteAllowsDatagrams = false
             let localAllowsDatagrams: Bool
 
+            var datagramsNegotiated: Bool {
+                self.localAllowsDatagrams && self.remoteAllowsDatagrams
+            }
+
             init(notStarted: consuming NotStarted) {
                 self.inboundControlStream = .init()
                 self.inboundQPACKDecoderStream = .init()
@@ -191,8 +195,7 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             }
 
         case .initialized(let initialized):
-            // Datagrams can only be sent once both peers have advertised support.
-            guard initialized.localAllowsDatagrams, initialized.remoteAllowsDatagrams else {
+            guard initialized.datagramsNegotiated else {
                 return .datagramsNotNegotiated(location: .here())
             }
 
@@ -247,8 +250,7 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             )
 
         case .initialized(let initialized):
-            // Datagrams can only be sent once both peers have advertised support.
-            guard initialized.remoteAllowsDatagrams, initialized.localAllowsDatagrams else {
+            guard initialized.datagramsNegotiated else {
                 return .drop(
                     code: .datagramsNotNegotiated,
                     message: "Datagrams have not been negotiated by both peers",
@@ -692,14 +694,22 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
 
     @_spi(PackageInternal)
     public enum ControlFrameReceivedAction {
-        /// An outbound QPACK encoder instruction stream needs to be created.
-        case makeEncoderInstructionStream
+        /// The remote's SETTINGS were processed; do each thing it indicates.
+        case onSettings(OnSettings)
         /// A connection error should be emitted
         case emitConnectionError(HTTP3Error)
         /// The following streams should be cancelled (we got a GOAWAY)
         case cancelStreams(ids: [QUICStreamID])
         /// The connection should be immediately closed without an error.
         case closeConnection
+
+        @_spi(PackageInternal)
+        public struct OnSettings: Hashable, Sendable {
+            /// An outbound QPACK encoder instruction stream needs to be created.
+            public var makeEncoderInstructionStream: Bool
+            /// Tell the user that both peers have agreed to use HTTP datagrams.
+            public var emitDatagramsNegotiatedEvent: Bool
+        }
     }
 
     @_spi(PackageInternal)
@@ -717,13 +727,21 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
                     )
                 )
                 initializedState.remoteAllowsDatagrams = settings.h3Datagram
+                let datagramsNegotiated = initializedState.datagramsNegotiated
+                let makeEncoderStream: Bool
                 self = .init(state: .initialized(initializedState))
                 switch action {
                 case .makeEncoderInstructionStream:
-                    return .makeEncoderInstructionStream
+                    makeEncoderStream = true
                 case .none:
-                    return nil
+                    makeEncoderStream = false
                 }
+                return .onSettings(
+                    ControlFrameReceivedAction.OnSettings(
+                        makeEncoderInstructionStream: makeEncoderStream,
+                        emitDatagramsNegotiatedEvent: datagramsNegotiated
+                    )
+                )
             case .notStarted:
                 fatalError("Inbound control frame received before state machine started")
             case .finished:

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -565,8 +565,13 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
             break
         case .emitConnectionError(let error):
             self.connection?.emitConnectionError(error)
-        case .makeEncoderInstructionStream:
-            self.createQPACKEncoderInstructionStream()
+        case .onSettings(let onSettings):
+            if onSettings.makeEncoderInstructionStream {
+                self.createQPACKEncoderInstructionStream()
+            }
+            if onSettings.emitDatagramsNegotiatedEvent {
+                self.connection?.fireDatagramsNegotiatedEvent()
+            }
         case .cancelStreams(let ids):
             self.cancelStreamsDueToReceivingGoaway(ids)
         case .closeConnection:

--- a/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
@@ -640,6 +640,10 @@ extension HTTP3ConnectionHandler {
         context.fireChannelReadComplete()
     }
 
+    func fireDatagramsNegotiatedEvent() {
+        self.context?.fireUserInboundEventTriggered(HTTP3DatagramsNegotiated())
+    }
+
     func emitConnectionError(_ error: HTTP3Error) {
         self.logger.debug(
             "Closing connection",

--- a/Sources/NIOHTTP3/HTTP3Datagram.swift
+++ b/Sources/NIOHTTP3/HTTP3Datagram.swift
@@ -85,6 +85,11 @@ extension HTTP3Datagram {
     }
 }
 
+/// Fired on the connection channel when both peers have advertised support for HTTP datagrams.
+public struct HTTP3DatagramsNegotiated: Hashable, Sendable {
+    public init() {}
+}
+
 extension ByteBuffer {
     mutating func parseDatagram() throws(HTTP3Error) -> HTTP3Datagram {
         guard let quarterStreamID = self.readEncodedInteger(as: UInt64.self, strategy: .quic) else {

--- a/Tests/H3IntegrationTests/EndToEndTests.swift
+++ b/Tests/H3IntegrationTests/EndToEndTests.swift
@@ -66,6 +66,24 @@ final class InboundSlowingHandler: ChannelInboundHandler {
     }
 }
 
+/// Counts the ``HTTP3DatagramsNegotiated`` events fired on a connection channel.
+final class DatagramsNegotiatedCounter: ChannelInboundHandler, Sendable {
+    typealias InboundIn = HTTP3Datagram
+
+    private let events = NIOLockedValueBox(0)
+
+    var eventCount: Int {
+        self.events.withLockedValue { $0 }
+    }
+
+    func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        if event is HTTP3DatagramsNegotiated {
+            self.events.withLockedValue { $0 &+= 1 }
+        }
+        context.fireUserInboundEventTriggered(event)
+    }
+}
+
 final class InboundDataRecorder<DataType: Sendable>: ChannelInboundHandler {
     typealias InboundIn = DataType
     typealias InboundOut = DataType
@@ -1490,6 +1508,7 @@ struct EndToEndTests {
         serverSettings: HTTP3Settings = HTTP3Settings(h3Datagram: true),
         serverDatagrams: (promise: EventLoopPromise<[HTTP3Datagram]>, count: Int)? = nil,
         clientDatagrams: (promise: EventLoopPromise<[HTTP3Datagram]>, count: Int)? = nil,
+        negotiationCounters: (client: DatagramsNegotiatedCounter, server: DatagramsNegotiatedCounter)? = nil,
         execute: (
             _ clientConnection: any Channel,
             _ serverConnection: any Channel,
@@ -1525,6 +1544,9 @@ struct EndToEndTests {
             logger: serverLogger,
             inboundConnectionInitializer: { connection in
                 connection.eventLoop.makeCompletedFuture {
+                    if let negotiationCounters {
+                        try connection.pipeline.syncOperations.addHandler(negotiationCounters.server)
+                    }
                     if let serverDatagrams {
                         try connection.pipeline.syncOperations.addHandler(
                             InboundDataRecorder<HTTP3Datagram>(
@@ -1574,6 +1596,9 @@ struct EndToEndTests {
             },
             connectionInitializer: { connection in
                 connection.eventLoop.makeCompletedFuture {
+                    if let negotiationCounters {
+                        try connection.pipeline.syncOperations.addHandler(negotiationCounters.client)
+                    }
                     if let clientDatagrams {
                         try connection.pipeline.syncOperations.addHandler(
                             InboundDataRecorder<HTTP3Datagram>(
@@ -1650,6 +1675,24 @@ struct EndToEndTests {
             let received = try await clientDatagrams.futureResult.get()
             #expect(received.map { $0.streamID } == [streamID])
             #expect(received.map { String(buffer: $0.payload) } == ["from the server"])
+        }
+    }
+
+    @Test(arguments: Self.standardAuthenticationConfigurations, [true, false])
+    @available(anyAppleOS 26, *)
+    func testDatagramsNegotiatedEvent(
+        authenticationConfiguration: AuthenticationConfiguration,
+        enabled: Bool
+    ) async throws {
+        let counters = (client: DatagramsNegotiatedCounter(), server: DatagramsNegotiatedCounter())
+
+        try await self.withDatagramConnection(
+            authenticationConfiguration: authenticationConfiguration,
+            serverSettings: HTTP3Settings(h3Datagram: enabled),
+            negotiationCounters: counters
+        ) { _, _, _ in
+            #expect(counters.client.eventCount == (enabled ? 1 : 0))
+            #expect(counters.server.eventCount == (enabled ? 1 : 0))
         }
     }
 

--- a/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
@@ -359,7 +359,12 @@ struct HTTP3ConnectionStateMachineTests {
         let action1 = stateMachine.initialize()
         #expect(action1 == .createControlStream)
         let action2 = stateMachine.receivedControlFrame(.settings(remoteSettings))
-        #expect(action2 == nil)
+        guard case .onSettings(let settings) = action2 else {
+            Issue.record("Unexpected action \(String(describing: action2))")
+            return
+        }
+        #expect(!settings.makeEncoderInstructionStream)
+        #expect(!settings.emitDatagramsNegotiatedEvent)
     }
 
     @Test
@@ -372,7 +377,7 @@ struct HTTP3ConnectionStateMachineTests {
         #expect(action1 == .createControlAndDecoderStreams)
 
         let action2 = stateMachine.receivedControlFrame(.settings(remoteSettings))
-        guard case .makeEncoderInstructionStream = action2 else {
+        guard case .onSettings(let settings) = action2, settings.makeEncoderInstructionStream else {
             Issue.record("Unexpected action \(String(describing: action2))")
             return
         }
@@ -745,7 +750,7 @@ struct HTTP3ConnectionStateMachineTests {
         #expect(action1 == .createControlAndDecoderStreams)
 
         let action2 = stateMachine.receivedControlFrame(.settings(remoteSettings))
-        guard case .makeEncoderInstructionStream = action2 else {
+        guard case .onSettings(let settings) = action2, settings.makeEncoderInstructionStream else {
             Issue.record("Unexpected action \(String(describing: action2))")
             return
         }
@@ -963,6 +968,22 @@ struct HTTP3ConnectionStateMachineTests {
         let streamID = idGenerator.inboundBidi()
         #expect(stateMachine.inboundRequestStreamReceived(streamID: streamID).isAddHandlers)
         stateMachine.expectReceivingDatagramIsConnectionError(streamID: streamID, code: .datagramsNotNegotiated)
+    }
+
+    @Test(arguments: [true, false], [true, false])
+    func testSettingsReportWhetherDatagramsAreNegotiated(localSupport: Bool, remoteSupport: Bool) {
+        var stateMachine = HTTP3ConnectionStateMachine(
+            settings: HTTP3Settings(h3Datagram: localSupport),
+            type: .client
+        )
+        _ = stateMachine.initialize()
+
+        let action = stateMachine.receivedControlFrame(.settings(HTTP3Settings(h3Datagram: remoteSupport)))
+        guard case .onSettings(let settings) = action else {
+            Issue.record("Unexpected action \(String(describing: action))")
+            return
+        }
+        #expect(settings.emitDatagramsNegotiatedEvent == (localSupport && remoteSupport))
     }
 
     @Test
@@ -1293,19 +1314,20 @@ extension HTTP3ConnectionStateMachine {
         // receive remotes settings
         let action3 = stateMachine.receivedControlFrame(.settings(remoteSettings))
         switch action3 {
-        case .makeEncoderInstructionStream:
-            // We shouldn't be asked to make an encoder stream if remote qpack isn't enabled.
-            #expect(expectRemoteQPACK)
-            let action3 = stateMachine.outboundEncoderStreamReady(streamID: idGenerator.outboundUni())
-            switch action3 {
-            case .sendEncoderInstruction(let ins):
-                #expect(ins == .setDynamicTableCapacity(Int(localSettings.qpackMaximumTableCapacity)))
-            case .none:
-                Issue.record()
+        case .onSettings(let settings):
+            // We should be asked to make an encoder stream if and only if remote qpack is enabled.
+            #expect(settings.makeEncoderInstructionStream == expectRemoteQPACK)
+            if settings.makeEncoderInstructionStream {
+                let action3 = stateMachine.outboundEncoderStreamReady(streamID: idGenerator.outboundUni())
+                switch action3 {
+                case .sendEncoderInstruction(let ins):
+                    #expect(ins == .setDynamicTableCapacity(Int(localSettings.qpackMaximumTableCapacity)))
+                case .none:
+                    Issue.record()
+                }
             }
         default:
-            // We should be asked to make an encoder stream if remote qpack is enabled.
-            #expect(!expectRemoteQPACK)
+            Issue.record("Unexpected action \(String(describing: action3))")
         }
 
         return stateMachine


### PR DESCRIPTION
Motivation:

Users don't have access to the control stream so they can't observe when SETTINGS have been sent by both streams, meaning they don't know if datagram support has been negotiated.

Modifications:

- Fire a new datagram negotiated event indicating when datagrams can be used

Result:

Users can learn when they may start sending datagrams