### PR TITLE
HTTP3FrameDecoder: return .waitForMoreBytes when a skip is incomplete

### DIFF
--- a/Sources/HTTP3/HTTP3FrameDecoder.swift
+++ b/Sources/HTTP3/HTTP3FrameDecoder.swift
@@ -147,13 +147,14 @@ struct HTTP3FrameDecoder: ~Copyable {
                 buffer.moveReaderIndex(forwardBy: remainingLength)
                 // We have finished skipping bytes.
                 self.nextStep = .decodeFrameType
+                return .continueDecodeLoop
             } else {
                 buffer.moveReaderIndex(forwardBy: readableBytes)
                 let newRemainingLength = remainingLength - readableBytes
                 // Need to skip more bytes still.
                 self.nextStep = .skipBytes(length: newRemainingLength)
+                return .waitForMoreBytes
             }
-            return .continueDecodeLoop
         case .decodePayload(let type, let length):
             // Make sure the length is not excessive. If it is, drop the frame.
             guard length <= type.maximumAcceptableLength else {


### PR DESCRIPTION
### Motivation

We dislike infinite loops.

### Changes

If we don't have enough bytes when dropping bytes of an unknown frame return .needsMoreBytes directly, instead of setting state and looping once more, to return the same (infinite loop).

### Result

No more infinite loops.
