### PR TITLE
Adopt breaking changes in swift-nio-quic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.19.3"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.22.0"),
         .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", .upToNextMinor(from: "0.1.1")),
-        .package(url: "https://github.com/apple/swift-nio-quic.git", .upToNextMinor(from: "0.3.0")),
+        .package(url: "https://github.com/apple/swift-nio-quic.git", branch: "main"),
     ],
     targets: [
         .target(

--- a/Tests/H3IntegrationTests/EndToEndTests.swift
+++ b/Tests/H3IntegrationTests/EndToEndTests.swift
@@ -311,7 +311,7 @@ struct EndToEndTests {
         #expect(clientReceivedControlFrames == [.settings(serverSettings)])
 
         // Tear down
-        try await serverChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        try await serverChannel.pipeline.handler(type: QUICHandler<QUICStreamChannels>.self).flatMap {
             $0.shutdownGracefully(deadline: .now())
         }.get()
         try await clientConnectionChannel.closeFuture.get()
@@ -536,7 +536,7 @@ struct EndToEndTests {
         )
 
         // Tear down
-        try await serverChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        try await serverChannel.pipeline.handler(type: QUICHandler<QUICStreamChannels>.self).flatMap {
             $0.shutdownGracefully(deadline: .now())
         }.get()
         try await clientConnectionChannel.closeFuture.get()
@@ -642,7 +642,7 @@ struct EndToEndTests {
         #expect(clientReceivedFrames == [.headers([HTTPField(name: .status, value: "200")])])
 
         // Tear down
-        try await serverChannel.pipeline.handler(type: QUICHandler.self).flatMap {
+        try await serverChannel.pipeline.handler(type: QUICHandler<QUICStreamChannels>.self).flatMap {
             $0.shutdownGracefully(deadline: .now())
         }.get()
         try await clientConnectionChannel.closeFuture.get()

--- a/Tests/H3IntegrationTests/QUICConnectionCreator.swift
+++ b/Tests/H3IntegrationTests/QUICConnectionCreator.swift
@@ -22,7 +22,7 @@ typealias ConcreteQUICStreamCreator = NIOQUIC.QUICStreamCreator
 
 @available(anyAppleOS 26, *)
 struct QUICConnectionCreator: HTTP3ConnectionCreator {
-    let quicHandler: QUICHandler
+    let quicHandler: QUICHandler<QUICStreamChannels>
     let connectionInitializer: @Sendable (any Channel, ConcreteQUICStreamCreator) -> EventLoopFuture<any Channel>
     let inboundStreamInitializer: @Sendable (any Channel) -> EventLoopFuture<Void>
 


### PR DESCRIPTION
Motivation:

swift-nio-quic has some breaking changes, adopt them so that swift-nio-quic's integration tests can continue to run. The dependency will need to switch back prior to a tag prior to the next swift-nio-http3 release.

Modifications:

- Specify generic parameter for QUICHandler

Result:

Compiles aga