### PR TITLE
Make `QUICEncodableInteger.maxValue` a static var

### DIFF
--- a/Sources/HTTP3/QUICEncoding.swift
+++ b/Sources/HTTP3/QUICEncoding.swift
@@ -15,5 +15,5 @@
 enum QUICEncodableInteger {
     /// A QUIC-encoded integer is 62-bit integer (0 to 2^62-1).
     /// See RFC 9000 § 16 for more details.
-    static let maxValue: UInt64 = (1 << 62) - 1
+    static var maxValue: UInt64 { (1 << 62) - 1 }
 }


### PR DESCRIPTION
### Motivation

`static let`s are lazily initialized and therefore introduce syncronisation (swift_once). Using a static var with a fixed value therefore is generally faster.

### Changes

- Make `QUICEncodableInteger.maxValue` a static var

### Result

Faster code