### PR TITLE
Remove returning QPACK decode input from result calls

### DIFF
--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -925,8 +925,6 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             @_spi(PackageInternal)
             public var fields: [HTTPField]
             @_spi(PackageInternal)
-            public var headers: HTTP3PartialFrame.Headers
-            @_spi(PackageInternal)
             public var streamID: QUICStreamID
             @_spi(PackageInternal)
             public var instructionToWrite: QPACKDecoderInstruction?
@@ -934,12 +932,10 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             @_spi(PackageInternal)
             public init(
                 fields: [HTTPField],
-                headers: HTTP3PartialFrame.Headers,
                 streamID: QUICStreamID,
                 instructionToWrite: QPACKDecoderInstruction?
             ) {
                 self.fields = fields
-                self.headers = headers
                 self.streamID = streamID
                 self.instructionToWrite = instructionToWrite
             }
@@ -950,14 +946,11 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             @_spi(PackageInternal)
             public var error: HTTP3Error
             @_spi(PackageInternal)
-            public var headers: HTTP3PartialFrame.Headers
-            @_spi(PackageInternal)
             public var streamID: QUICStreamID
 
             @_spi(PackageInternal)
-            public init(error: HTTP3Error, headers: HTTP3PartialFrame.Headers, streamID: QUICStreamID) {
+            public init(error: HTTP3Error, streamID: QUICStreamID) {
                 self.error = error
-                self.headers = headers
                 self.streamID = streamID
             }
         }
@@ -967,12 +960,11 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             case .emitConnectionError(let error):
                 self = .emitConnectionError(error)
             case .informDecodeError(let error):
-                self = .informDecodeError(.init(error: error.error, headers: error.headers, streamID: error.streamID))
+                self = .informDecodeError(.init(error: error.error, streamID: error.streamID))
             case .informDecodeResult(let result):
                 self = .informDecodeResult(
                     .init(
                         fields: result.fields,
-                        headers: result.headers,
                         streamID: result.streamID,
                         instructionToWrite: result.instructionToWrite
                     )

--- a/Sources/HTTP3/HTTP3StreamStateMachine.swift
+++ b/Sources/HTTP3/HTTP3StreamStateMachine.swift
@@ -48,13 +48,11 @@ public struct HTTP3StreamStateMachine: ~Copyable {
 
             struct WaitingForDecode: ~Copyable {
                 var decoder: HTTP3FrameDecoderStateMachine
-                let partialHeader: HTTP3PartialFrame.Headers
                 /// If we receive a close whilst waiting for a decode, we buffer it here. We must maintain the order of closes relative to reads.
                 var seenEOF: Bool
 
-                init(idleState: consuming Idle, partialHeader: HTTP3PartialFrame.Headers) {
+                init(idleState: consuming Idle) {
                     self.decoder = idleState.decoder
-                    self.partialHeader = partialHeader
                     self.seenEOF = idleState.seenEOF
                 }
             }
@@ -156,7 +154,7 @@ public struct HTTP3StreamStateMachine: ~Copyable {
                     }
                 case .returnFrame(.headers(let partialHeader)):
                     self = .init(
-                        state: .waitingForDecode(.init(idleState: idleState, partialHeader: partialHeader))
+                        state: .waitingForDecode(.init(idleState: idleState))
                     )
                     return .decodeHeader(partialHeader)
                 case .returnFrame(.pushPromise):
@@ -198,12 +196,9 @@ public struct HTTP3StreamStateMachine: ~Copyable {
 
         /// Inform the state machine of a qpack decode result that has been previously asked for.
         /// It is an error to call this function with a result for a partial header which wasn't asked for.
-        mutating func gotHeaderDecodeResult(_ decoded: [HTTPField], from: HTTP3PartialFrame.Headers) {
+        mutating func gotHeaderDecodeResult(_ decoded: [HTTPField]) {
             switch consume self.state {
             case .waitingForDecode(let waitingState):
-                guard waitingState.partialHeader == from else {
-                    fatalError("Called gotHeaderDecodeResult with wrong partial header")
-                }
                 self = .init(
                     state: .buffered(
                         .init(
@@ -225,7 +220,7 @@ public struct HTTP3StreamStateMachine: ~Copyable {
 
         /// Inform the state machine of a qpack decode error for a header that the machine previously asked to decode.
         /// It is an error to call this function with a result for a partial header which wasn't asked for.
-        mutating func gotHeaderDecodeError(_ error: HTTP3Error, from: HTTP3PartialFrame.Headers) {
+        mutating func gotHeaderDecodeError(_ error: HTTP3Error) {
             switch consume self.state {
             case .idle:
                 fatalError("Unexpected header decode")
@@ -236,9 +231,6 @@ public struct HTTP3StreamStateMachine: ~Copyable {
             case .inputClosed:
                 fatalError("Unexpected header decode")
             case .waitingForDecode(let waitingState):
-                guard waitingState.partialHeader == from else {
-                    fatalError("Called gotHeaderDecodeError with wrong partial header")
-                }
                 self = .init(state: .headerDecodeError(.init(error: error, seenEOF: waitingState.seenEOF)))
             }
         }
@@ -705,13 +697,13 @@ public struct HTTP3StreamStateMachine: ~Copyable {
     /// Inform the state machine of a qpack decode result that has been previously been asked for.
     /// It is an error to call this function with a result for a partial header which wasn't asked for.
     @_spi(PackageInternal)
-    public mutating func gotHeaderDecodeResult(_ decoded: [HTTPField], from: HTTP3PartialFrame.Headers) {
+    public mutating func gotHeaderDecodeResult(_ decoded: [HTTPField]) {
         switch self.state {
         case .finished:
             // Ignore it, we don't care anymore
             self = .init(state: .finished)
         case .idle(var idleState):
-            idleState.readState.gotHeaderDecodeResult(decoded, from: from)
+            idleState.readState.gotHeaderDecodeResult(decoded)
             self = .init(state: .idle(idleState))
         case .previousError(let error):
             self = .init(state: .previousError(error))
@@ -722,13 +714,13 @@ public struct HTTP3StreamStateMachine: ~Copyable {
     /// It is an error to call this function with a result for a partial header which wasn't asked for.
     /// This error will fail the stream. Connection-level errors should not be sent here.
     @_spi(PackageInternal)
-    public mutating func gotHeaderDecodeError(_ error: HTTP3Error, from: HTTP3PartialFrame.Headers) {
+    public mutating func gotHeaderDecodeError(_ error: HTTP3Error) {
         switch self.state {
         case .finished:
             // Ignore it, we don't care anymore
             self = .init(state: .finished)
         case .idle(var idleState):
-            idleState.readState.gotHeaderDecodeError(error, from: from)
+            idleState.readState.gotHeaderDecodeError(error)
             self = .init(state: .idle(idleState))
         case .previousError(let error):
             self = .init(state: .previousError(error))

--- a/Sources/HTTP3/QPACK/QPACKStateMachine.swift
+++ b/Sources/HTTP3/QPACK/QPACKStateMachine.swift
@@ -348,7 +348,6 @@ struct QPACKStateMachine: ~Copyable {
 
         struct InformDecodeResult: Hashable, Sendable {
             var fields: [HTTPField]
-            var headers: HTTP3PartialFrame.Headers
             var streamID: QUICStreamID
             var instructionToWrite: QPACKDecoderInstruction?
 
@@ -359,7 +358,6 @@ struct QPACKStateMachine: ~Copyable {
                 instructionToWrite: QPACKDecoderInstruction?
             ) {
                 self.fields = fields
-                self.headers = headers
                 self.streamID = streamID
                 self.instructionToWrite = instructionToWrite
             }
@@ -367,12 +365,10 @@ struct QPACKStateMachine: ~Copyable {
 
         struct InformDecodeError {
             var error: HTTP3Error
-            var headers: HTTP3PartialFrame.Headers
             var streamID: QUICStreamID
 
-            init(error: HTTP3Error, headers: HTTP3PartialFrame.Headers, streamID: QUICStreamID) {
+            init(error: HTTP3Error, streamID: QUICStreamID) {
                 self.error = error
-                self.headers = headers
                 self.streamID = streamID
             }
         }
@@ -448,7 +444,7 @@ struct QPACKStateMachine: ~Copyable {
             case .connection(let h3Error):
                 return .emitConnectionError(h3Error)
             case .stream(let h3Error):
-                return .informDecodeError(.init(error: h3Error, headers: headers, streamID: streamID))
+                return .informDecodeError(.init(error: h3Error, streamID: streamID))
             }
         }
     }
@@ -473,7 +469,7 @@ struct QPACKStateMachine: ~Copyable {
             case .connection(let h3Error):
                 return .emitConnectionError(h3Error)
             case .stream(let h3Error):
-                return .informDecodeError(.init(error: h3Error, headers: entry.headers, streamID: entry.streamID))
+                return .informDecodeError(.init(error: h3Error, streamID: entry.streamID))
             }
         case .success(let fields, let instruction):
             let writeAction = instruction.flatMap { self.outboundDecoderInstructionQueue.writeDecoderInstruction($0) }

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -712,7 +712,6 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
             // And stream closing would have triggered pending decodes to be dropped, so we wouldn't have reached here.
             self.streamHandlers[payload.streamID]!.onQPACKDecodeError(
                 payload.error,
-                forHeaders: payload.headers
             )
         case .informDecodeResult(let payload):
             self.processQPACKDecodeResult(payload)
@@ -791,7 +790,6 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
                 // And stream closing would have triggered pending decodes to be dropped, so we wouldn't have reached here.
                 self.streamHandlers[payload.streamID]!.onQPACKDecodeError(
                     payload.error,
-                    forHeaders: payload.headers
                 )
             case .informDecodeResult(let payload):
                 self.processQPACKDecodeResult(payload)
@@ -807,8 +805,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
         // And that handler cannot have been removed yet because removal only happens when the stream closes.
         // And stream closing would have triggered pending decodes to be dropped, so we wouldn't have reached here.
         self.streamHandlers[result.streamID]!.onQPACKDecodeResult(
-            fields: result.fields,
-            forHeaders: result.headers
+            fields: result.fields
         )
         if let i = result.instructionToWrite {
             self.outboundQPACKDecoderHandler.sendInstruction(i)

--- a/Sources/NIOHTTP3/HTTP3StreamHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3StreamHandler.swift
@@ -354,7 +354,7 @@ final class HTTP3StreamHandler<Delegate: HTTP3StreamDelegate>: ChannelDuplexHand
     }
 
     /// Call this when `header` has been decoded.
-    func onQPACKDecodeResult(fields: [HTTPField], forHeaders headers: HTTP3PartialFrame.Headers) {
+    func onQPACKDecodeResult(fields: [HTTPField]) {
         self.logger.trace("HTTP3StreamHandler.onQPACKDecodeResult")
         guard let context = self.context else {
             // The stream must have been created and registered to get QPACK events and thus already have
@@ -362,20 +362,20 @@ final class HTTP3StreamHandler<Delegate: HTTP3StreamDelegate>: ChannelDuplexHand
             // still be open and active.
             fatalError("Tried to deliver QPACK results before handler was added")
         }
-        self.stateMachine.gotHeaderDecodeResult(fields, from: headers)
+        self.stateMachine.gotHeaderDecodeResult(fields)
         // Call self.channelReadComplete which will decode and fire reads as much as possible before firing a read complete
         self.channelReadComplete(context: context)
     }
 
     /// Call this if an error is encountered whilst trying to decode `header`.
-    func onQPACKDecodeError(_ error: HTTP3Error, forHeaders headers: HTTP3PartialFrame.Headers) {
+    func onQPACKDecodeError(_ error: HTTP3Error) {
         guard let context = self.context else {
             // The stream must have been created an registered to get QPACK events and thus already have
             // the context available. Since pending decodes are dropped when the stream closes it must
             // still be open and active.
             fatalError("Tried to deliver QPACK error before handler was set")
         }
-        self.stateMachine.gotHeaderDecodeError(error, from: headers)
+        self.stateMachine.gotHeaderDecodeError(error)
         // Call self.channelReadComplete which will decode and fire reads as much as possible before firing a read complete
         self.channelReadComplete(context: context)
     }

--- a/Tests/HTTP3Tests/HTTP3StreamStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3StreamStateMachineTests.swift
@@ -149,7 +149,7 @@ struct HTTP3StreamStateMachineTests {
         #expect(partialHeader == self.testRequestHeader)
 
         let decodeResult = self.testRequestHeaderFields
-        machine.gotHeaderDecodeResult(decodeResult, from: partialHeader)
+        machine.gotHeaderDecodeResult(decodeResult)
         let action2 = machine.decodeNext()
         guard case .returnFrame(let frame) = action2 else {
             Issue.record("Unexpected action \(action2)")
@@ -195,7 +195,7 @@ struct HTTP3StreamStateMachineTests {
 
         // Put in the decode result
         let decodeResult = self.testRequestHeaderFields
-        machine.gotHeaderDecodeResult(decodeResult, from: partialHeader)
+        machine.gotHeaderDecodeResult(decodeResult)
 
         // We should also be able to read more bytes now, after putting in the header decode result, before fetching back the action
         machine.buffer(.init(bytes: self.testDataFrameBytes))
@@ -235,7 +235,7 @@ struct HTTP3StreamStateMachineTests {
             errorCode: .internalError,
             location: .here()
         )
-        machine.gotHeaderDecodeError(testError, from: partialHeader)
+        machine.gotHeaderDecodeError(testError)
 
         // Let's put in some more bytes. They should get ignored because they come after an error
         machine.buffer(.init(bytes: self.testDataFrameBytes))
@@ -278,7 +278,7 @@ struct HTTP3StreamStateMachineTests {
             errorCode: .internalError,
             location: .here()
         )
-        machine.gotHeaderDecodeError(testError, from: partialHeader)
+        machine.gotHeaderDecodeError(testError)
 
         // Writes are now dropped
         let writeAction = machine.writeFrame(frame: .headers(self.testResponseHeaderFields))
@@ -447,7 +447,7 @@ struct HTTP3StreamStateMachineTests {
 
         // Now decode the request trailers
         let testResult = self.testTrailerFields
-        machine.gotHeaderDecodeResult(testResult, from: self.testRequestHeader)
+        machine.gotHeaderDecodeResult(testResult)
 
         // The machine is now in a buffering state for reads, where it is holding on to that trailer for us. We can still write data out
         let writeAction2 = machine.writeFrameAndQPACK(frame: self.testDataFrame)
@@ -535,7 +535,7 @@ struct HTTP3StreamStateMachineTests {
             return
         }
 
-        machine.gotHeaderDecodeResult(self.testRequestHeaderFields, from: headerToDecode)
+        machine.gotHeaderDecodeResult(self.testRequestHeaderFields)
         machine.inputClosed()
 
         machine.assertReturnFrame(expected: .headers(self.testRequestHeaderFields))
@@ -563,7 +563,7 @@ struct HTTP3StreamStateMachineTests {
             return
         }
 
-        machine.gotHeaderDecodeResult(self.testResponseHeaderFields, from: headerToDecode)
+        machine.gotHeaderDecodeResult(self.testResponseHeaderFields)
         machine.inputClosed()
 
         machine.assertReturnFrame(expected: .headers(self.testResponseHeaderFields))
@@ -590,7 +590,7 @@ struct HTTP3StreamStateMachineTests {
 
         // There is no next, despite the input close, until we decode the header
         machine.assertNoNext()
-        machine.gotHeaderDecodeResult(self.testRequestHeaderFields, from: headerToDecode)
+        machine.gotHeaderDecodeResult(self.testRequestHeaderFields)
 
         // Now the headers are returned, then the input close, then nothing else
         machine.assertReturnFrame(expected: .headers(self.testRequestHeaderFields))
@@ -615,7 +615,7 @@ struct HTTP3StreamStateMachineTests {
         // There is no next, despite the input close, until we decode the header
         machine.inputClosed()
         machine.assertNoNext()
-        machine.gotHeaderDecodeResult(self.testRequestHeaderFields, from: headerToDecode)
+        machine.gotHeaderDecodeResult(self.testRequestHeaderFields)
 
         // Now the headers are returned, then the input close, then nothing else
         machine.assertReturnFrame(expected: .headers(self.testRequestHeaderFields))
@@ -639,7 +639,7 @@ struct HTTP3StreamStateMachineTests {
 
         // There is no next until we decode the header
         machine.assertNoNext()
-        machine.gotHeaderDecodeResult(self.testRequestHeaderFields, from: headerToDecode)
+        machine.gotHeaderDecodeResult(self.testRequestHeaderFields)
 
         machine.inputClosed()
 
@@ -833,7 +833,7 @@ extension HTTP3StreamStateMachine {
         case .missingInsertCount:
             Issue.record("Unexpected result", sourceLocation: sourceLocation)
         case .success(let fields, _):
-            self.gotHeaderDecodeResult(fields, from: partialHeader)
+            self.gotHeaderDecodeResult(fields)
             self.assertReturnFrame(expected: .headers(fields), sourceLocation: sourceLocation)
         case .error(let qpackError):
             let error = HTTP3Error(
@@ -843,7 +843,7 @@ extension HTTP3StreamStateMachine {
                 errorCode: .qpackDecompressionFailed,
                 location: .here()
             )
-            self.gotHeaderDecodeError(error, from: partialHeader)
+            self.gotHeaderDecodeError(error)
         }
     }
 

--- a/Tests/HTTP3Tests/HTTP3StreamStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3StreamStateMachineTests.swift
@@ -534,6 +534,7 @@ struct HTTP3StreamStateMachineTests {
             Issue.record("Unexpected action \(action1)")
             return
         }
+        #expect(headerToDecode.fieldSection.lines.count == 4)
 
         machine.gotHeaderDecodeResult(self.testRequestHeaderFields)
         machine.inputClosed()
@@ -562,6 +563,7 @@ struct HTTP3StreamStateMachineTests {
             Issue.record("Unexpected action \(action1)")
             return
         }
+        #expect(headerToDecode.fieldSection.lines.count == 1)
 
         machine.gotHeaderDecodeResult(self.testResponseHeaderFields)
         machine.inputClosed()
@@ -587,6 +589,7 @@ struct HTTP3StreamStateMachineTests {
             Issue.record("Unexpected action \(action1)")
             return
         }
+        #expect(headerToDecode.fieldSection.lines.count == 4)
 
         // There is no next, despite the input close, until we decode the header
         machine.assertNoNext()
@@ -611,6 +614,7 @@ struct HTTP3StreamStateMachineTests {
             Issue.record("Unexpected action \(action1)")
             return
         }
+        #expect(headerToDecode.fieldSection.lines.count == 4)
 
         // There is no next, despite the input close, until we decode the header
         machine.inputClosed()
@@ -636,6 +640,7 @@ struct HTTP3StreamStateMachineTests {
             Issue.record("Unexpected action \(action1)")
             return
         }
+        #expect(headerToDecode.fieldSection.lines.count == 4)
 
         // There is no next until we decode the header
         machine.assertNoNext()

--- a/Tests/HTTP3Tests/QPACKStateMachineTests.swift
+++ b/Tests/HTTP3Tests/QPACKStateMachineTests.swift
@@ -215,7 +215,6 @@ struct QPACKStateMachineTests {
             Issue.record("Unexpected actions \(String(describing: action2))")
             return
         }
-        #expect(error.headers == testHeader)
         #expect(error.streamID == streamID)
         expectH3ErrorEqual(error: error.error, expectedCode: .qpackDecoderError, expectedH3ErrorCode: .messageError)
     }
@@ -297,7 +296,6 @@ struct QPACKStateMachineTests {
             Issue.record("Unexpected action \(String(describing: action5))")
             return
         }
-        #expect(decodeError.headers == testHeader)
         #expect(decodeError.streamID == streamID)
         expectH3ErrorEqual(
             error: decodeError.error,

--- a/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
@@ -146,7 +146,7 @@ struct NIOHTTP3StreamHandlerTests {
             Issue.record("Expected to have a header to decode")
             return
         }
-        handler.onQPACKDecodeError(testError, forHeaders: headerToDecode)
+        handler.onQPACKDecodeError(testError)
 
         expectH3Error(code: .qpackDecoderError, h3ErrorCode: .internalError, message: "test") {
             _ = try recorderPromise.futureResult.wait()
@@ -186,7 +186,7 @@ struct NIOHTTP3StreamHandlerTests {
             Issue.record("Expected to have a header to decode")
             return
         }
-        handler.onQPACKDecodeResult(fields: self.testRequestHeaderFields, forHeaders: headerToDecode)
+        handler.onQPACKDecodeResult(fields: self.testRequestHeaderFields)
 
         // Make sure we read the right value
         guard let readFrameAny = seenEvents.popFirst()?.readValue else {
@@ -236,7 +236,7 @@ struct NIOHTTP3StreamHandlerTests {
             Issue.record("Expected to have a header to decode")
             return
         }
-        handler.onQPACKDecodeResult(fields: self.testRequestHeaderFields, forHeaders: headerToDecode)
+        handler.onQPACKDecodeResult(fields: self.testRequestHeaderFields)
 
         // Make sure we read the right value
         guard let readFrameAny = seenEvents.popFirst()?.readValue else {
@@ -532,7 +532,7 @@ struct NIOHTTP3StreamHandlerTests {
         #expect(seenEvents.isEmpty())
 
         // Give the stream the header decode result
-        handler.onQPACKDecodeResult(fields: self.testRequestHeaderFields, forHeaders: self.testRequestPartialHeader)
+        handler.onQPACKDecodeResult(fields: self.testRequestHeaderFields)
 
         guard let headerReadEvent = seenEvents.popFirst()?.readValue else {
             Issue.record("Expected a read event")
@@ -586,7 +586,7 @@ struct NIOHTTP3StreamHandlerTests {
 
         // Headers frame
         try channel.writeInbound(self.testRequestPartialHeaderBytes)
-        handler.onQPACKDecodeResult(fields: self.testRequestHeaderFields, forHeaders: self.testRequestPartialHeader)
+        handler.onQPACKDecodeResult(fields: self.testRequestHeaderFields)
 
         // Input close
         channel.pipeline.fireUserInboundEventTriggered(ChannelEvent.inputClosed)

--- a/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3StreamHandlerTests.swift
@@ -142,10 +142,7 @@ struct NIOHTTP3StreamHandlerTests {
             errorCode: .internalError,
             location: .here()
         )
-        guard let headerToDecode else {
-            Issue.record("Expected to have a header to decode")
-            return
-        }
+        #expect(headerToDecode?.fieldSection.lines.count == 4)
         handler.onQPACKDecodeError(testError)
 
         expectH3Error(code: .qpackDecoderError, h3ErrorCode: .internalError, message: "test") {
@@ -182,10 +179,7 @@ struct NIOHTTP3StreamHandlerTests {
         try channel.writeInbound(self.testRequestPartialHeaderBytes)
 
         // Make the result available
-        guard let headerToDecode else {
-            Issue.record("Expected to have a header to decode")
-            return
-        }
+        #expect(headerToDecode?.fieldSection.lines.count == 4)
         handler.onQPACKDecodeResult(fields: self.testRequestHeaderFields)
 
         // Make sure we read the right value
@@ -236,6 +230,7 @@ struct NIOHTTP3StreamHandlerTests {
             Issue.record("Expected to have a header to decode")
             return
         }
+        #expect(headerToDecode.fieldSection.lines.count == 4)
         handler.onQPACKDecodeResult(fields: self.testRequestHeaderFields)
 
         // Make sure we read the right value


### PR DESCRIPTION
### Motivation

We want to improve performance. Currently qpack decoding returns its input with its decode result. The http stream than validates that qpack has decoded the correct header field. This is unnecessary and costly. Its not only the comparison that is expensive but the movement of the array pointer as well.

### Changes

- Remove returning QPACK decode input from result calls

### Result

Easier and faster code.
