### PR TITLE
Compute the Huffman encoded length just once

### DIFF
--- a/Sources/QPACK/HuffmanCoding.swift
+++ b/Sources/QPACK/HuffmanCoding.swift
@@ -39,8 +39,32 @@ extension ByteBuffer {
     /// - Returns: The number of bytes used while encoding the string.
     @discardableResult
     mutating func setHuffmanEncoded(bytes stringBytes: some Collection<UInt8>) -> Int {
-        let clen = ByteBuffer.huffmanEncodedBitLength(of: stringBytes)
-        self.ensureBitsAvailable(clen)
+        self.setHuffmanEncoded(
+            bytes: stringBytes,
+            encodedByteLength: ByteBuffer.huffmanEncodedByteLength(of: stringBytes)
+        )
+    }
+
+    /// Encodes the given string to the buffer, using QPACK Huffman encoding.
+    ///
+    /// Determining the encoded length costs a full table lookup per input byte,
+    /// so callers that already know it — because they had to write it out as a
+    /// length prefix, or to decide whether Huffman encoding was worth using at
+    /// all — should pass it here rather than have it recomputed.
+    ///
+    /// - Parameters:
+    ///   - stringBytes: The string data to encode.
+    ///   - encodedByteLength: The encoded length of `stringBytes`, as returned
+    ///     by ``huffmanEncodedByteLength(of:)``. Passing anything else is a
+    ///     programmer error; too small a value would overrun the buffer.
+    /// - Returns: The number of bytes used while encoding the string.
+    @discardableResult
+    mutating func setHuffmanEncoded(
+        bytes stringBytes: some Collection<UInt8>,
+        encodedByteLength: Int
+    ) -> Int {
+        assert(encodedByteLength == ByteBuffer.huffmanEncodedByteLength(of: stringBytes))
+        self.ensureBytesAvailable(encodedByteLength)
 
         return self.withUnsafeMutableWritableBytes { bytes in
             var state = _EncoderState()
@@ -63,6 +87,18 @@ extension ByteBuffer {
     @discardableResult
     mutating func writeHuffmanEncoded(bytes stringBytes: some Collection<UInt8>) -> Int {
         let written = self.setHuffmanEncoded(bytes: stringBytes)
+        self.moveWriterIndex(forwardBy: written)
+        return written
+    }
+
+    /// As ``writeHuffmanEncoded(bytes:)``, but avoids recomputing an encoded
+    /// length the caller already has. See ``setHuffmanEncoded(bytes:encodedByteLength:)``.
+    @discardableResult
+    mutating func writeHuffmanEncoded(
+        bytes stringBytes: some Collection<UInt8>,
+        encodedByteLength: Int
+    ) -> Int {
+        let written = self.setHuffmanEncoded(bytes: stringBytes, encodedByteLength: encodedByteLength)
         self.moveWriterIndex(forwardBy: written)
         return written
     }
@@ -131,8 +167,7 @@ extension ByteBuffer {
         }
     }
 
-    private mutating func ensureBitsAvailable(_ bits: Int) {
-        let bytesNeeded = bits / 8
+    private mutating func ensureBytesAvailable(_ bytesNeeded: Int) {
         if bytesNeeded <= self.writableBytes {
             // just zero the requested number of bytes before we start OR-ing in our values
             self.withUnsafeMutableWritableBytes { ptr in

--- a/Sources/QPACK/HuffmanCoding.swift
+++ b/Sources/QPACK/HuffmanCoding.swift
@@ -35,18 +35,6 @@ extension ByteBuffer {
 
     /// Encodes the given string to the buffer, using QPACK Huffman encoding.
     ///
-    /// - Parameter stringBytes: The string data to encode.
-    /// - Returns: The number of bytes used while encoding the string.
-    @discardableResult
-    mutating func setHuffmanEncoded(bytes stringBytes: some Collection<UInt8>) -> Int {
-        self.setHuffmanEncoded(
-            bytes: stringBytes,
-            encodedByteLength: ByteBuffer.huffmanEncodedByteLength(of: stringBytes)
-        )
-    }
-
-    /// Encodes the given string to the buffer, using QPACK Huffman encoding.
-    ///
     /// Determining the encoded length costs a full table lookup per input byte,
     /// so callers that already know it — because they had to write it out as a
     /// length prefix, or to decide whether Huffman encoding was worth using at
@@ -82,13 +70,6 @@ extension ByteBuffer {
 
             return state.offset
         }
-    }
-
-    @discardableResult
-    mutating func writeHuffmanEncoded(bytes stringBytes: some Collection<UInt8>) -> Int {
-        let written = self.setHuffmanEncoded(bytes: stringBytes)
-        self.moveWriterIndex(forwardBy: written)
-        return written
     }
 
     /// As ``writeHuffmanEncoded(bytes:)``, but avoids recomputing an encoded

--- a/Sources/QPACK/HuffmanCoding.swift
+++ b/Sources/QPACK/HuffmanCoding.swift
@@ -35,13 +35,8 @@ extension ByteBuffer {
 
     /// Encodes the given string to the buffer, using QPACK Huffman encoding.
     ///
-    /// Determining the encoded length costs a full table lookup per input byte,
-    /// so callers that already know it — because they had to write it out as a
-    /// length prefix, or to decide whether Huffman encoding was worth using at
-    /// all — should pass it here rather than have it recomputed.
-    ///
     /// - Parameters:
-    ///   - stringBytes: The string data to encode.
+    ///   - stringBytes: The data to encode.
     ///   - encodedByteLength: The encoded length of `stringBytes`, as returned
     ///     by ``huffmanEncodedByteLength(of:)``. Passing anything else is a
     ///     programmer error; too small a value would overrun the buffer.
@@ -72,8 +67,6 @@ extension ByteBuffer {
         }
     }
 
-    /// As ``writeHuffmanEncoded(bytes:)``, but avoids recomputing an encoded
-    /// length the caller already has. See ``setHuffmanEncoded(bytes:encodedByteLength:)``.
     @discardableResult
     mutating func writeHuffmanEncoded(
         bytes stringBytes: some Collection<UInt8>,

--- a/Sources/QPACK/StringCoding.swift
+++ b/Sources/QPACK/StringCoding.swift
@@ -116,7 +116,7 @@ extension ByteBuffer {
                 prefix: prefix - 1,
                 prefixBits: huffmanMask | prefixBits
             )
-            self.writeHuffmanEncoded(bytes: utf8)
+            self.writeHuffmanEncoded(bytes: utf8, encodedByteLength: encodedByteLength)
         case .raw:
             // One bit is used for the Huffman flag (0)
             // So the prefix is reduced by one

--- a/Tests/HTTP3Tests/TestUtil.swift
+++ b/Tests/HTTP3Tests/TestUtil.swift
@@ -36,3 +36,13 @@ extension HTTP3GoawayID: ExpressibleByIntegerLiteral {
         self.init(rawValue: value)
     }
 }
+
+extension ByteBuffer {
+    @discardableResult
+    mutating func writeHuffmanEncoded(bytes stringBytes: some Collection<UInt8>) -> Int {
+        self.writeHuffmanEncoded(
+            bytes: stringBytes,
+            encodedByteLength: ByteBuffer.huffmanEncodedByteLength(of: stringBytes)
+        )
+    }
+}

--- a/Tests/QPACKTests/HuffmanCodingTests.swift
+++ b/Tests/QPACKTests/HuffmanCodingTests.swift
@@ -145,3 +145,13 @@ struct HuffmanCodingTests {
         self.verifyHuffmanCoding(text2, Array(encoded2Data))
     }
 }
+
+extension ByteBuffer {
+    @discardableResult
+    mutating func writeHuffmanEncoded(bytes stringBytes: some Collection<UInt8>) -> Int {
+        self.writeHuffmanEncoded(
+            bytes: stringBytes,
+            encodedByteLength: ByteBuffer.huffmanEncodedByteLength(of: stringBytes)
+        )
+    }
+}


### PR DESCRIPTION
### Motivation

`writeQPACKString` computes the encoded length so it can write the length prefix and decide whether Huffman encoding is even worth using. It then calls `writeHuffmanEncoded(bytes:)`, which computes exactly the same length again before writing anything. That is a second full pass over the input with a table lookup per byte -- and it is roughly as expensive as the encoding itself.

### Changes

- pass the precomputed encoded length down instead of recomputing it again
- `ensureBitsAvailable` took bits only to immediately divide by eight; it now takes bytes, which is what both callers actually have.

### Result

Encoding the header corpus: 3028K -> 1964K instructions, 102us -> 64us (-35%) on my machine.