### PR TITLE
Remove a fields equality correctness check in prod code

### DIFF
--- a/Sources/HTTP3/HTTP3StreamStateMachine.swift
+++ b/Sources/HTTP3/HTTP3StreamStateMachine.swift
@@ -343,11 +343,9 @@ public struct HTTP3StreamStateMachine: ~Copyable {
             }
 
             struct WaitingForEncode {
-                let fields: [HTTPField]
                 var preferHuffmanEncoding: Bool
 
-                init(idleState: consuming Idle, fields: [HTTPField]) {
-                    self.fields = fields
+                init(idleState: consuming Idle) {
                     self.preferHuffmanEncoding = idleState.preferHuffmanEncoding
                 }
             }
@@ -377,7 +375,7 @@ public struct HTTP3StreamStateMachine: ~Copyable {
                 let maybePartial = MaybePartialFrame(frame)
                 switch maybePartial {
                 case .headers(let headers):
-                    self = .init(state: .waitingForEncode(.init(idleState: idleState, fields: headers.fields)))
+                    self = .init(state: .waitingForEncode(.init(idleState: idleState)))
                     return .encodeHeaders(headers.fields)
                 case .pushPromise:
                     // This cannot be reached. The validator currently forbids writing push promises at all
@@ -404,16 +402,12 @@ public struct HTTP3StreamStateMachine: ~Copyable {
 
         mutating func gotHeaderEncodeResult(
             _ result: HTTP3PartialFrame.Headers,
-            from: [HTTPField],
             into buffer: inout ByteBuffer
         ) -> HeaderEncodeResultAction {
             switch consume self.state {
             case .idle:
                 fatalError("Unexpected encode result")
             case .waitingForEncode(let waitingState):
-                guard from == waitingState.fields else {
-                    fatalError("Unexpected encode result")
-                }
                 buffer.writeHTTP3PartialFrame(
                     .headers(result),
                     preferHuffmanEncoding: waitingState.preferHuffmanEncoding
@@ -538,12 +532,11 @@ public struct HTTP3StreamStateMachine: ~Copyable {
     @_spi(PackageInternal)
     public mutating func gotHeaderEncodeResult(
         _ result: HTTP3PartialFrame.Headers,
-        from: [HTTPField],
         into buffer: inout ByteBuffer
     ) -> HeaderEncodeResultAction {
         switch self.state {
         case .idle(var idleState):
-            let writeAction = idleState.writeState.gotHeaderEncodeResult(result, from: from, into: &buffer)
+            let writeAction = idleState.writeState.gotHeaderEncodeResult(result, into: &buffer)
             self = .init(state: .idle(idleState))
             switch writeAction {
             case .wroteBytes:

--- a/Sources/NIOHTTP3/HTTP3StreamHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3StreamHandler.swift
@@ -269,7 +269,7 @@ final class HTTP3StreamHandler<Delegate: HTTP3StreamDelegate>: ChannelDuplexHand
             promise?.fail(error)
         case .encodeHeaders(let fields):
             let encoded = self.delegate.encodeHeaders(fields, forStream: self.streamID)
-            let action = self.stateMachine.gotHeaderEncodeResult(encoded, from: fields, into: &self.pendingBytes!)
+            let action = self.stateMachine.gotHeaderEncodeResult(encoded, into: &self.pendingBytes!)
 
             switch action {
             case .previousError(let previousError):

--- a/Tests/HTTP3Tests/HTTP3StreamStateMachineTests.swift
+++ b/Tests/HTTP3Tests/HTTP3StreamStateMachineTests.swift
@@ -751,7 +751,7 @@ struct HTTP3StreamStateMachineTests {
         #expect(action2 == .streamClosed(seenEOF: false))
 
         // Now give the encode result
-        let action3 = machine.gotHeaderEncodeResult(self.testRequestHeader, from: fieldsToEncode)
+        let action3 = machine.gotHeaderEncodeResult(self.testRequestHeader)
         guard case .alreadyClosed = action3 else {
             Issue.record("Unexpected action \(String(describing: action3))")
             return
@@ -925,11 +925,10 @@ extension HTTP3StreamStateMachine {
 
     /// Test convenience: deliver an encode result using a throwaway buffer.
     fileprivate mutating func gotHeaderEncodeResult(
-        _ result: HTTP3PartialFrame.Headers,
-        from: [HTTPField]
+        _ result: HTTP3PartialFrame.Headers
     ) -> HeaderEncodeResultAction {
         var buffer = ByteBuffer()
-        return self.gotHeaderEncodeResult(result, from: from, into: &buffer)
+        return self.gotHeaderEncodeResult(result, into: &buffer)
     }
 
     fileprivate enum ResolvedAction {
@@ -957,7 +956,7 @@ extension HTTP3StreamStateMachine {
             return .alreadyClosed
         case .encodeHeaders(let fields):
             let qpackResult = encoder.encode(headers: fields)
-            let action2 = self.gotHeaderEncodeResult(.init(fieldSection: qpackResult), from: fields, into: &buffer)
+            let action2 = self.gotHeaderEncodeResult(.init(fieldSection: qpackResult), into: &buffer)
             switch action2 {
             case .wroteBytes:
                 return .returnBytes(buffer)


### PR DESCRIPTION
### Motivation

Unit tests should enforce correct code. Not production code in the hot path.

### Changes

- remove a correctness check, that validated that we passed the correct http fields to the qpack encoder

### Result

Fewer needless checks, faster code
