### PR TITLE
Make HTTP3FrameDecoder a NIOSingleStepByteToMessageDecoder

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -81,6 +81,8 @@ let package = Package(
                 .target(name: "HTTP3"),
                 .target(name: "QPACK"),
                 .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOEmbedded", package: "swift-nio"),
+                .product(name: "NIOTestUtils", package: "swift-nio"),
                 .product(name: "HTTPTypes", package: "swift-http-types"),
             ],
             swiftSettings: swiftSettings

--- a/Sources/HTTP3/HTTP3Frame.swift
+++ b/Sources/HTTP3/HTTP3Frame.swift
@@ -21,7 +21,7 @@ public import struct NIOCore.ByteBuffer
 ///
 /// The types are identical to ``HTTP3Frame`` except that the ``HTTP3PartialFrame/headers(_:)`` and ``HTTP3PartialFrame/pushPromise(_:)`` cases hold encoded field sections instead of fields.
 @_spi(PackageInternal)
-public enum HTTP3PartialFrame: Hashable {
+public enum HTTP3PartialFrame: Hashable, Sendable {
     /// A headers frame for which we don't have the dynamic table references yet.
     /// Pass this to a QPACK decoder to get the full HTTP3Frame.
     @_spi(PackageInternal)

--- a/Sources/HTTP3/HTTP3FrameDecoder.swift
+++ b/Sources/HTTP3/HTTP3FrameDecoder.swift
@@ -68,7 +68,10 @@ public struct HTTP3FrameDecoder {
     }
 
     @_spi(PackageInternal)
-    public mutating func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws(HTTP3Error) -> HTTP3PartialFrameOrUnknown? {
+    public mutating func decodeLast(
+        buffer: inout ByteBuffer,
+        seenEOF: Bool
+    ) throws(HTTP3Error) -> HTTP3PartialFrameOrUnknown? {
         if let frame = try self.decode(buffer: &buffer) {
             return frame
         }

--- a/Sources/HTTP3/HTTP3FrameDecoder.swift
+++ b/Sources/HTTP3/HTTP3FrameDecoder.swift
@@ -14,11 +14,11 @@
 
 @_spi(PackageInternal) import QPACK
 
-import struct NIOCore.ByteBuffer
+public import struct NIOCore.ByteBuffer
 
 /// A decoder for ``HTTP3PartialFrame``.
-struct HTTP3FrameDecoder: ~Copyable {
-    typealias InboundOut = HTTP3PartialFrame
+@_spi(PackageInternal)
+public struct HTTP3FrameDecoder {
 
     /// An enum indicating the next step when decoding HTTP/3 frames.
     private enum NextStep: Hashable {
@@ -46,11 +46,13 @@ struct HTTP3FrameDecoder: ~Copyable {
     /// Indicates the next decoding step.
     private var nextStep: NextStep = .decodeFrameType
 
-    init() {}
+    @_spi(PackageInternal)
+    public init() {}
 
     /// - Note: Any error thrown from here should be treated as a connection-level error.
     /// - Returns: A frame if one can be decoded from the available bytes, or `nil` if more bytes are needed.
-    mutating func decode(buffer: inout ByteBuffer) throws(HTTP3Error) -> HTTP3PartialFrameOrUnknown? {
+    @_spi(PackageInternal)
+    public mutating func decode(buffer: inout ByteBuffer) throws(HTTP3Error) -> HTTP3PartialFrameOrUnknown? {
         while true {
             switch try self.next(buffer: &buffer) {
             case .returnFrame(let frame):
@@ -63,6 +65,28 @@ struct HTTP3FrameDecoder: ~Copyable {
                 ()
             }
         }
+    }
+
+    @_spi(PackageInternal)
+    public mutating func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws(HTTP3Error) -> HTTP3PartialFrameOrUnknown? {
+        if let frame = try self.decode(buffer: &buffer) {
+            return frame
+        }
+
+        // RFC 9114 § 7.1: When a stream terminates cleanly, if the last frame on the stream was truncated, this MUST
+        // be treated as a connection error of type H3_FRAME_ERROR. Streams that terminate abruptly may be reset at
+        // any point in a frame, so we only complain if we actually saw an EOF.
+        guard seenEOF && (buffer.readableBytes > 0 || self.hasPartialFrame) else {
+            return nil
+        }
+
+        throw HTTP3Error(
+            code: .leftoverBytes,
+            message: "There were leftover bytes when the input was closed",
+            cause: nil,
+            errorCode: .frameError,
+            location: .here()
+        )
     }
 
     /// True if this decoder has consumed some bytes to start building up a frame, but has not completed doing so
@@ -279,7 +303,8 @@ extension ByteBuffer {
     }
 }
 
-enum HTTP3PartialFrameOrUnknown: Hashable {
+@_spi(PackageInternal)
+public enum HTTP3PartialFrameOrUnknown: Hashable {
     case known(HTTP3PartialFrame)
     case unknown
 }

--- a/Sources/NIOHTTP3/NIOHTTP3FrameDecoder.swift
+++ b/Sources/NIOHTTP3/NIOHTTP3FrameDecoder.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIOCore
 @_spi(PackageInternal) import HTTP3
+import NIOCore
 
 struct NIOHTTP3FrameDecoder: NIOSingleStepByteToMessageDecoder {
     typealias InboundOut = HTTP3PartialFrameOrUnknown

--- a/Sources/NIOHTTP3/NIOHTTP3FrameDecoder.swift
+++ b/Sources/NIOHTTP3/NIOHTTP3FrameDecoder.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+@_spi(PackageInternal) import HTTP3
+
+struct NIOHTTP3FrameDecoder: NIOSingleStepByteToMessageDecoder {
+    typealias InboundOut = HTTP3PartialFrameOrUnknown
+
+    var underlying: HTTP3FrameDecoder
+
+    init() {
+        self.underlying = .init()
+    }
+
+    mutating func decode(buffer: inout ByteBuffer) throws -> HTTP3PartialFrameOrUnknown? {
+        try self.underlying.decode(buffer: &buffer)
+    }
+
+    mutating func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> HTTP3PartialFrameOrUnknown? {
+        try self.underlying.decodeLast(buffer: &buffer, seenEOF: seenEOF)
+    }
+}

--- a/Tests/HTTP3Tests/HTTP3FrameDecoderTests.swift
+++ b/Tests/HTTP3Tests/HTTP3FrameDecoderTests.swift
@@ -1,0 +1,178 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOTestUtils
+@_spi(PackageInternal) import QPACK
+import Testing
+
+@testable @_spi(PackageInternal) import HTTP3
+
+/// Adapts the single-step ``HTTP3FrameDecoder`` to `ByteToMessageDecoder` so that NIO's
+/// `ByteToMessageDecoderVerifier` can drive it.
+private struct HTTP3FrameByteToMessageDecoder: NIOSingleStepByteToMessageDecoder {
+    typealias InboundOut = HTTP3PartialFrameOrUnknown
+
+    private var decoder = HTTP3FrameDecoder()
+
+    mutating func decode(buffer: inout ByteBuffer) throws -> HTTP3PartialFrameOrUnknown? {
+        try self.decoder.decode(buffer: &buffer)
+    }
+
+    mutating func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> HTTP3PartialFrameOrUnknown? {
+        try self.decoder.decodeLast(buffer: &buffer, seenEOF: seenEOF)
+    }
+}
+
+struct HTTP3FrameDecoderTests {
+    private var testHeader: HTTP3PartialFrame.Headers {
+        let fieldSectionPrefix = FieldSectionPrefix(requiredInsertCount: 0, base: 0).encode(maxCapacity: 0)
+        let line = FieldLine.literal(requireLiteralRepresentation: false, name: "test", value: "hello")
+        return .init(fieldSection: .init(prefix: fieldSectionPrefix, lines: [line]))
+    }
+
+    private func encode(_ frame: HTTP3PartialFrame) -> ByteBuffer {
+        var buffer = ByteBuffer()
+        buffer.writeHTTP3PartialFrame(frame, preferHuffmanEncoding: false)
+        return buffer
+    }
+
+    /// Drive the decoder through NIO's verifier, which drip feeds, batches and interleaves the inputs.
+    ///
+    /// - Note: DATA frames are deliberately absent: the decoder emits one partial DATA frame per chunk of payload it
+    ///   sees, so its output legitimately depends on how the bytes were fed in. They are covered separately below.
+    @Test func decoderPassesVerification() throws {
+        let frames: [HTTP3PartialFrame] = [
+            .settings(.init(qpackMaximumTableCapacity: 1024, h3Datagram: false)),
+//            .settings(.init(qpackMaximumTableCapacity: 151_288_809_941_952_652, qpackBlockedStreams: 1)),
+            .goaway(.init(rawValue: 4)),
+            .maxPushID(.init(rawValue: 7)),
+            .cancelPush(.init(rawValue: 3)),
+            .headers(self.testHeader),
+        ]
+
+        var inputOutputPairs: [(ByteBuffer, [HTTP3PartialFrameOrUnknown])] = frames.map {
+            (self.encode($0), [.known($0)])
+        }
+
+        // Frame type 0x40db is not one we know about. Its payload (here, empty) must be skipped.
+        inputOutputPairs.append((ByteBuffer(bytes: [0x40, 0xdb, 0x00]), [.unknown]))
+        // The same, but with a payload to skip over.
+        inputOutputPairs.append((ByteBuffer(bytes: [0x40, 0xdb, 0x03, 1, 2, 3]), [.unknown]))
+
+        try ByteToMessageDecoderVerifier.verifyDecoder(inputOutputPairs: inputOutputPairs) {
+            HTTP3FrameByteToMessageDecoder()
+        }
+    }
+
+    /// A DATA frame's payload is emitted as it arrives, rather than being buffered until the frame is complete.
+    @Test func dataFrameIsEmittedInChunks() throws {
+        var decoder = HTTP3FrameDecoder()
+
+        var buffer = ByteBuffer(bytes: [0, 4])  // type data, length 4
+        #expect(try decoder.decode(buffer: &buffer) == nil)
+
+        buffer.writeBytes([1, 2])
+        #expect(try decoder.decode(buffer: &buffer) == .known(.data(.init(bytes: [1, 2]))))
+        #expect(try decoder.decode(buffer: &buffer) == nil)
+
+        buffer.writeBytes([3, 4])
+        #expect(try decoder.decode(buffer: &buffer) == .known(.data(.init(bytes: [3, 4]))))
+        #expect(try decoder.decode(buffer: &buffer) == nil)
+
+        // The frame is complete, so the decoder is back to expecting a frame type.
+        #expect(!decoder.hasPartialFrame)
+    }
+
+    @Test func fullDataFrameInOneBuffer() throws {
+        var decoder = HTTP3FrameDecoder()
+        var buffer = ByteBuffer(bytes: [0, 4, 1, 2, 3, 4])
+        #expect(try decoder.decode(buffer: &buffer) == .known(.data(.init(bytes: [1, 2, 3, 4]))))
+        #expect(try decoder.decode(buffer: &buffer) == nil)
+    }
+
+    @Test(arguments: [2, 6, 8, 9] as [UInt8])
+    func forbiddenFrameTypesAreRejected(type: UInt8) {
+        var decoder = HTTP3FrameDecoder()
+        var buffer = ByteBuffer(bytes: [type])
+        expectH3Error(code: .forbiddenFrameType, h3ErrorCode: .frameUnexpected) {
+            _ = try decoder.decode(buffer: &buffer)
+        }
+    }
+
+    @Test func excessivePayloadLengthIsRejected() {
+        var decoder = HTTP3FrameDecoder()
+        // A SETTINGS frame with a payload length of 4096, which is well above what we're prepared to buffer.
+        var buffer = ByteBuffer()
+        buffer.writeInteger(UInt8(HTTP3FrameType.settings.rawValue))
+        buffer.writeEncodedInteger(UInt64(4096), strategy: .quic)
+        expectH3Error(code: .invalidFramePayload, h3ErrorCode: .excessiveLoad) {
+            _ = try decoder.decode(buffer: &buffer)
+        }
+    }
+
+    @Test func invalidPayloadIsRejected() {
+        var decoder = HTTP3FrameDecoder()
+        // Type 4 (settings), length 1, identifier 1 - the value is missing.
+        var buffer = ByteBuffer(bytes: [4, 1, 1])
+        expectH3Error(code: .invalidFramePayload, h3ErrorCode: .frameError) {
+            _ = try decoder.decode(buffer: &buffer)
+        }
+    }
+
+    // MARK: decodeLast
+
+    @Test func decodeLastOnCleanBoundaryProducesNothing() throws {
+        var decoder = HTTP3FrameDecoder()
+        var buffer = self.encode(.goaway(.init(rawValue: 4)))
+        #expect(try decoder.decode(buffer: &buffer) == .known(.goaway(.init(rawValue: 4))))
+
+        #expect(try decoder.decodeLast(buffer: &buffer, seenEOF: true) == nil)
+    }
+
+    @Test func decodeLastWithNoInputAtAllProducesNothing() throws {
+        var decoder = HTTP3FrameDecoder()
+        var buffer = ByteBuffer()
+        #expect(try decoder.decodeLast(buffer: &buffer, seenEOF: true) == nil)
+    }
+
+    /// RFC 9114 § 7.1: a truncated final frame on a cleanly terminated stream is a H3\_FRAME\_ERROR.
+    @Test(
+        arguments: [
+            [0],  // Frame type 0, no length
+            [64],  // Partial frame type (64 implies a multi-byte integer)
+            [0, 5, 1],  // Frame type + length but incomplete data (only 1 byte of data, expecting 5)
+            [4, 11, 7],  // A settings frame with an incomplete payload
+            [0, 1, 1, 0, 1],  // A full frame, followed by a frame with missing payload
+        ] as [[UInt8]]
+    )
+    func decodeLastWithLeftoverBytesIsAnError(testData: [UInt8]) throws {
+        var decoder = HTTP3FrameDecoder()
+        var buffer = ByteBuffer(bytes: testData)
+        // Consume all the complete frames first.
+        while try decoder.decode(buffer: &buffer) != nil {}
+
+        expectH3Error(code: .leftoverBytes, h3ErrorCode: .frameError) {
+            _ = try decoder.decodeLast(buffer: &buffer, seenEOF: true)
+        }
+    }
+
+    /// A stream which terminates abruptly may be reset at any point in a frame, so truncation isn't an error there.
+    @Test func decodeLastWithLeftoverBytesWithoutEOFIsNotAnError() throws {
+        var decoder = HTTP3FrameDecoder()
+        var buffer = ByteBuffer(bytes: [0, 5, 1])
+        _ = try decoder.decode(buffer: &buffer)
+        #expect(try decoder.decodeLast(buffer: &buffer, seenEOF: false) == nil)
+    }
+}

--- a/Tests/HTTP3Tests/HTTP3FrameDecoderTests.swift
+++ b/Tests/HTTP3Tests/HTTP3FrameDecoderTests.swift
@@ -55,7 +55,7 @@ struct HTTP3FrameDecoderTests {
     @Test func decoderPassesVerification() throws {
         let frames: [HTTP3PartialFrame] = [
             .settings(.init(qpackMaximumTableCapacity: 1024, h3Datagram: false)),
-//            .settings(.init(qpackMaximumTableCapacity: 151_288_809_941_952_652, qpackBlockedStreams: 1)),
+            .settings(.init(qpackMaximumTableCapacity: 151_288_809_941_952_652, qpackBlockedStreams: 1)),
             .goaway(.init(rawValue: 4)),
             .maxPushID(.init(rawValue: 7)),
             .cancelPush(.init(rawValue: 3)),


### PR DESCRIPTION
`HTTP3FrameDecoder` currently only knows how to pull a frame out of a buffer it is handed; the accumulation of partial frames across reads lives in `HTTP3FrameDecoderStateMachine`, which is a hand-rolled version of what `NIOSingleStepByteToMessageProcessor` already does.

As a first step towards deleting that duplication, conform a wrapper `NIOHTTP3FrameDecoder` to NIOSingleStepByteToMessageDecoder:

- Add `decodeLast(buffer:seenEOF:)`, which enforces RFC 9114 § 7.1: a truncated frame at a clean stream end is an `H3_FRAME_ERROR`, whereas an abrupt close may cut a frame anywhere and is not an error.
- Raise the decoder to `@_spi(PackageInternal)` public so `NIOHTTP3` can drive it directly.

Nothing uses the conformance yet. The new tests run the decoder through NIO's `ByteToMessageDecoderVerifier`, which checks that decoding is independent of how the bytes are chopped up across reads.
