### PR TITLE
Bump quic version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.19.3"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.22.0"),
         .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", .upToNextMinor(from: "0.1.1")),
-        .package(url: "https://github.com/apple/swift-nio-quic.git", .upToNextMinor(from: "0.2.1")),
+        .package(url: "https://github.com/apple/swift-nio-quic.git", .upToNextMinor(from: "0.3.0")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Motivation:

swift-nio-quic 0.3.0 was tagged with some API breaking changes.

Modifications:

- Bump min version

Result:

Using latest version