### PR TITLE
Emit datagram negotiation result

### DIFF
--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -707,8 +707,7 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         public struct OnSettings: Hashable, Sendable {
             /// An outbound QPACK encoder instruction stream needs to be created.
             public var makeEncoderInstructionStream: Bool
-            /// Whether both peers have agreed to use HTTP datagrams. The outcome must be reported by firing the
-            /// `HTTP3DatagramsNegotiated` event.
+            /// Whether both peers have agreed to use HTTP datagrams. The outcome must be reported downstream.
             public var datagramsNegotiated: Bool
         }
     }

--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -707,8 +707,9 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         public struct OnSettings: Hashable, Sendable {
             /// An outbound QPACK encoder instruction stream needs to be created.
             public var makeEncoderInstructionStream: Bool
-            /// Tell the user that both peers have agreed to use HTTP datagrams.
-            public var emitDatagramsNegotiatedEvent: Bool
+            /// Whether both peers have agreed to use HTTP datagrams. The outcome must be reported by firing the
+            /// `HTTP3DatagramsNegotiated` event.
+            public var datagramsNegotiated: Bool
         }
     }
 
@@ -719,27 +720,31 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             let settings = payload.settings
             switch consume self.state {
             case .initialized(var initializedState):
-                let action = initializedState.qpackState.receivedRemoteSettings(
+                initializedState.remoteAllowsDatagrams = settings.h3Datagram
+                let datagramsNegotiated = initializedState.datagramsNegotiated
+
+                let qpackAction = initializedState.qpackState.receivedRemoteSettings(
                     maxQueueSize: Int(clamping: settings.qpackBlockedStreams),
                     effectiveDynamicTableSize: min(
                         initializedState.encoderMaxTableSize,
                         Int(clamping: settings.qpackMaximumTableCapacity)
                     )
                 )
-                initializedState.remoteAllowsDatagrams = settings.h3Datagram
-                let datagramsNegotiated = initializedState.datagramsNegotiated
-                let makeEncoderStream: Bool
+
+                let makeEncoderStream =
+                    switch qpackAction {
+                    case .makeEncoderInstructionStream:
+                        true
+                    case .none:
+                        false
+                    }
+
                 self = .init(state: .initialized(initializedState))
-                switch action {
-                case .makeEncoderInstructionStream:
-                    makeEncoderStream = true
-                case .none:
-                    makeEncoderStream = false
-                }
+
                 return .onSettings(
                     ControlFrameReceivedAction.OnSettings(
                         makeEncoderInstructionStream: makeEncoderStream,
-                        emitDatagramsNegotiatedEvent: datagramsNegotiated
+                        datagramsNegotiated: datagramsNegotiated
                     )
                 )
             case .notStarted:

--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -719,27 +719,23 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             let settings = payload.settings
             switch consume self.state {
             case .initialized(var initializedState):
-                initializedState.remoteAllowsDatagrams = settings.h3Datagram
-                let datagramsNegotiated = initializedState.datagramsNegotiated
-
-                let qpackAction = initializedState.qpackState.receivedRemoteSettings(
+                let action = initializedState.qpackState.receivedRemoteSettings(
                     maxQueueSize: Int(clamping: settings.qpackBlockedStreams),
                     effectiveDynamicTableSize: min(
                         initializedState.encoderMaxTableSize,
                         Int(clamping: settings.qpackMaximumTableCapacity)
                     )
                 )
-
-                let makeEncoderStream =
-                    switch qpackAction {
-                    case .makeEncoderInstructionStream:
-                        true
-                    case .none:
-                        false
-                    }
-
+                initializedState.remoteAllowsDatagrams = settings.h3Datagram
+                let datagramsNegotiated = initializedState.datagramsNegotiated
+                let makeEncoderStream: Bool
                 self = .init(state: .initialized(initializedState))
-
+                switch action {
+                case .makeEncoderInstructionStream:
+                    makeEncoderStream = true
+                case .none:
+                    makeEncoderStream = false
+                }
                 return .onSettings(
                     ControlFrameReceivedAction.OnSettings(
                         makeEncoderInstructionStream: makeEncoderStream,

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -637,9 +637,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
             if onSettings.makeEncoderInstructionStream {
                 self.createQPACKEncoderInstructionStream()
             }
-            if onSettings.emitDatagramsNegotiatedEvent {
-                self.connection?.fireDatagramsNegotiatedEvent()
-            }
+            self.connection?.fireDatagramsNegotiatedEvent(onSettings.datagramsNegotiated)
         case .cancelStreams(let ids):
             self.cancelStreamsDueToReceivingGoaway(ids)
         case .closeConnection:

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -637,7 +637,9 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
             if onSettings.makeEncoderInstructionStream {
                 self.createQPACKEncoderInstructionStream()
             }
-            self.connection?.fireDatagramsNegotiatedEvent(onSettings.datagramsNegotiated)
+            self.connection?.fireReceivedSettingsEvent(
+                ReceivedSettings(datagramsSupported: onSettings.datagramsNegotiated)
+            )
         case .cancelStreams(let ids):
             self.cancelStreamsDueToReceivingGoaway(ids)
         case .closeConnection:

--- a/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
@@ -641,8 +641,8 @@ extension HTTP3ConnectionHandler {
         context.fireChannelReadComplete()
     }
 
-    func fireDatagramsNegotiatedEvent() {
-        self.context?.fireUserInboundEventTriggered(HTTP3DatagramsNegotiated())
+    func fireDatagramsNegotiatedEvent(_ result: Bool) {
+        self.context?.fireUserInboundEventTriggered(HTTP3DatagramsNegotiated(result))
     }
 
     func emitConnectionError(_ error: HTTP3Error) {

--- a/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
@@ -641,8 +641,8 @@ extension HTTP3ConnectionHandler {
         context.fireChannelReadComplete()
     }
 
-    func fireDatagramsNegotiatedEvent(_ result: Bool) {
-        self.context?.fireUserInboundEventTriggered(HTTP3DatagramsNegotiated(result))
+    func fireReceivedSettingsEvent(_ event: ReceivedSettings) {
+        self.context?.fireUserInboundEventTriggered(event)
     }
 
     func emitConnectionError(_ error: HTTP3Error) {

--- a/Sources/NIOHTTP3/HTTP3Datagram.swift
+++ b/Sources/NIOHTTP3/HTTP3Datagram.swift
@@ -86,12 +86,12 @@ extension HTTP3Datagram {
 }
 
 /// Fired on the connection channel once the peer's SETTINGS have been received.
-public struct HTTP3DatagramsNegotiated: Hashable, Sendable {
+public struct ReceivedSettings: Hashable, Sendable {
     /// Whether both peers advertised support for HTTP datagrams.
-    public var isSupported: Bool
+    public var datagramsSupported: Bool
 
-    init(_ isSupported: Bool) {
-        self.isSupported = isSupported
+    init(datagramsSupported: Bool) {
+        self.datagramsSupported = datagramsSupported
     }
 }
 

--- a/Sources/NIOHTTP3/HTTP3Datagram.swift
+++ b/Sources/NIOHTTP3/HTTP3Datagram.swift
@@ -85,9 +85,14 @@ extension HTTP3Datagram {
     }
 }
 
-/// Fired on the connection channel when both peers have advertised support for HTTP datagrams.
+/// Fired on the connection channel once the peer's SETTINGS have been received.
 public struct HTTP3DatagramsNegotiated: Hashable, Sendable {
-    public init() {}
+    /// Whether both peers advertised support for HTTP datagrams.
+    public var isSupported: Bool
+
+    init(_ isSupported: Bool) {
+        self.isSupported = isSupported
+    }
 }
 
 extension ByteBuffer {

--- a/Sources/NIOHTTP3/HTTP3Datagram.swift
+++ b/Sources/NIOHTTP3/HTTP3Datagram.swift
@@ -90,7 +90,7 @@ public struct ReceivedSettings: Hashable, Sendable {
     /// Whether both peers advertised support for HTTP datagrams.
     public var datagramsSupported: Bool
 
-    init(datagramsSupported: Bool) {
+    public init(datagramsSupported: Bool) {
         self.datagramsSupported = datagramsSupported
     }
 }

--- a/Tests/H3IntegrationTests/EndToEndTests.swift
+++ b/Tests/H3IntegrationTests/EndToEndTests.swift
@@ -66,18 +66,18 @@ final class InboundSlowingHandler: ChannelInboundHandler {
     }
 }
 
-/// Records the ``HTTP3DatagramsNegotiated`` events fired on a connection channel.
-final class DatagramsNegotiatedRecorder: ChannelInboundHandler, Sendable {
+/// Records the ``ReceivedSettings`` events fired on a connection channel.
+final class ReceivedSettingsRecorder: ChannelInboundHandler, Sendable {
     typealias InboundIn = HTTP3Datagram
 
-    private let events = NIOLockedValueBox([HTTP3DatagramsNegotiated]())
+    private let events = NIOLockedValueBox([ReceivedSettings]())
 
-    var recordedEvents: [HTTP3DatagramsNegotiated] {
+    var recordedEvents: [ReceivedSettings] {
         self.events.withLockedValue { $0 }
     }
 
     func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
-        if let event = event as? HTTP3DatagramsNegotiated {
+        if let event = event as? ReceivedSettings {
             self.events.withLockedValue { $0.append(event) }
         }
         context.fireUserInboundEventTriggered(event)
@@ -1509,7 +1509,7 @@ struct EndToEndTests {
         serverSettings: HTTP3Settings = HTTP3Settings(h3Datagram: true),
         serverDatagrams: (promise: EventLoopPromise<[HTTP3Datagram]>, count: Int)? = nil,
         clientDatagrams: (promise: EventLoopPromise<[HTTP3Datagram]>, count: Int)? = nil,
-        negotiationRecorders: (client: DatagramsNegotiatedRecorder, server: DatagramsNegotiatedRecorder)? = nil,
+        recorders: (client: ReceivedSettingsRecorder, server: ReceivedSettingsRecorder)? = nil,
         execute: (
             _ clientConnection: any Channel,
             _ serverConnection: any Channel,
@@ -1545,8 +1545,8 @@ struct EndToEndTests {
             logger: serverLogger,
             inboundConnectionInitializer: { connection in
                 connection.eventLoop.makeCompletedFuture {
-                    if let negotiationRecorders {
-                        try connection.pipeline.syncOperations.addHandler(negotiationRecorders.server)
+                    if let recorders {
+                        try connection.pipeline.syncOperations.addHandler(recorders.server)
                     }
                     if let serverDatagrams {
                         try connection.pipeline.syncOperations.addHandler(
@@ -1597,8 +1597,8 @@ struct EndToEndTests {
             },
             connectionInitializer: { connection in
                 connection.eventLoop.makeCompletedFuture {
-                    if let negotiationRecorders {
-                        try connection.pipeline.syncOperations.addHandler(negotiationRecorders.client)
+                    if let recorders {
+                        try connection.pipeline.syncOperations.addHandler(recorders.client)
                     }
                     if let clientDatagrams {
                         try connection.pipeline.syncOperations.addHandler(
@@ -1689,20 +1689,20 @@ struct EndToEndTests {
         ]
     )
     @available(anyAppleOS 26, *)
-    func testDatagramsNegotiatedEvent(
+    func testDatagramsNegotiated(
         authenticationConfiguration: AuthenticationConfiguration,
         support: (client: Bool, server: Bool)
     ) async throws {
-        let recorders = (client: DatagramsNegotiatedRecorder(), server: DatagramsNegotiatedRecorder())
+        let recorders = (client: ReceivedSettingsRecorder(), server: ReceivedSettingsRecorder())
 
         try await self.withDatagramConnection(
             authenticationConfiguration: authenticationConfiguration,
             clientSettings: HTTP3Settings(h3Datagram: support.client),
             serverSettings: HTTP3Settings(h3Datagram: support.server),
-            negotiationRecorders: recorders
+            recorders: recorders
         ) { _, _, _ in
             // Both peers must advertise support for datagrams to be negotiated.
-            let expected = HTTP3DatagramsNegotiated(support.client && support.server)
+            let expected = ReceivedSettings(datagramsSupported: support.client && support.server)
             #expect(recorders.client.recordedEvents == [expected])
             #expect(recorders.server.recordedEvents == [expected])
         }

--- a/Tests/H3IntegrationTests/EndToEndTests.swift
+++ b/Tests/H3IntegrationTests/EndToEndTests.swift
@@ -66,19 +66,19 @@ final class InboundSlowingHandler: ChannelInboundHandler {
     }
 }
 
-/// Counts the ``HTTP3DatagramsNegotiated`` events fired on a connection channel.
-final class DatagramsNegotiatedCounter: ChannelInboundHandler, Sendable {
+/// Records the ``HTTP3DatagramsNegotiated`` events fired on a connection channel.
+final class DatagramsNegotiatedRecorder: ChannelInboundHandler, Sendable {
     typealias InboundIn = HTTP3Datagram
 
-    private let events = NIOLockedValueBox(0)
+    private let events = NIOLockedValueBox([HTTP3DatagramsNegotiated]())
 
-    var eventCount: Int {
+    var recordedEvents: [HTTP3DatagramsNegotiated] {
         self.events.withLockedValue { $0 }
     }
 
     func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
-        if event is HTTP3DatagramsNegotiated {
-            self.events.withLockedValue { $0 &+= 1 }
+        if let event = event as? HTTP3DatagramsNegotiated {
+            self.events.withLockedValue { $0.append(event) }
         }
         context.fireUserInboundEventTriggered(event)
     }
@@ -1499,16 +1499,17 @@ struct EndToEndTests {
 
     // MARK: - Datagrams
 
-    /// Sets up a client and server which both advertise datagram support, waits until each has
-    /// received the other's SETTINGS frame, then calls `execute` with the two connection channels and
-    /// the ID of a request stream which the client has opened and the server has accepted.
+    /// Sets up a client and server, waits until each has received the other's SETTINGS frame, then calls `execute` with
+    /// the two connection channels and the ID of a request stream which the client has opened and the server has
+    /// accepted.
     @available(anyAppleOS 26, *)
     private func withDatagramConnection(
         authenticationConfiguration: AuthenticationConfiguration,
+        clientSettings: HTTP3Settings = HTTP3Settings(h3Datagram: true),
         serverSettings: HTTP3Settings = HTTP3Settings(h3Datagram: true),
         serverDatagrams: (promise: EventLoopPromise<[HTTP3Datagram]>, count: Int)? = nil,
         clientDatagrams: (promise: EventLoopPromise<[HTTP3Datagram]>, count: Int)? = nil,
-        negotiationCounters: (client: DatagramsNegotiatedCounter, server: DatagramsNegotiatedCounter)? = nil,
+        negotiationRecorders: (client: DatagramsNegotiatedRecorder, server: DatagramsNegotiatedRecorder)? = nil,
         execute: (
             _ clientConnection: any Channel,
             _ serverConnection: any Channel,
@@ -1544,8 +1545,8 @@ struct EndToEndTests {
             logger: serverLogger,
             inboundConnectionInitializer: { connection in
                 connection.eventLoop.makeCompletedFuture {
-                    if let negotiationCounters {
-                        try connection.pipeline.syncOperations.addHandler(negotiationCounters.server)
+                    if let negotiationRecorders {
+                        try connection.pipeline.syncOperations.addHandler(negotiationRecorders.server)
                     }
                     if let serverDatagrams {
                         try connection.pipeline.syncOperations.addHandler(
@@ -1580,7 +1581,7 @@ struct EndToEndTests {
             credentials: credentials,
             host: host,
             port: serverChannel.localAddress!.port!,
-            settings: HTTP3Settings(h3Datagram: true),
+            settings: clientSettings,
             logger: clientLogger,
             internalInboundStreamInitializer: { channel, _, streamType in
                 channel.eventLoop.makeCompletedFuture {
@@ -1596,8 +1597,8 @@ struct EndToEndTests {
             },
             connectionInitializer: { connection in
                 connection.eventLoop.makeCompletedFuture {
-                    if let negotiationCounters {
-                        try connection.pipeline.syncOperations.addHandler(negotiationCounters.client)
+                    if let negotiationRecorders {
+                        try connection.pipeline.syncOperations.addHandler(negotiationRecorders.client)
                     }
                     if let clientDatagrams {
                         try connection.pipeline.syncOperations.addHandler(
@@ -1678,21 +1679,32 @@ struct EndToEndTests {
         }
     }
 
-    @Test(arguments: Self.standardAuthenticationConfigurations, [true, false])
+    @Test(
+        arguments: Self.standardAuthenticationConfigurations,
+        [
+            (client: true, server: true),
+            (client: true, server: false),
+            (client: false, server: true),
+            (client: false, server: false),
+        ]
+    )
     @available(anyAppleOS 26, *)
     func testDatagramsNegotiatedEvent(
         authenticationConfiguration: AuthenticationConfiguration,
-        enabled: Bool
+        support: (client: Bool, server: Bool)
     ) async throws {
-        let counters = (client: DatagramsNegotiatedCounter(), server: DatagramsNegotiatedCounter())
+        let recorders = (client: DatagramsNegotiatedRecorder(), server: DatagramsNegotiatedRecorder())
 
         try await self.withDatagramConnection(
             authenticationConfiguration: authenticationConfiguration,
-            serverSettings: HTTP3Settings(h3Datagram: enabled),
-            negotiationCounters: counters
+            clientSettings: HTTP3Settings(h3Datagram: support.client),
+            serverSettings: HTTP3Settings(h3Datagram: support.server),
+            negotiationRecorders: recorders
         ) { _, _, _ in
-            #expect(counters.client.eventCount == (enabled ? 1 : 0))
-            #expect(counters.server.eventCount == (enabled ? 1 : 0))
+            // Both peers must advertise support for datagrams to be negotiated.
+            let expected = HTTP3DatagramsNegotiated(support.client && support.server)
+            #expect(recorders.client.recordedEvents == [expected])
+            #expect(recorders.server.recordedEvents == [expected])
         }
     }
 

--- a/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3ConnectionStateMachineTests.swift
@@ -364,7 +364,7 @@ struct HTTP3ConnectionStateMachineTests {
             return
         }
         #expect(!settings.makeEncoderInstructionStream)
-        #expect(!settings.emitDatagramsNegotiatedEvent)
+        #expect(!settings.datagramsNegotiated)
     }
 
     @Test
@@ -983,7 +983,7 @@ struct HTTP3ConnectionStateMachineTests {
             Issue.record("Unexpected action \(String(describing: action))")
             return
         }
-        #expect(settings.emitDatagramsNegotiatedEvent == (localSupport && remoteSupport))
+        #expect(settings.datagramsNegotiated == (localSupport && remoteSupport))
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Currently, the `HTTP3DatagramsNegotiated` event is only emitted if the peer agreed to receiving datagrams. It would be useful to also know if the peer did not agree to receiving datagrams.

### Modifications

Replaced the `HTTP3DatagramsNegotiated` event with a more general `SettingsReceived` event. This event now contains the datagram negotiation result and will be fired when the SETTINGS frame is received.

### Result

Downstream handlers can now know if the peer did not agree to receiving datagrams and use that information to avoid performing unnecessary work.