### PR TITLE
Store Context in QPACKStateMachine

### DIFF
--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -925,8 +925,6 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             @_spi(PackageInternal)
             public var fields: [HTTPField]
             @_spi(PackageInternal)
-            public var headers: HTTP3PartialFrame.Headers
-            @_spi(PackageInternal)
             public var streamID: QUICStreamID
             @_spi(PackageInternal)
             public var instructionToWrite: QPACKDecoderInstruction?
@@ -934,12 +932,10 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             @_spi(PackageInternal)
             public init(
                 fields: [HTTPField],
-                headers: HTTP3PartialFrame.Headers,
                 streamID: QUICStreamID,
                 instructionToWrite: QPACKDecoderInstruction?
             ) {
                 self.fields = fields
-                self.headers = headers
                 self.streamID = streamID
                 self.instructionToWrite = instructionToWrite
             }
@@ -950,14 +946,11 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             @_spi(PackageInternal)
             public var error: HTTP3Error
             @_spi(PackageInternal)
-            public var headers: HTTP3PartialFrame.Headers
-            @_spi(PackageInternal)
             public var streamID: QUICStreamID
 
             @_spi(PackageInternal)
-            public init(error: HTTP3Error, headers: HTTP3PartialFrame.Headers, streamID: QUICStreamID) {
+            public init(error: HTTP3Error, streamID: QUICStreamID) {
                 self.error = error
-                self.headers = headers
                 self.streamID = streamID
             }
         }
@@ -967,12 +960,11 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             case .emitConnectionError(let error, _):
                 self = .emitConnectionError(error)
             case .informDecodeError(let error, _):
-                self = .informDecodeError(.init(error: error.error, headers: error.headers, streamID: error.streamID))
+                self = .informDecodeError(.init(error: error.error, streamID: error.streamID))
             case .informDecodeResult(let result, _):
                 self = .informDecodeResult(
                     .init(
                         fields: result.fields,
-                        headers: result.headers,
                         streamID: result.streamID,
                         instructionToWrite: result.instructionToWrite
                     )

--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -76,7 +76,7 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
         case finished
 
         struct NotStarted: ~Copyable {
-            var qpackState: QPACKStateMachine
+            var qpackState: QPACKStateMachine<Void>
             /// Our own settings that we will send to the remote.
             let localSettings: HTTP3Settings
             /// The type of the connection (client or server).
@@ -87,7 +87,7 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             var inboundControlStream: InboundStreamCreationState
             var inboundQPACKDecoderStream: InboundStreamCreationState
             var inboundQPACKEncoderStream: InboundStreamCreationState
-            var qpackState: QPACKStateMachine
+            var qpackState: QPACKStateMachine<Void>
             /// The type of the connection (client or server).
             let type: HTTP3ConnectionType
             let encoderMaxTableSize: Int
@@ -117,7 +117,7 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
 
     @_spi(PackageInternal)
     public init(settings: HTTP3Settings, type: HTTP3ConnectionType) {
-        let qpackState = QPACKStateMachine(
+        let qpackState = QPACKStateMachine<Void>(
             decoderMaxTableSize: Int(clamping: settings.qpackMaximumTableCapacity),
             decoderMaxBlockedStreams: Int(clamping: settings.qpackBlockedStreams)
         )
@@ -925,6 +925,8 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             @_spi(PackageInternal)
             public var fields: [HTTPField]
             @_spi(PackageInternal)
+            public var headers: HTTP3PartialFrame.Headers
+            @_spi(PackageInternal)
             public var streamID: QUICStreamID
             @_spi(PackageInternal)
             public var instructionToWrite: QPACKDecoderInstruction?
@@ -932,10 +934,12 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             @_spi(PackageInternal)
             public init(
                 fields: [HTTPField],
+                headers: HTTP3PartialFrame.Headers,
                 streamID: QUICStreamID,
                 instructionToWrite: QPACKDecoderInstruction?
             ) {
                 self.fields = fields
+                self.headers = headers
                 self.streamID = streamID
                 self.instructionToWrite = instructionToWrite
             }
@@ -946,25 +950,29 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             @_spi(PackageInternal)
             public var error: HTTP3Error
             @_spi(PackageInternal)
+            public var headers: HTTP3PartialFrame.Headers
+            @_spi(PackageInternal)
             public var streamID: QUICStreamID
 
             @_spi(PackageInternal)
-            public init(error: HTTP3Error, streamID: QUICStreamID) {
+            public init(error: HTTP3Error, headers: HTTP3PartialFrame.Headers, streamID: QUICStreamID) {
                 self.error = error
+                self.headers = headers
                 self.streamID = streamID
             }
         }
 
-        init(_ informDecodeResult: QPACKStateMachine.DecodeHeaderAction) {
+        init(_ informDecodeResult: QPACKStateMachine<Void>.DecodeHeaderAction) {
             switch informDecodeResult {
-            case .emitConnectionError(let error):
+            case .emitConnectionError(let error, _):
                 self = .emitConnectionError(error)
-            case .informDecodeError(let error):
-                self = .informDecodeError(.init(error: error.error, streamID: error.streamID))
-            case .informDecodeResult(let result):
+            case .informDecodeError(let error, _):
+                self = .informDecodeError(.init(error: error.error, headers: error.headers, streamID: error.streamID))
+            case .informDecodeResult(let result, _):
                 self = .informDecodeResult(
                     .init(
                         fields: result.fields,
+                        headers: result.headers,
                         streamID: result.streamID,
                         instructionToWrite: result.instructionToWrite
                     )
@@ -986,7 +994,7 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
             self = .init(state: .finished)
             return nil
         case .initialized(var initializedState):
-            let action = initializedState.qpackState.decodeHeaders(header, forStream: streamID)
+            let action = initializedState.qpackState.decodeHeaders(header, forStream: streamID, context: ())
             self = .init(state: .initialized(initializedState))
             return action.map { .init($0) }
         }

--- a/Sources/HTTP3/QPACK/FieldSectionQueue.swift
+++ b/Sources/HTTP3/QPACK/FieldSectionQueue.swift
@@ -21,10 +21,10 @@ enum FieldSectionQueueError: Error, Hashable, Sendable {
 }
 
 /// A queue of FieldSections which cannot yet be decoded.
-struct FieldSectionQueue {
+struct FieldSectionQueue<Context> {
     /// An entry in the queue.
     /// `Comparable` and `Equatable` are implemented based on the ``FieldSectionPrefix/requiredInsertCount`` only.
-    struct Entry: Sendable, Comparable {
+    struct Entry: Comparable {
         /// The original full headers.
         var headers: HTTP3PartialFrame.Headers
         /// The prefix of the message to be decoded.
@@ -34,16 +34,20 @@ struct FieldSectionQueue {
         /// The id of the stream we received this message on.
         var streamID: QUICStreamID
 
+        var context: Context
+
         init(
             headers: HTTP3PartialFrame.Headers,
             prefix: FieldSectionPrefix,
             lines: [FieldLine],
-            streamID: QUICStreamID
+            streamID: QUICStreamID,
+            context: Context
         ) {
             self.headers = headers
             self.prefix = prefix
             self.lines = lines
             self.streamID = streamID
+            self.context = context
         }
 
         static func < (lhs: Entry, rhs: Entry) -> Bool {

--- a/Sources/HTTP3/QPACK/FieldSectionQueue.swift
+++ b/Sources/HTTP3/QPACK/FieldSectionQueue.swift
@@ -33,7 +33,7 @@ struct FieldSectionQueue<Context> {
         var lines: [FieldLine]
         /// The id of the stream we received this message on.
         var streamID: QUICStreamID
-
+        /// Additional info that shall be stored with the header fields to decode
         var context: Context
 
         init(
@@ -101,3 +101,5 @@ struct FieldSectionQueue<Context> {
         self.maxItems = maxItems
     }
 }
+
+extension FieldSectionQueue.Entry: Sendable where Context: Sendable {}

--- a/Sources/HTTP3/QPACK/QPACKStateMachine.swift
+++ b/Sources/HTTP3/QPACK/QPACKStateMachine.swift
@@ -417,7 +417,13 @@ struct QPACKStateMachine<DecodeContext>: ~Copyable {
         case .missingInsertCount:
             do {
                 try self.decoderQueue.add(
-                    .init(headers: headers, prefix: prefix, lines: headers.fieldSection.lines, streamID: streamID, context: context)
+                    .init(
+                        headers: headers,
+                        prefix: prefix,
+                        lines: headers.fieldSection.lines,
+                        streamID: streamID,
+                        context: context
+                    )
                 )
                 return nil
             } catch {

--- a/Sources/HTTP3/QPACK/QPACKStateMachine.swift
+++ b/Sources/HTTP3/QPACK/QPACKStateMachine.swift
@@ -347,18 +347,15 @@ struct QPACKStateMachine<DecodeContext>: ~Copyable {
 
         struct InformDecodeResult: Hashable, Sendable {
             var fields: [HTTPField]
-            var headers: HTTP3PartialFrame.Headers
             var streamID: QUICStreamID
             var instructionToWrite: QPACKDecoderInstruction?
 
             init(
                 fields: [HTTPField],
-                headers: HTTP3PartialFrame.Headers,
                 streamID: QUICStreamID,
                 instructionToWrite: QPACKDecoderInstruction?
             ) {
                 self.fields = fields
-                self.headers = headers
                 self.streamID = streamID
                 self.instructionToWrite = instructionToWrite
             }
@@ -366,12 +363,10 @@ struct QPACKStateMachine<DecodeContext>: ~Copyable {
 
         struct InformDecodeError {
             var error: HTTP3Error
-            var headers: HTTP3PartialFrame.Headers
             var streamID: QUICStreamID
 
-            init(error: HTTP3Error, headers: HTTP3PartialFrame.Headers, streamID: QUICStreamID) {
+            init(error: HTTP3Error, streamID: QUICStreamID) {
                 self.error = error
-                self.headers = headers
                 self.streamID = streamID
             }
         }
@@ -409,12 +404,12 @@ struct QPACKStateMachine<DecodeContext>: ~Copyable {
             switch writeAction {
             case .sendDecoderInstruction(let instruction):
                 return .informDecodeResult(
-                    .init(fields: fields, headers: headers, streamID: streamID, instructionToWrite: instruction),
+                    .init(fields: fields, streamID: streamID, instructionToWrite: instruction),
                     context
                 )
             case .none:
                 return .informDecodeResult(
-                    .init(fields: fields, headers: headers, streamID: streamID, instructionToWrite: nil),
+                    .init(fields: fields, streamID: streamID, instructionToWrite: nil),
                     context
                 )
             }
@@ -450,7 +445,7 @@ struct QPACKStateMachine<DecodeContext>: ~Copyable {
             case .connection(let h3Error):
                 return .emitConnectionError(h3Error, context)
             case .stream(let h3Error):
-                return .informDecodeError(.init(error: h3Error, headers: headers, streamID: streamID), context)
+                return .informDecodeError(.init(error: h3Error, streamID: streamID), context)
             }
         }
     }
@@ -475,7 +470,7 @@ struct QPACKStateMachine<DecodeContext>: ~Copyable {
             case .connection(let h3Error):
                 return .emitConnectionError(h3Error, entry.context)
             case .stream(let h3Error):
-                return .informDecodeError(.init(error: h3Error, headers: entry.headers, streamID: entry.streamID), entry.context)
+                return .informDecodeError(.init(error: h3Error, streamID: entry.streamID), entry.context)
             }
         case .success(let fields, let instruction):
             let writeAction = instruction.flatMap { self.outboundDecoderInstructionQueue.writeDecoderInstruction($0) }
@@ -484,7 +479,6 @@ struct QPACKStateMachine<DecodeContext>: ~Copyable {
                 return .informDecodeResult(
                     .init(
                         fields: fields,
-                        headers: entry.headers,
                         streamID: entry.streamID,
                         instructionToWrite: instruction
                     ),
@@ -494,7 +488,6 @@ struct QPACKStateMachine<DecodeContext>: ~Copyable {
                 return .informDecodeResult(
                     .init(
                         fields: fields,
-                        headers: entry.headers,
                         streamID: entry.streamID,
                         instructionToWrite: nil
                     ),

--- a/Sources/HTTP3/QPACK/QPACKStateMachine.swift
+++ b/Sources/HTTP3/QPACK/QPACKStateMachine.swift
@@ -14,14 +14,13 @@
 
 import DequeModule
 import HTTPTypes
-import Logging
 import NIOQUICHelpers
 @_spi(PackageInternal) import QPACK
 
 /// A state machine which holds qpack encoder and decoder.
 /// You can ask it to encode/decode things, and inform it of incoming instructions.
 /// It will then return actions to be taken.
-struct QPACKStateMachine: ~Copyable {
+struct QPACKStateMachine<DecodeContext>: ~Copyable {
     struct EncoderStateMachine: ~Copyable {
         private enum State: ~Copyable {
             /// The remote side has not yet told us what dynamic table size to use, so we must assume 0, ie use a static encoder.
@@ -281,7 +280,7 @@ struct QPACKStateMachine: ~Copyable {
 
     private var encoderState: EncoderStateMachine
     private var qpackDecoder: QPACKDecoder
-    private var decoderQueue: FieldSectionQueue
+    private var decoderQueue: FieldSectionQueue<DecodeContext>
     private var outboundDecoderInstructionQueue: OutboundDecoderInstructionQueue
 
     init(decoderMaxTableSize: Int, decoderMaxBlockedStreams: Int) {
@@ -338,16 +337,17 @@ struct QPACKStateMachine: ~Copyable {
 
     enum DecodeHeaderAction {
         /// Send this qpack decode result to the relevant stream.
-        case informDecodeResult(InformDecodeResult)
+        case informDecodeResult(InformDecodeResult, DecodeContext)
 
         /// Send this qpack decoder error to the relevant stream. This is a stream-level error.
-        case informDecodeError(InformDecodeError)
+        case informDecodeError(InformDecodeError, DecodeContext)
 
         /// Send a connection-level error.
-        case emitConnectionError(HTTP3Error)
+        case emitConnectionError(HTTP3Error, DecodeContext)
 
         struct InformDecodeResult: Hashable, Sendable {
             var fields: [HTTPField]
+            var headers: HTTP3PartialFrame.Headers
             var streamID: QUICStreamID
             var instructionToWrite: QPACKDecoderInstruction?
 
@@ -358,6 +358,7 @@ struct QPACKStateMachine: ~Copyable {
                 instructionToWrite: QPACKDecoderInstruction?
             ) {
                 self.fields = fields
+                self.headers = headers
                 self.streamID = streamID
                 self.instructionToWrite = instructionToWrite
             }
@@ -365,10 +366,12 @@ struct QPACKStateMachine: ~Copyable {
 
         struct InformDecodeError {
             var error: HTTP3Error
+            var headers: HTTP3PartialFrame.Headers
             var streamID: QUICStreamID
 
-            init(error: HTTP3Error, streamID: QUICStreamID) {
+            init(error: HTTP3Error, headers: HTTP3PartialFrame.Headers, streamID: QUICStreamID) {
                 self.error = error
+                self.headers = headers
                 self.streamID = streamID
             }
         }
@@ -376,7 +379,8 @@ struct QPACKStateMachine: ~Copyable {
 
     mutating func decodeHeaders(
         _ headers: HTTP3PartialFrame.Headers,
-        forStream streamID: QUICStreamID
+        forStream streamID: QUICStreamID,
+        context: DecodeContext
     ) -> DecodeHeaderAction? {
         @inline(never)
         func invalidFieldSectionPrefixError(location: HTTP3Error.SourceLocation) -> HTTP3Error {
@@ -392,7 +396,7 @@ struct QPACKStateMachine: ~Copyable {
             // The field section prefix can't have been produced by a conformant encoder
             // RFC 9204 4.5.1.1: If the decoder encounters a value of EncodedInsertCount that could not have been produced by a
             // conformant encoder, it MUST treat this as a connection error of type QPACK_DECOMPRESSION_FAILED.
-            return .emitConnectionError(invalidFieldSectionPrefixError(location: .here()))
+            return .emitConnectionError(invalidFieldSectionPrefixError(location: .here()), context)
         }
         let result = self.qpackDecoder.decodeFieldSection(
             prefix: prefix,
@@ -405,18 +409,20 @@ struct QPACKStateMachine: ~Copyable {
             switch writeAction {
             case .sendDecoderInstruction(let instruction):
                 return .informDecodeResult(
-                    .init(fields: fields, headers: headers, streamID: streamID, instructionToWrite: instruction)
+                    .init(fields: fields, headers: headers, streamID: streamID, instructionToWrite: instruction),
+                    context
                 )
             case .none:
                 return .informDecodeResult(
-                    .init(fields: fields, headers: headers, streamID: streamID, instructionToWrite: nil)
+                    .init(fields: fields, headers: headers, streamID: streamID, instructionToWrite: nil),
+                    context
                 )
             }
 
         case .missingInsertCount:
             do {
                 try self.decoderQueue.add(
-                    .init(headers: headers, prefix: prefix, lines: headers.fieldSection.lines, streamID: streamID)
+                    .init(headers: headers, prefix: prefix, lines: headers.fieldSection.lines, streamID: streamID, context: context)
                 )
                 return nil
             } catch {
@@ -435,16 +441,16 @@ struct QPACKStateMachine: ~Copyable {
                             location: location
                         )
                     }
-                    return .emitConnectionError(tooManyBlockedStreamsError(cause: error, location: .here()))
+                    return .emitConnectionError(tooManyBlockedStreamsError(cause: error, location: .here()), context)
                 }
             }
 
         case .error(let qpackError):
             switch self.errorTypeForDecoderError(qpackError, streamID: streamID) {
             case .connection(let h3Error):
-                return .emitConnectionError(h3Error)
+                return .emitConnectionError(h3Error, context)
             case .stream(let h3Error):
-                return .informDecodeError(.init(error: h3Error, streamID: streamID))
+                return .informDecodeError(.init(error: h3Error, headers: headers, streamID: streamID), context)
             }
         }
     }
@@ -467,9 +473,9 @@ struct QPACKStateMachine: ~Copyable {
         case .error(let qpackError):
             switch self.errorTypeForDecoderError(qpackError, streamID: entry.streamID) {
             case .connection(let h3Error):
-                return .emitConnectionError(h3Error)
+                return .emitConnectionError(h3Error, entry.context)
             case .stream(let h3Error):
-                return .informDecodeError(.init(error: h3Error, streamID: entry.streamID))
+                return .informDecodeError(.init(error: h3Error, headers: entry.headers, streamID: entry.streamID), entry.context)
             }
         case .success(let fields, let instruction):
             let writeAction = instruction.flatMap { self.outboundDecoderInstructionQueue.writeDecoderInstruction($0) }
@@ -481,7 +487,8 @@ struct QPACKStateMachine: ~Copyable {
                         headers: entry.headers,
                         streamID: entry.streamID,
                         instructionToWrite: instruction
-                    )
+                    ),
+                    entry.context
                 )
             case .none:
                 return .informDecodeResult(
@@ -490,7 +497,8 @@ struct QPACKStateMachine: ~Copyable {
                         headers: entry.headers,
                         streamID: entry.streamID,
                         instructionToWrite: nil
-                    )
+                    ),
+                    entry.context
                 )
             }
         }

--- a/Tests/HTTP3Tests/FieldSectionQueueTests.swift
+++ b/Tests/HTTP3Tests/FieldSectionQueueTests.swift
@@ -19,46 +19,47 @@ import Testing
 @_spi(PackageInternal) @testable import HTTP3
 
 struct FieldSectionQueueTests {
-    private func makeTestEntry(streamID: QUICStreamID, requiredInsertCount: Int) -> FieldSectionQueue.Entry {
+    private func makeTestEntry(streamID: QUICStreamID, requiredInsertCount: Int, context: Int) -> FieldSectionQueue<Int>.Entry {
         let prefix = FieldSectionPrefix(requiredInsertCount: requiredInsertCount, base: 0)
         return FieldSectionQueue.Entry(
             headers: .init(fieldSection: .init(prefix: prefix.encode(maxCapacity: 100), lines: [])),
             prefix: prefix,
             lines: [],
-            streamID: streamID
+            streamID: streamID,
+            context: context
         )
     }
 
     @Test
     func cantAddMoreThanMaxItems() throws {
-        var queue = FieldSectionQueue(maxItems: 3)
+        var queue = FieldSectionQueue<Int>(maxItems: 3)
 
-        try queue.add(self.makeTestEntry(streamID: 1, requiredInsertCount: 1))
-        try queue.add(self.makeTestEntry(streamID: 2, requiredInsertCount: 1))
-        try queue.add(self.makeTestEntry(streamID: 3, requiredInsertCount: 1))
+        try queue.add(self.makeTestEntry(streamID: 1, requiredInsertCount: 1, context: 1))
+        try queue.add(self.makeTestEntry(streamID: 2, requiredInsertCount: 1, context: 2))
+        try queue.add(self.makeTestEntry(streamID: 3, requiredInsertCount: 1, context: 3))
         // 4th item fails, because max is 3
         #expect(throws: FieldSectionQueueError.reachedMaxSize) {
-            try queue.add(self.makeTestEntry(streamID: 4, requiredInsertCount: 1))
+            try queue.add(self.makeTestEntry(streamID: 4, requiredInsertCount: 1, context: 4))
         }
     }
 
     @Test
     func popsNothingIfNothingDecodable() throws {
-        var queue = FieldSectionQueue(maxItems: 3)
+        var queue = FieldSectionQueue<Int>(maxItems: 3)
 
-        try queue.add(self.makeTestEntry(streamID: 1, requiredInsertCount: 10))
-        try queue.add(self.makeTestEntry(streamID: 2, requiredInsertCount: 20))
+        try queue.add(self.makeTestEntry(streamID: 1, requiredInsertCount: 10, context: 1))
+        try queue.add(self.makeTestEntry(streamID: 2, requiredInsertCount: 20, context: 2))
 
         #expect(queue.popIfDecodable(availableInsertCount: 5) == nil)
     }
 
     @Test
     func popsOldestIfMultipleDecodable() throws {
-        var queue = FieldSectionQueue(maxItems: 3)
+        var queue = FieldSectionQueue<Int>(maxItems: 3)
 
-        try queue.add(self.makeTestEntry(streamID: 1, requiredInsertCount: 40))
-        try queue.add(self.makeTestEntry(streamID: 2, requiredInsertCount: 10))
-        try queue.add(self.makeTestEntry(streamID: 3, requiredInsertCount: 20))
+        try queue.add(self.makeTestEntry(streamID: 1, requiredInsertCount: 40, context: 1))
+        try queue.add(self.makeTestEntry(streamID: 2, requiredInsertCount: 10, context: 2))
+        try queue.add(self.makeTestEntry(streamID: 3, requiredInsertCount: 20, context: 3))
 
         #expect(queue.popIfDecodable(availableInsertCount: 30)?.streamID == 2)
         #expect(queue.popIfDecodable(availableInsertCount: 30)?.streamID == 3)
@@ -69,11 +70,11 @@ struct FieldSectionQueueTests {
 
     @Test
     func removesEntries() throws {
-        var queue = FieldSectionQueue(maxItems: 3)
+        var queue = FieldSectionQueue<Int>(maxItems: 3)
 
-        try queue.add(self.makeTestEntry(streamID: 1, requiredInsertCount: 40))
-        try queue.add(self.makeTestEntry(streamID: 2, requiredInsertCount: 10))
-        try queue.add(self.makeTestEntry(streamID: 3, requiredInsertCount: 20))
+        try queue.add(self.makeTestEntry(streamID: 1, requiredInsertCount: 40, context: 1))
+        try queue.add(self.makeTestEntry(streamID: 2, requiredInsertCount: 10, context: 2))
+        try queue.add(self.makeTestEntry(streamID: 3, requiredInsertCount: 20, context: 3))
 
         // We have 3 entries, until we remove one, and then we have 2
         #expect(queue._allEntries.count == 3)

--- a/Tests/HTTP3Tests/FieldSectionQueueTests.swift
+++ b/Tests/HTTP3Tests/FieldSectionQueueTests.swift
@@ -19,7 +19,11 @@ import Testing
 @_spi(PackageInternal) @testable import HTTP3
 
 struct FieldSectionQueueTests {
-    private func makeTestEntry(streamID: QUICStreamID, requiredInsertCount: Int, context: Int) -> FieldSectionQueue<Int>.Entry {
+    private func makeTestEntry(
+        streamID: QUICStreamID,
+        requiredInsertCount: Int,
+        context: Int
+    ) -> FieldSectionQueue<Int>.Entry {
         let prefix = FieldSectionPrefix(requiredInsertCount: requiredInsertCount, base: 0)
         return FieldSectionQueue.Entry(
             headers: .init(fieldSection: .init(prefix: prefix.encode(maxCapacity: 100), lines: [])),

--- a/Tests/HTTP3Tests/QPACKStateMachineTests.swift
+++ b/Tests/HTTP3Tests/QPACKStateMachineTests.swift
@@ -19,15 +19,13 @@ import Testing
 @_spi(PackageInternal) @testable import HTTP3
 
 struct QPACKStateMachineTests {
-    @Test
-    func testBeginUsingDynamicTable() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testBeginUsingDynamicTable() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
     }
 
-    @Test
-    func testSettingsWithoutDynamicTable() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testSettingsWithoutDynamicTable() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let action = stateMachine.receivedRemoteSettings(maxQueueSize: 0, effectiveDynamicTableSize: 0)
         switch action {
         case .makeEncoderInstructionStream:
@@ -40,9 +38,8 @@ struct QPACKStateMachineTests {
 
     // MARK: Encoding headers
 
-    @Test
-    func testEncodeHeadersInInitialState() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testEncodeHeadersInInitialState() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let result = stateMachine.encodeHeaders([.init(name: .cookie, value: "test")], forStream: 1)
         #expect(
             result.fieldSection.lines
@@ -57,9 +54,8 @@ struct QPACKStateMachineTests {
         )
     }
 
-    @Test
-    func testEncodeHeadersInWaitingForStreamState() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testEncodeHeadersInWaitingForStreamState() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let action = stateMachine.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: 100)
         #expect(action == .makeEncoderInstructionStream)
         // We have received remote settings, and been asked to create outbound encoder stream
@@ -67,18 +63,16 @@ struct QPACKStateMachineTests {
         stateMachine.assertEncodesWithoutUsingDynamicTable()
     }
 
-    @Test
-    func testEncodeHeadersInWithoutDynamicState() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testEncodeHeadersInWithoutDynamicState() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let action = stateMachine.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: 0)
         #expect(action == nil)  // No outbound stream because 0 size
         // We have received remote settings, but they specify 0 table size. Therefore we should not use dynamic table
         stateMachine.assertEncodesWithoutUsingDynamicTable()
     }
 
-    @Test
-    func testEncodeHeadersInWithDynamicState() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testEncodeHeadersInWithDynamicState() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let action1 = stateMachine.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: 300)
         #expect(action1 == .makeEncoderInstructionStream)
         let action2 = stateMachine.outboundEncoderStreamReady()
@@ -101,18 +95,18 @@ struct QPACKStateMachineTests {
 
     // MARK: Decoding headers
 
-    @Test
-    func testDecodeHeadersWithoutDynamicTable() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testDecodeHeadersWithoutDynamicTable() {
+        var stateMachine = QPACKStateMachine<Int>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let streamID = QUICStreamID(0)
+        let receiver = 5
         let testHeader = HTTP3PartialFrame.Headers(
             fieldSection: FieldSection(
                 prefix: .init(encodedRequiredInsertCount: 0, deltaBase: 0, signBit: false),
                 lines: [.literal(requireLiteralRepresentation: false, name: "cookie", value: "test")]
             )
         )
-        let action = stateMachine.decodeHeaders(testHeader, forStream: streamID)
-        guard case .informDecodeResult(let result) = action else {
+        let action = stateMachine.decodeHeaders(testHeader, forStream: streamID, context: receiver)
+        guard case .informDecodeResult(let result, let context) = action else {
             Issue.record("Unexpected action \(String(describing: action))")
             return
         }
@@ -125,11 +119,11 @@ struct QPACKStateMachineTests {
                     instructionToWrite: nil
                 )
         )
+        #expect(receiver == context)
     }
 
-    @Test
-    func testDecodeHeadersWithDynamicTable() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testDecodeHeadersWithDynamicTable() {
+        var stateMachine = QPACKStateMachine<Int>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let streamID = QUICStreamID(0)
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
@@ -149,8 +143,9 @@ struct QPACKStateMachineTests {
                 lines: [.indexedWithPostBase(index: 0)]
             )
         )
-        let actions2 = stateMachine.decodeHeaders(testHeader, forStream: streamID)
-        guard case .informDecodeResult(let decodeResult) = actions2 else {
+        let receiver = 3
+        let actions2 = stateMachine.decodeHeaders(testHeader, forStream: streamID, context: receiver)
+        guard case .informDecodeResult(let decodeResult, let context) = actions2 else {
             Issue.record("Unexpected action \(String(describing: actions2))")
             return
         }
@@ -163,12 +158,13 @@ struct QPACKStateMachineTests {
                     instructionToWrite: .sectionAcknowledgement(streamID: streamID)
                 )
         )
+        #expect(context == receiver)
     }
 
-    @Test
-    func testDecodeHeadersConnectionError() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testDecodeHeadersConnectionError() {
+        var stateMachine = QPACKStateMachine<Int>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let streamID = QUICStreamID(0)
+        let contextID = 123
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
         stateMachine.setupLocalDynamicTable(maxSize: 1024)
@@ -181,9 +177,9 @@ struct QPACKStateMachineTests {
                 lines: [.indexedWithPostBase(index: 0)]
             )
         )
-        let action2 = stateMachine.decodeHeaders(testHeader, forStream: streamID)
+        let action2 = stateMachine.decodeHeaders(testHeader, forStream: streamID, context: contextID)
 
-        guard case .emitConnectionError(let error) = action2 else {
+        guard case .emitConnectionError(let error, let context) = action2 else {
             Issue.record("Unexpected actions \(String(describing: action2))")
             return
         }
@@ -192,12 +188,13 @@ struct QPACKStateMachineTests {
             expectedCode: .qpackDecoderError,
             expectedH3ErrorCode: .qpackDecompressionFailed
         )
+        #expect(context == contextID)
     }
 
-    @Test
-    func testDecodeHeadersStreamError() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testDecodeHeadersStreamError() {
+        var stateMachine = QPACKStateMachine<Int>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let streamID = QUICStreamID(0)
+        let contextID = 42
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
         stateMachine.setupLocalDynamicTable(maxSize: 1024)
@@ -210,18 +207,18 @@ struct QPACKStateMachineTests {
                 lines: [.literal(requireLiteralRepresentation: false, name: "ILLEGAL", value: "value")]
             )
         )
-        let action2 = stateMachine.decodeHeaders(testHeader, forStream: streamID)
-        guard case .informDecodeError(let error) = action2 else {
+        let action2 = stateMachine.decodeHeaders(testHeader, forStream: streamID, context: contextID)
+        guard case .informDecodeError(let error, let context) = action2 else {
             Issue.record("Unexpected actions \(String(describing: action2))")
             return
         }
         #expect(error.streamID == streamID)
         expectH3ErrorEqual(error: error.error, expectedCode: .qpackDecoderError, expectedH3ErrorCode: .messageError)
+        #expect(context == contextID)
     }
 
-    @Test
-    func testDecodeHeadersWithDynamicTableDelayed() throws {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testDecodeHeadersWithDynamicTableDelayed() throws {
+        var stateMachine = QPACKStateMachine<Int>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let streamID = QUICStreamID(0)
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
@@ -235,7 +232,8 @@ struct QPACKStateMachineTests {
                 lines: [.indexedWithPostBase(index: 0)]
             )
         )
-        let actions3 = stateMachine.decodeHeaders(testHeader, forStream: streamID)
+        let contextID = 12
+        let actions3 = stateMachine.decodeHeaders(testHeader, forStream: streamID, context: contextID)
         // The machine can't decode it, because it hasn't received that entry yet
         #expect(actions3 == nil)
 
@@ -254,15 +252,15 @@ struct QPACKStateMachineTests {
                         headers: testHeader,
                         streamID: streamID,
                         instructionToWrite: .sectionAcknowledgement(streamID: streamID)
-                    )
+                    ),
+                    contextID
                 )
         )
         #expect(stateMachine.checkPendingDecodes() == nil)
     }
 
-    @Test
-    func testDecodeHeadersStreamErrorDelayed() throws {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testDecodeHeadersStreamErrorDelayed() throws {
+        var stateMachine = QPACKStateMachine<Int>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let streamID = QUICStreamID(0)
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
@@ -280,7 +278,8 @@ struct QPACKStateMachineTests {
                 ]
             )
         )
-        let actions3 = stateMachine.decodeHeaders(testHeader, forStream: streamID)
+        let contextID = 6
+        let actions3 = stateMachine.decodeHeaders(testHeader, forStream: streamID, context: contextID)
         // The machine can't decode it, because it hasn't received that entry yet
         #expect(actions3 == nil)
 
@@ -292,7 +291,7 @@ struct QPACKStateMachineTests {
 
         // Decoding now becomes possible and gives us the error
         let action5 = stateMachine.checkPendingDecodes()
-        guard case .informDecodeError(let decodeError) = action5 else {
+        guard case .informDecodeError(let decodeError, let context) = action5 else {
             Issue.record("Unexpected action \(String(describing: action5))")
             return
         }
@@ -302,12 +301,13 @@ struct QPACKStateMachineTests {
             expectedCode: .qpackDecoderError,
             expectedH3ErrorCode: .messageError
         )
+        #expect(context == contextID)
     }
 
-    @Test
-    func testInvalidFieldPrefix() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testInvalidFieldPrefix() {
+        var stateMachine = QPACKStateMachine<Int>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let streamID = QUICStreamID(0)
+        let contextID = 7
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
         stateMachine.setupLocalDynamicTable(maxSize: 1024)
         stateMachine.setupOutboundDecoderStream()
@@ -319,9 +319,9 @@ struct QPACKStateMachineTests {
                 ]
             )
         )
-        let actions3 = stateMachine.decodeHeaders(testHeader, forStream: streamID)
+        let actions3 = stateMachine.decodeHeaders(testHeader, forStream: streamID, context: contextID)
         // The machine can't decode it, because the prefix is nonsense
-        guard case .emitConnectionError(let error) = actions3 else {
+        guard case .emitConnectionError(let error, let context) = actions3 else {
             Issue.record("Unexpected action \(String(describing: actions3))")
             return
         }
@@ -332,16 +332,17 @@ struct QPACKStateMachineTests {
             expectedH3ErrorCode: .qpackDecompressionFailed,
             expectedMessage: "Invalid field section prefix"
         )
+        #expect(context == contextID)
     }
 
-    @Test
-    func testMaxBlockedStreams() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 3)
+    @Test func testMaxBlockedStreams() {
+        var stateMachine = QPACKStateMachine<Int>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 3)
 
         let streamID1 = QUICStreamID(1)
         let streamID2 = QUICStreamID(2)
         let streamID3 = QUICStreamID(3)
         let streamID4 = QUICStreamID(4)
+        let contextID = 99
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
         stateMachine.setupLocalDynamicTable(maxSize: 1024)
@@ -356,17 +357,17 @@ struct QPACKStateMachineTests {
         )
 
         // Max blocked streams is 3, so the first 3 are fine, they just get queued
-        let action1 = stateMachine.decodeHeaders(testHeader, forStream: streamID1)
+        let action1 = stateMachine.decodeHeaders(testHeader, forStream: streamID1, context: contextID)
         #expect(action1 == nil)
-        let action2 = stateMachine.decodeHeaders(testHeader, forStream: streamID2)
+        let action2 = stateMachine.decodeHeaders(testHeader, forStream: streamID2, context: contextID)
         #expect(action2 == nil)
-        let action3 = stateMachine.decodeHeaders(testHeader, forStream: streamID3)
+        let action3 = stateMachine.decodeHeaders(testHeader, forStream: streamID3, context: contextID)
         #expect(action3 == nil)
 
         // Trying to queue on a 4th stream is a connection error
         // RFC 9204 2.1.2: If a decoder encounters more blocked streams than it promised to support, it MUST treat this as a connection error of type QPACK_DECOMPRESSION_FAILED.
-        let action4 = stateMachine.decodeHeaders(testHeader, forStream: streamID4)
-        guard case .emitConnectionError(let error) = action4 else {
+        let action4 = stateMachine.decodeHeaders(testHeader, forStream: streamID4, context: contextID)
+        guard case .emitConnectionError(let error, let context) = action4 else {
             Issue.record("Unexpected action \(String(describing: action4))")
             return
         }
@@ -376,11 +377,11 @@ struct QPACKStateMachineTests {
             expectedH3ErrorCode: .qpackDecompressionFailed,
             expectedMessage: "Too many streams blocked on QPACK"
         )
+        #expect(context == contextID)
     }
 
-    @Test
-    func testDecodeInstructionsBufferedWhenStreamNotReady() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testDecodeInstructionsBufferedWhenStreamNotReady() {
+        var stateMachine = QPACKStateMachine<Int>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
         stateMachine.setupLocalDynamicTable(maxSize: 1024)
@@ -400,7 +401,8 @@ struct QPACKStateMachineTests {
             )
         )
         let streamID = QUICStreamID(0)
-        let actions2 = stateMachine.decodeHeaders(testHeader, forStream: streamID)
+        let contextID = 11
+        let actions2 = stateMachine.decodeHeaders(testHeader, forStream: streamID, context: contextID)
         // The action is only to inform the decode result, there is no section acknowledgment because the outbound stream isn't ready
         #expect(
             actions2
@@ -410,7 +412,8 @@ struct QPACKStateMachineTests {
                         headers: testHeader,
                         streamID: streamID,
                         instructionToWrite: nil
-                    )
+                    ),
+                    contextID
                 )
         )
 
@@ -432,9 +435,8 @@ struct QPACKStateMachineTests {
 
     // MARK: Decoder instructions
 
-    @Test
-    func testGotIncomingDecoderInstruction() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testGotIncomingDecoderInstruction() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
         let streamID = QUICStreamID(4)
         _ = stateMachine.encodeHeaders([.init(name: .cookie, value: "test")], forStream: streamID)
@@ -444,9 +446,8 @@ struct QPACKStateMachineTests {
         #expect(actions == nil)
     }
 
-    @Test
-    func testGotDecoderInstructionWhenImplicitlyNoDynamicTable() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testGotDecoderInstructionWhenImplicitlyNoDynamicTable() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         // This instruction is invalid because there is no dynamic table initially and no stream with id 1
         let action = stateMachine.receivedIncomingDecoderInstruction(.sectionAcknowledgement(streamID: 1))
         guard case .emitConnectionError(let error) = action else {
@@ -460,9 +461,8 @@ struct QPACKStateMachineTests {
         )
     }
 
-    @Test
-    func testGotDecoderInstructionWhenExplicitlyNoDynamicTable() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testGotDecoderInstructionWhenExplicitlyNoDynamicTable() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         _ = stateMachine.receivedRemoteSettings(maxQueueSize: 0, effectiveDynamicTableSize: 0)
         // This instruction is invalid because remote explicitly told us no dynamic table capacity
         let action = stateMachine.receivedIncomingDecoderInstruction(.sectionAcknowledgement(streamID: 1))
@@ -477,9 +477,8 @@ struct QPACKStateMachineTests {
         )
     }
 
-    @Test
-    func testGotDecoderInstructionWhenAwaitingStream() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testGotDecoderInstructionWhenAwaitingStream() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         _ = stateMachine.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: 100)
         // We can't receive instructions from the remote decoder until we ourselves have sent an instruction to indicate support of the dynamic table
         let action = stateMachine.receivedIncomingDecoderInstruction(.sectionAcknowledgement(streamID: 1))
@@ -494,9 +493,8 @@ struct QPACKStateMachineTests {
         )
     }
 
-    @Test
-    func testGotInvalidIncomingDecoderInstruction() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testGotInvalidIncomingDecoderInstruction() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         stateMachine.setupRemoteDynamicTable(maxSize: 1)
         // This instruction is invalid because we can't ack an insert which hasn't happened
         let action = stateMachine.receivedIncomingDecoderInstruction(.insertCountIncrement(increment: 1))
@@ -513,9 +511,8 @@ struct QPACKStateMachineTests {
 
     // MARK: Encoder instructions
 
-    @Test
-    func testGotInvalidIncomingEncoderInstruction() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testGotInvalidIncomingEncoderInstruction() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
 
         // Invalid because 1025 is higher than allowed max capacity
         let action = stateMachine.receivedIncomingEncoderInstruction(.setDynamicTableCapacity(1025))
@@ -530,9 +527,8 @@ struct QPACKStateMachineTests {
         )
     }
 
-    @Test
-    func testInsertTooLargeEntry() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1, decoderMaxBlockedStreams: 100)
+    @Test func testInsertTooLargeEntry() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1, decoderMaxBlockedStreams: 100)
 
         let action1 = stateMachine.receivedIncomingEncoderInstruction(.setDynamicTableCapacity(1))
         #expect(action1?.decoderInstructions == nil)
@@ -555,9 +551,8 @@ struct QPACKStateMachineTests {
 
     // MARK: Request stream closing
 
-    @Test
-    func testClosedRequestStreamAfterEOF() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testClosedRequestStreamAfterEOF() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let streamID = QUICStreamID(1)
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
@@ -569,9 +564,8 @@ struct QPACKStateMachineTests {
         #expect(actions == nil)
     }
 
-    @Test
-    func testClosedRequestStreamBeforeEOFWithoutDynamicTable() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testClosedRequestStreamBeforeEOFWithoutDynamicTable() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let streamID = QUICStreamID(1)
 
         // Cancel the stream
@@ -579,10 +573,10 @@ struct QPACKStateMachineTests {
         #expect(actions == nil)  // No instruction to send, because no dynamic table
     }
 
-    @Test
-    func testClosedRequestStreamWhilstDecodingQPACK() {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testClosedRequestStreamWhilstDecodingQPACK() {
+        var stateMachine = QPACKStateMachine<Int>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let streamID = QUICStreamID(1)
+        let contextID = 3
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
         stateMachine.setupLocalDynamicTable(maxSize: 1024)
@@ -595,7 +589,7 @@ struct QPACKStateMachineTests {
                 lines: [.indexedWithPostBase(index: 0)]
             )
         )
-        let actions1 = stateMachine.decodeHeaders(testHeader, forStream: streamID)
+        let actions1 = stateMachine.decodeHeaders(testHeader, forStream: streamID, context: contextID)
         // The state machine will have queued the decoding, so we don't have an action yet.
         #expect(actions1 == nil)
 
@@ -614,9 +608,8 @@ struct QPACKStateMachineTests {
 
     /// This tests the scenario where a request is fully completed, the stream is closed, and then an ack comes in on the QPACK decoder stream for that request.
     /// This test is for a potential bug where we accidentally treat it as an error to receive an ack for a 'nonexistent' stream.
-    @Test
-    func testClosedRequestStreamThenReceiveSectionAck() throws {
-        var stateMachine = QPACKStateMachine(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+    @Test func testClosedRequestStreamThenReceiveSectionAck() throws {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
 
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
         stateMachine.setupLocalDynamicTable(maxSize: 1024)
@@ -642,11 +635,11 @@ struct QPACKStateMachineTests {
     }
 }
 
-extension QPACKStateMachine.DecodeHeaderAction: Equatable {
+extension QPACKStateMachine.DecodeHeaderAction: Equatable where DecodeContext: Equatable {
     static func == (lhs: QPACKStateMachine.DecodeHeaderAction, rhs: QPACKStateMachine.DecodeHeaderAction) -> Bool {
         switch (lhs, rhs) {
-        case (.informDecodeResult(let l), .informDecodeResult(let r)):
-            return l == r
+        case (.informDecodeResult(let l, let lContext), .informDecodeResult(let r, let rContext)):
+            return l == r && lContext == rContext
         case (.informDecodeError, .informDecodeError):
             return false  // no good way to equate these
         default:

--- a/Tests/HTTP3Tests/QPACKStateMachineTests.swift
+++ b/Tests/HTTP3Tests/QPACKStateMachineTests.swift
@@ -114,7 +114,6 @@ struct QPACKStateMachineTests {
             result
                 == QPACKStateMachine.DecodeHeaderAction.InformDecodeResult(
                     fields: [.init(name: .cookie, value: "test")],
-                    headers: testHeader,
                     streamID: streamID,
                     instructionToWrite: nil
                 )
@@ -153,7 +152,6 @@ struct QPACKStateMachineTests {
             decodeResult
                 == QPACKStateMachine.DecodeHeaderAction.InformDecodeResult(
                     fields: [.init(name: .cookie, value: "test")],
-                    headers: testHeader,
                     streamID: streamID,
                     instructionToWrite: .sectionAcknowledgement(streamID: streamID)
                 )
@@ -249,7 +247,6 @@ struct QPACKStateMachineTests {
                 == .informDecodeResult(
                     .init(
                         fields: [.init(name: .cookie, value: "test")],
-                        headers: testHeader,
                         streamID: streamID,
                         instructionToWrite: .sectionAcknowledgement(streamID: streamID)
                     ),
@@ -409,7 +406,6 @@ struct QPACKStateMachineTests {
                 == .informDecodeResult(
                     .init(
                         fields: [.init(name: .cookie, value: "test")],
-                        headers: testHeader,
                         streamID: streamID,
                         instructionToWrite: nil
                     ),


### PR DESCRIPTION
### Motivation

Currently after a QPACK decode, we use a QUICStream lookup dictionary to find the stream that we need to inform about the decode result. This means one dictionary lookup for each stream.

Instead we can store the entity that shall be informed about the QPACK decode result with the http fields to decode in the QPACK state machine.

### Changes

- Add a generic Context parameter to the QPACKStateMachine that allows storing a Context type next to the header fields to decode

### Result

The attached context is returned when the decode finishes. Because of this we can now directly invoke the object that cares about the decode result, without a dictionary lookup.

This PR only adds the option to store a context next to the header fields to be decoded. `HTTP3ConnectionStateMachine` does not use this feature yet.
