### PR TITLE
Rename QPACK's ConnectionDelegate to QPACKConnectionDelegate

### DIFF
--- a/Sources/HTTP3/QPACKCoder.swift
+++ b/Sources/HTTP3/QPACKCoder.swift
@@ -41,7 +41,7 @@ public protocol QPACKOutboundDecoderStream: ~Copyable {
 
 /// An object representing an HTTP3Connection to forward connection level errors to.
 @_spi(PackageInternal)
-public protocol ConnectionDelegate {
+public protocol QPACKConnectionDelegate {
     /// Tear the connection down. The error's ``HTTP3Error/h3ErrorCode`` is the code to close it with.
     func connectionError(_ error: HTTP3Error)
 
@@ -99,7 +99,7 @@ public protocol QPACKDecodeReceiver {
 public final class QPACKCoder<
     OutboundEncoderStream: QPACKOutboundEncoderStream & ~Copyable,
     OutboundDecoderStream: QPACKOutboundDecoderStream & ~Copyable,
-    ConnectionDelegate: HTTP3.ConnectionDelegate,
+    ConnectionDelegate: HTTP3.QPACKConnectionDelegate,
     DecodeReceiver: QPACKDecodeReceiver
 > {
 

--- a/Tests/HTTP3Tests/QPACKCoderTests.swift
+++ b/Tests/HTTP3Tests/QPACKCoderTests.swift
@@ -546,7 +546,7 @@ private final class TestOutboundDecoderStream: QPACKOutboundDecoderStream {
 }
 
 /// Records the connection level side effects: errors and requests to open an encoder stream.
-private final class TestConnection: HTTP3.ConnectionDelegate {
+private final class TestConnection: HTTP3.QPACKConnectionDelegate {
     var errors: [HTTP3Error] = []
     var madeOutboundEncoderStreamCount = 0
 


### PR DESCRIPTION
`ConnectionDelegate` is a very general name for a protocol vended from the HTTP3 module: it says nothing about QPACK, and the HTTP/3 connection already has plenty of other delegates. Rename it so that a type conforming to it — which will be the connection coordinator — reads as what it is.

Pure rename, no behavior change.
