### PR TITLE
QPACK: a second SETTINGS frame is a connection error, not a trap

### DIFF
--- a/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
+++ b/Sources/HTTP3/HTTP3ConnectionStateMachine.swift
@@ -734,6 +734,10 @@ public struct HTTP3ConnectionStateMachine: ~Copyable {
                 switch action {
                 case .makeEncoderInstructionStream:
                     makeEncoderStream = true
+                case .emitConnectionError(let error):
+                    // The peer sent SETTINGS twice. The frame validator normally catches this first. Leave the
+                    // settings we got the first time in place: the connection is going away anyway.
+                    return .emitConnectionError(error)
                 case .none:
                     makeEncoderStream = false
                 }

--- a/Sources/HTTP3/QPACK/QPACKStateMachine.swift
+++ b/Sources/HTTP3/QPACK/QPACKStateMachine.swift
@@ -91,16 +91,28 @@ struct QPACKStateMachine<DecodeContext>: ~Copyable {
                     )
                     return .makeEncoderInstructionStream
                 }
-            case .awaitingStream:
-                // This can't happen because the frame validator enforces only one settings frame
-                fatalError("Double remote settings")
-            case .withDynamic:
-                // This can't happen because the frame validator enforces only one settings frame
-                fatalError("Double remote settings")
-            case .withoutDynamic:
-                // This can't happen because the frame validator enforces only one settings frame
-                fatalError("Double remote settings")
+            case .awaitingStream(let awaitingStream):
+                self = .init(state: .awaitingStream(awaitingStream))
+                return .emitConnectionError(Self.duplicateSettingsError(location: .here()))
+            case .withDynamic(let withDynamic):
+                self = .init(state: .withDynamic(withDynamic))
+                return .emitConnectionError(Self.duplicateSettingsError(location: .here()))
+            case .withoutDynamic(let withoutDynamic):
+                self = .init(state: .withoutDynamic(withoutDynamic))
+                return .emitConnectionError(Self.duplicateSettingsError(location: .here()))
             }
+        }
+
+        /// RFC 9114 § 7.2.4: the peer may only send SETTINGS once, and a second one is a connection error.
+        @inline(never)
+        private static func duplicateSettingsError(location: HTTP3Error.SourceLocation) -> HTTP3Error {
+            HTTP3Error(
+                code: .unexpectedFrame,
+                message: "Received a second settings frame",
+                cause: nil,
+                errorCode: .frameUnexpected,
+                location: location
+            )
         }
 
         enum OutboundEncoderStreamReadyAction {
@@ -292,9 +304,13 @@ struct QPACKStateMachine<DecodeContext>: ~Copyable {
 
     enum GotRemoteSettingsAction {
         case makeEncoderInstructionStream
+        case emitConnectionError(HTTP3Error)
     }
 
-    /// Call this when the settings have been received from the remote. This must never be called more than once.
+    /// Call this when the settings have been received from the remote.
+    ///
+    /// The peer may only send SETTINGS once: a second call returns ``GotRemoteSettingsAction/emitConnectionError(_:)``
+    /// and leaves the encoder state untouched.
     mutating func receivedRemoteSettings(
         maxQueueSize: Int,
         effectiveDynamicTableSize: Int

--- a/Sources/HTTP3/QPACKCoder.swift
+++ b/Sources/HTTP3/QPACKCoder.swift
@@ -151,7 +151,8 @@ public final class QPACKCoder<
     /// If the peer advertised a zero sized dynamic table no encoder stream is requested, since it would never be
     /// used. See RFC 9204 § 4.2.
     ///
-    /// - Precondition: The peer may only send SETTINGS once, so this must not be called more than once.
+    /// - Important: The peer may only send SETTINGS once. Calling this a second time leaves the coder's state
+    ///   untouched and reports an `H3_FRAME_UNEXPECTED` connection error to the ``ConnectionDelegate``.
     ///
     /// - Parameters:
     ///   - maxQueueSize: The peer's `SETTINGS_QPACK_BLOCKED_STREAMS`.
@@ -169,6 +170,8 @@ public final class QPACKCoder<
         switch action {
         case .makeEncoderInstructionStream:
             self.connection.makeOutboundEncoderStream()
+        case .emitConnectionError(let error):
+            self.connection.connectionError(error)
         case .none:
             break
         }

--- a/Tests/HTTP3Tests/QPACKCoderTests.swift
+++ b/Tests/HTTP3Tests/QPACKCoderTests.swift
@@ -49,6 +49,48 @@ struct QPACKCoderTests {
         #expect(connection.errors.isEmpty)
     }
 
+    @Test func secondRemoteSettingsIsAConnectionError() {
+        let connection = TestConnection()
+        let coder = TestCoder(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100, errorDelegate: connection)
+
+        coder.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: 300)
+        #expect(connection.madeOutboundEncoderStreamCount == 1)
+
+        // RFC 9114 § 7.2.4: the peer may only send SETTINGS once.
+        coder.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: 4096)
+
+        #expect(connection.errors.count == 1)
+        expectH3ErrorEqual(
+            error: connection.errors.first,
+            expectedCode: .unexpectedFrame,
+            expectedH3ErrorCode: .frameUnexpected
+        )
+        // The first settings still stand: no second encoder stream, and the table keeps its original size.
+        #expect(connection.madeOutboundEncoderStreamCount == 1)
+        let encoderStream = TestOutboundEncoderStream()
+        coder.outboundEncoderStreamReady(encoderStream)
+        #expect(encoderStream.instructions == [.setDynamicTableCapacity(300)])
+    }
+
+    @Test func secondRemoteSettingsWithoutDynamicTableIsAConnectionError() {
+        let connection = TestConnection()
+        let coder = TestCoder(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100, errorDelegate: connection)
+
+        coder.receivedRemoteSettings(maxQueueSize: 0, effectiveDynamicTableSize: 0)
+        #expect(connection.madeOutboundEncoderStreamCount == 0)
+
+        // The peer can't change its mind about the dynamic table by sending SETTINGS again.
+        coder.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: 300)
+
+        #expect(connection.errors.count == 1)
+        expectH3ErrorEqual(
+            error: connection.errors.first,
+            expectedCode: .unexpectedFrame,
+            expectedH3ErrorCode: .frameUnexpected
+        )
+        #expect(connection.madeOutboundEncoderStreamCount == 0)
+    }
+
     // MARK: Encoder stream
 
     @Test func outboundEncoderStreamReadySendsTableCapacity() {

--- a/Tests/HTTP3Tests/QPACKStateMachineTests.swift
+++ b/Tests/HTTP3Tests/QPACKStateMachineTests.swift
@@ -19,6 +19,14 @@ import Testing
 @_spi(PackageInternal) @testable import HTTP3
 
 struct QPACKStateMachineTests {
+    /// ``QPACKStateMachine/GotRemoteSettingsAction`` carries an error, so it isn't `Equatable`.
+    private func isMakeEncoderInstructionStream<Context>(
+        _ action: QPACKStateMachine<Context>.GotRemoteSettingsAction?
+    ) -> Bool {
+        guard case .makeEncoderInstructionStream = action else { return false }
+        return true
+    }
+
     @Test func testBeginUsingDynamicTable() {
         var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         stateMachine.setupRemoteDynamicTable(maxSize: 1024)
@@ -31,9 +39,47 @@ struct QPACKStateMachineTests {
         case .makeEncoderInstructionStream:
             Issue.record("Expected no outbound encoder stream")
             return
+        case .emitConnectionError(let error):
+            Issue.record("Unexpected connection error \(error)")
+            return
         case .none:
             break  // Good
         }
+    }
+
+    @Test func secondSettingsIsAConnectionError() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        let action1 = stateMachine.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: 300)
+        #expect(isMakeEncoderInstructionStream(action1))
+
+        // RFC 9114 § 7.2.4: the peer may only send SETTINGS once.
+        let action2 = stateMachine.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: 4096)
+        guard case .emitConnectionError(let error) = action2 else {
+            Issue.record("Expected a connection error, got \(String(describing: action2))")
+            return
+        }
+        #expect(error.code == .unexpectedFrame)
+        #expect(error.h3ErrorCode == .frameUnexpected)
+
+        // The first settings still stand: the encoder uses the table size they asked for.
+        let action3 = stateMachine.outboundEncoderStreamReady()
+        #expect(action3 == .sendEncoderInstruction(.setDynamicTableCapacity(300)))
+    }
+
+    @Test func secondSettingsWithoutDynamicTableIsAConnectionError() {
+        var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
+        #expect(stateMachine.receivedRemoteSettings(maxQueueSize: 0, effectiveDynamicTableSize: 0) == nil)
+
+        // The peer can't change its mind about the dynamic table by sending SETTINGS again.
+        let action = stateMachine.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: 300)
+        guard case .emitConnectionError(let error) = action else {
+            Issue.record("Expected a connection error, got \(String(describing: action))")
+            return
+        }
+        #expect(error.code == .unexpectedFrame)
+        #expect(error.h3ErrorCode == .frameUnexpected)
+
+        stateMachine.assertEncodesWithoutUsingDynamicTable()
     }
 
     // MARK: Encoding headers
@@ -57,7 +103,7 @@ struct QPACKStateMachineTests {
     @Test func testEncodeHeadersInWaitingForStreamState() {
         var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let action = stateMachine.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: 100)
-        #expect(action == .makeEncoderInstructionStream)
+        #expect(isMakeEncoderInstructionStream(action))
         // We have received remote settings, and been asked to create outbound encoder stream
         // However, the outbound stream isn't ready yet, so the dynamic table should not be used
         stateMachine.assertEncodesWithoutUsingDynamicTable()
@@ -74,7 +120,7 @@ struct QPACKStateMachineTests {
     @Test func testEncodeHeadersInWithDynamicState() {
         var stateMachine = QPACKStateMachine<Void>(decoderMaxTableSize: 1024, decoderMaxBlockedStreams: 100)
         let action1 = stateMachine.receivedRemoteSettings(maxQueueSize: 100, effectiveDynamicTableSize: 300)
-        #expect(action1 == .makeEncoderInstructionStream)
+        #expect(isMakeEncoderInstructionStream(action1))
         let action2 = stateMachine.outboundEncoderStreamReady()
         // The stream is ready so we should immediately start using the table at max capacity
         #expect(action2 == .sendEncoderInstruction(.setDynamicTableCapacity(300)))
@@ -658,6 +704,8 @@ extension QPACKStateMachine {
             #expect(actions2 == .sendEncoderInstruction(expectedInstruction))
         case .none:
             Issue.record("Unexpected action")
+        case .emitConnectionError(let error):
+            Issue.record("Unexpected connection error \(error)")
         }
     }
 


### PR DESCRIPTION
`QPACKStateMachine.receivedRemoteSettings` used to `fatalError` if it was called in any state other than the initial one, on the grounds that the frame validator rejects a second SETTINGS frame before we get here. That is true today, but it makes the state machine's correctness depend on a check made somewhere else entirely, and the penalty for being wrong is a crash driven by remote input.

Return an `H3_FRAME_UNEXPECTED` connection error instead (RFC 9114 § 7.2.4), and leave the state from the first SETTINGS in place: the connection is being torn down regardless, so there is nothing to gain by half-applying the second set of settings.