### PR TITLE
Remove separate QPACK decoder ByteToMessageHandler

### DIFF
--- a/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
+++ b/Sources/NIOHTTP3/HTTP3ConnectionCoordinator.swift
@@ -521,7 +521,6 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
         switch action {
         case .addHandlers:
             // qpack streams do not carry h3 frames
-            let decoder = ByteToMessageHandler(QPACKEncoderInstructionDecoder())
             let forwarder = QPACKInboundEncoderStreamHandler { instruction in
                 let action = self.connectionStateMachine.receivedIncomingEncoderInstruction(instruction)
                 switch action {
@@ -544,7 +543,6 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
                     )
                 )
             }
-            try streamChannel.pipeline.syncOperations.addHandler(decoder)
             try streamChannel.pipeline.syncOperations.addHandler(forwarder)
             self.addStreamClosedCallback(
                 streamChannel: streamChannel,
@@ -576,7 +574,6 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
         switch action {
         case .addHandlers:
             // qpack streams do not carry h3 frames
-            let decoder = ByteToMessageHandler(QPACKDecoderInstructionDecoder())
             let forwarder = QPACKInboundDecoderStreamHandler {
                 let action = self.connectionStateMachine.receivedIncomingDecoderInstruction($0)
                 switch action {
@@ -596,7 +593,6 @@ final class HTTP3ConnectionCoordinator<QUICStreamCreator: NIOQUICHelpers.QUICStr
                     )
                 )
             }
-            try streamChannel.pipeline.syncOperations.addHandler(decoder)
             try streamChannel.pipeline.syncOperations.addHandler(forwarder)
             self.addStreamClosedCallback(
                 streamChannel: streamChannel,

--- a/Sources/NIOHTTP3/QPACKInboundDecoderStreamHandler.swift
+++ b/Sources/NIOHTTP3/QPACKInboundDecoderStreamHandler.swift
@@ -19,7 +19,9 @@ import NIOCore
 /// This belongs on the incoming decoder stream.
 /// The decoder instructions come from the remote decoder and should be fed into the local encoder.
 final class QPACKInboundDecoderStreamHandler: ChannelInboundHandler {
-    typealias InboundIn = QPACKDecoderInstruction
+    typealias InboundIn = ByteBuffer
+
+    let decoder: NIOSingleStepByteToMessageProcessor<QPACKDecoderInstructionDecoder>
 
     /// Called when an incoming instruction is successfully read.
     private var onReceivedInstruction: (QPACKDecoderInstruction) -> Void
@@ -30,6 +32,7 @@ final class QPACKInboundDecoderStreamHandler: ChannelInboundHandler {
         onReceivedInstruction: @escaping (QPACKDecoderInstruction) -> Void,
         onError: @escaping (any Error) -> Void
     ) {
+        self.decoder = NIOSingleStepByteToMessageProcessor(QPACKDecoderInstructionDecoder())
         self.onReceivedInstruction = onReceivedInstruction
         self.onError = onError
     }
@@ -40,8 +43,14 @@ final class QPACKInboundDecoderStreamHandler: ChannelInboundHandler {
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        let instruction = unwrapInboundIn(data)
-        self.onReceivedInstruction(instruction)
-        context.fireChannelRead(data)
+        let byteBuffer = Self.unwrapInboundIn(data)
+        do {
+            try self.decoder.process(buffer: byteBuffer) { instruction in
+                self.onReceivedInstruction(instruction)
+            }
+        } catch {
+            self.onError(error)
+            context.fireErrorCaught(error)
+        }
     }
 }

--- a/Sources/NIOHTTP3/QPACKInboundEncoderStreamHandler.swift
+++ b/Sources/NIOHTTP3/QPACKInboundEncoderStreamHandler.swift
@@ -18,8 +18,11 @@ import NIOCore
 /// Read encoder instructions from a channel and give them to a callback.
 /// This belongs on the incoming encoder stream.
 /// The encoder instructions come from the remote encoder and should be fed into the local decoder.
+@available(anyAppleOS 26.0, *)
 final class QPACKInboundEncoderStreamHandler: ChannelInboundHandler {
-    typealias InboundIn = QPACKEncoderInstruction
+    typealias InboundIn = ByteBuffer
+
+    let decoder: NIOSingleStepByteToMessageProcessor<QPACKEncoderInstructionDecoder>
 
     /// Called when an incoming instruction is successfully read.
     private var onReceivedInstruction: (QPACKEncoderInstruction) -> Void
@@ -30,6 +33,7 @@ final class QPACKInboundEncoderStreamHandler: ChannelInboundHandler {
         onReceivedInstruction: @escaping (QPACKEncoderInstruction) -> Void,
         onError: @escaping (any Error) -> Void
     ) {
+        self.decoder = NIOSingleStepByteToMessageProcessor(QPACKEncoderInstructionDecoder())
         self.onReceivedInstruction = onReceivedInstruction
         self.onError = onError
     }
@@ -40,8 +44,14 @@ final class QPACKInboundEncoderStreamHandler: ChannelInboundHandler {
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        let instruction = unwrapInboundIn(data)
-        self.onReceivedInstruction(instruction)
-        context.fireChannelRead(data)
+        let byteBuffer = Self.unwrapInboundIn(data)
+        do {
+            try self.decoder.process(buffer: byteBuffer) { instruction in
+                self.onReceivedInstruction(instruction)
+            }
+        } catch {
+            self.onError(error)
+            context.fireErrorCaught(error)
+        }
     }
 }


### PR DESCRIPTION
### Motivation

Fewer ChannelHandlers = Better performance

### Modifications

- Remove the extra `ByteToMessageHandler` for incoming QPACK streams
- Do the decoding inline the handlers via `NIOSingleStepByteToMessageDecoder`.

### Result

Fewer ChannelHandlers.
