### PR TITLE
Use `QUICStreamIDDictionary` instead of `Dictionary`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-crypto.git", from: "5.0.0-beta.1"),
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.19.3"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.22.0"),
-        .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", .upToNextMinor(from: "0.1.0")),
+        .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", .upToNextMinor(from: "0.1.1")),
         .package(url: "https://github.com/apple/swift-nio-quic.git", .upToNextMinor(from: "0.2.1")),
     ],
     targets: [

--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -21,6 +21,7 @@ import NIOQUICHelpers
 
 /// This class owns the connection state machine and is responsible for opening streams and sending frames.
 /// I.e. it coordinates everything across the connection, including qpack.
+@available(anyAppleOS 26, *)
 final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStreamCreator> {
     let eventLoop: any EventLoop
     private var connectionStateMachine: HTTP3ConnectionStateMachine
@@ -36,7 +37,8 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
     private let preferHuffmanEncoding: Bool
     private let logger: Logger
     /// Instances of stream handlers which need to be pinged whenever a dynamic table entry is added.
-    private var streamHandlers = [QUICStreamID: HTTP3StreamHandler<HTTP3ConnectionCoordinator<QUICStreamCreator>>]()
+    private var streamHandlers:
+        QUICStreamIDDictionary<HTTP3StreamHandler<HTTP3ConnectionCoordinator<QUICStreamCreator>>>
     private var datagramBuffer: HTTP3DatagramBuffer
 
     init(
@@ -58,6 +60,7 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
         self.logger = logger
         self.preferHuffmanEncoding = preferHuffmanEncoding
         self.datagramBuffer = HTTP3DatagramBuffer(maxAllowedSize: maxBufferedDatagramBytes)
+        self.streamHandlers = QUICStreamIDDictionary()
     }
 
     func setConnectionHandler(_ handler: HTTP3ConnectionHandler<QUICStreamCreator>?) {
@@ -945,6 +948,7 @@ extension Channel {
     }
 }
 
+@available(anyAppleOS 26, *)
 extension HTTP3ConnectionCoordinator: HTTP3StreamDelegate {
     func onStreamClosed(_ sawEOF: Bool, streamID: NIOQUICHelpers.QUICStreamID, streamType: HTTP3.HTTP3StreamType.Framed)
     {

--- a/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionHandler.swift
@@ -32,6 +32,7 @@ enum H3InboundStreamInitializer {
 /// This handler should be in a QUIC connection channel pipeline, and thus there should be one instance of this handler per connection.
 /// It expects to be told about any incoming stream channels by calling ``HTTP3ConnectionHandler/inboundStreamReceived(_:)``.
 /// The handler is also able to make outbound streams, see ``HTTP3ConnectionHandler/createRequestStream(streamInitializer:)``.
+@available(anyAppleOS 26, *)
 public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & SendableMetatype>:
     ChannelInboundHandler,
     ChannelOutboundHandler
@@ -175,7 +176,7 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
     ///   - connection: An instance of ``HTTP3ServerConnection`` which inbound connections can be vended to.
     /// - Returns: A ``HTTP3ConnectionHandler``.
     @_spi(HTTP3AsyncInterface)
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    @available(anyAppleOS 26, *)
     public static func server<Output: Sendable>(
         eventLoop: any EventLoop,
         configuration: HTTP3ServerConfiguration,
@@ -631,6 +632,7 @@ public final class HTTP3ConnectionHandler<StreamCreator: QUICStreamCreator & Sen
     }
 }
 
+@available(anyAppleOS 26, *)
 extension HTTP3ConnectionHandler {
     func emitDatagrams(_ datagrams: Deque<HTTP3Datagram>) {
         guard let context = self.context else { return }

--- a/Sources/NIOHTTP3/HTTP3ConnectionMultiplexer.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionMultiplexer.swift
@@ -21,7 +21,7 @@ public import NIOQUICHelpers
 // Allow creating outbound push streams.
 /// A HTTP/3 connection from a servers side. Allows iterating inbound streams.
 @_spi(HTTP3AsyncInterface)
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(anyAppleOS 26, *)
 public struct HTTP3ServerConnection<Output: Sendable, StreamCreator: QUICStreamCreator>: Sendable {
     /// Channel initializer called for each new inbound stream.
     private let inboundStreamInitializer: @Sendable (HTTP3StreamInitializerParameters) -> EventLoopFuture<Output>
@@ -86,7 +86,7 @@ extension HTTP3ServerConnection.InboundStreams.AsyncIterator: Sendable {}
 // Allow iterating incoming push streams.
 /// A HTTP/3 connection from a clients side. Allows creating outbound request streams.
 @_spi(HTTP3AsyncInterface)
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(anyAppleOS 26, *)
 public struct HTTP3ClientConnection<
     Output: Sendable,
     StreamCreator: QUICStreamCreator & SendableMetatype
@@ -146,7 +146,7 @@ protocol StreamMultiplexerContinuation: Sendable {
     func finish()
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(anyAppleOS 26, *)
 extension HTTP3ServerConnection: StreamMultiplexerContinuation {
     func initialize(parameters: HTTP3StreamInitializerParameters) -> EventLoopFuture<any Sendable> {
         self.inboundStreamInitializer(parameters).map { $0 as any Sendable }
@@ -166,7 +166,7 @@ extension HTTP3ServerConnection: StreamMultiplexerContinuation {
 /// You can use this type to wrap a QUIC implementation. Have the QUIC implementation call ``yield(connection:)`` and ``finish()`` as appropriate.
 /// Then, you can easily iterate through incoming connections and handle them.
 @_spi(HTTP3AsyncInterface)
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(anyAppleOS 26, *)
 public struct HTTP3ServerConnectionMultiplexer<Output: Sendable, StreamCreator: QUICStreamCreator>: Sendable {
     /// The inboundConnections' continuation.
     private let inboundConnectionsContinuation: AsyncStream<HTTP3ServerConnection<Output, StreamCreator>>.Continuation
@@ -240,7 +240,7 @@ public protocol HTTP3ConnectionCreator {
 
 /// Allows you to create outbound connections as a client.
 @_spi(HTTP3AsyncInterface)
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(anyAppleOS 26, *)
 public struct HTTP3ClientConnectionMultiplexer<
     ConnectionCreator: HTTP3ConnectionCreator & SendableMetatype,
     StreamCreator: QUICStreamCreator

--- a/Sources/NIOHTTP3/HTTP3InboundControlStreamHandler.swift
+++ b/Sources/NIOHTTP3/HTTP3InboundControlStreamHandler.swift
@@ -20,6 +20,7 @@ protocol ControlFrameProcessor {
     func receivedControlFrame(_ frame: HTTP3Frame, streamID: QUICStreamID)
 }
 
+@available(anyAppleOS 26, *)
 extension HTTP3ConnectionCoordinator: ControlFrameProcessor {}
 
 /// Handler to be used on the incoming control stream only.

--- a/Tests/H3IntegrationTests/EndToEndTests.swift
+++ b/Tests/H3IntegrationTests/EndToEndTests.swift
@@ -1896,6 +1896,7 @@ struct EndToEndTests {
 extension Channel {
     /// Call this on a HTTP3 connection channel to make an outbound request stream.
     /// - Returns: The request stream channel.
+    @available(anyAppleOS 26, *)
     fileprivate func makeHTTP3RequestChannel(
         initializer: (@Sendable (HTTP3StreamInitializerParameters) throws -> Void)? = nil
     ) -> EventLoopFuture<any Channel> {
@@ -1914,6 +1915,7 @@ extension Channel {
 
     /// Call this on a HTTP3 connection channel to make an outbound unidirectional stream.
     /// - Returns: The stream channel.
+    @available(anyAppleOS 26, *)
     fileprivate func makeHTTP3UnidirectionalStreamChannel(
         streamType: HTTP3StreamType.Unidirectional,
         initializer: (@Sendable (HTTP3StreamInitializerParameters) throws -> Void)? = nil

--- a/Tests/H3IntegrationTests/HTTP3+NIOQUIC.swift
+++ b/Tests/H3IntegrationTests/HTTP3+NIOQUIC.swift
@@ -25,6 +25,7 @@ import struct NIOQUIC.QUICStreamCreator
 
 @_spi(HTTP3AsyncInterface) @testable import NIOHTTP3
 
+@available(anyAppleOS 26, *)
 typealias QUICHTTP3ConnectionHandler = HTTP3ConnectionHandler<QUICStreamCreator>
 
 // MARK: Configure with async interface

--- a/Tests/NIOHTTP3Tests/HTTP3GracefulShutdownTests.swift
+++ b/Tests/NIOHTTP3Tests/HTTP3GracefulShutdownTests.swift
@@ -26,6 +26,7 @@ struct HTTP3GracefulShutdownTests {
     private let logger = Logger(label: "HTTP3GracefulShutdownTests")
 
     @Test
+    @available(anyAppleOS 26, *)
     func defaultDelayUsedWhenProviderNotSpecified() throws {
         let (connectionChannel, handler, _) = try self.makeServerHandler()
         defer { try? connectionChannel.close().wait() }
@@ -34,6 +35,7 @@ struct HTTP3GracefulShutdownTests {
     }
 
     @Test
+    @available(anyAppleOS 26, *)
     func rttMultiplierUsed() throws {
         var configuration = HTTP3ServerConfiguration.defaults
         configuration.rttProvider = { .milliseconds(75) }
@@ -46,6 +48,7 @@ struct HTTP3GracefulShutdownTests {
     }
 
     @Test
+    @available(anyAppleOS 26, *)
     func providerIsCalledEachTime() throws {
         let callCount = NIOLockedValueBox(0)
 
@@ -66,6 +69,7 @@ struct HTTP3GracefulShutdownTests {
     }
 
     @Test
+    @available(anyAppleOS 26, *)
     func changingRTTValues() throws {
         let rttProviderReturnValue = NIOLockedValueBox<TimeAmount>(.milliseconds(50))
 
@@ -89,6 +93,7 @@ struct HTTP3GracefulShutdownTests {
     }
 
     @Test
+    @available(anyAppleOS 26, *)
     func twoPhaseServerGOAWAYSequence() throws {
         var configuration = HTTP3ServerConfiguration.defaults
         configuration.rttProvider = { .milliseconds(20) }
@@ -131,6 +136,7 @@ struct HTTP3GracefulShutdownTests {
     }
 
     @Test
+    @available(anyAppleOS 26, *)
     func testGOAWAYSentByClient() throws {
         let (connectionChannel, _, streamChannel) = try self.makeClientHandler(configuration: .defaults)
         defer { try? connectionChannel.close().wait() }
@@ -161,6 +167,7 @@ struct HTTP3GracefulShutdownTests {
     }
 }
 
+@available(anyAppleOS 26, *)
 extension HTTP3GracefulShutdownTests {
     private func makeClientHandler(
         configuration: HTTP3ClientConfiguration = .defaults


### PR DESCRIPTION
### Motivation

We want faster code.

### Modifications

- Use `QUICStreamIDDictionary` instead of `Dictionary`
- Add `anyAppleOS 26` availability guards

### Result

Faster code.
